### PR TITLE
chore(deps): native bun refresh + disable npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration for Allo.
+#
+# This repo uses Bun (bun.lock) and tracks NO package-lock.json anywhere.
+# Dependabot's npm/npm_and_yarn updater does NOT support bun.lock — it can only
+# emit invalid package-lock.json PRs that are out of sync with the real tree.
+# JavaScript dependency bumps are therefore handled natively with `bun update`
+# (and root `overrides`/`resolutions`), never by Dependabot.
+#
+# Only the github-actions ecosystem (which Dependabot fully supports) is enabled.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/bun.lock
+++ b/bun.lock
@@ -159,6 +159,7 @@
     },
   },
   "overrides": {
+    "@isaacs/brace-expansion": "^5.0.1",
     "@oxyhq/contracts": "^0.2.1",
     "@oxyhq/core": "^3.10.1",
     "@oxyhq/services": "^11.0.0",
@@ -486,7 +487,7 @@
 
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
-    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "overrides": {
+    "@isaacs/brace-expansion": "^5.0.1",
     "@oxyhq/core": "^3.10.1",
     "@oxyhq/contracts": "^0.2.1",
     "@oxyhq/services": "^11.0.0",
@@ -14,6 +15,7 @@
     "@tanstack/query-core": "5.101.0"
   },
   "resolutions": {
+    "@isaacs/brace-expansion": "^5.0.1",
     "@oxyhq/core": "^3.10.1",
     "@oxyhq/contracts": "^0.2.1",
     "@oxyhq/services": "^11.0.0",


### PR DESCRIPTION
## Why

4 open Dependabot PRs (#11, #10, #7, #6) all edit `package-lock.json`, but this repo uses **bun.lock** and tracks **no** `package-lock.json` anywhere. Dependabot's npm updater has no bun support, so those PRs would add a stray, out-of-sync npm lockfile. They are invalid and are being closed.

This PR applies the equivalent updates **natively with bun** and stops the recurrence.

## Changes

- **`@isaacs/brace-expansion` 5.0.0 → 5.0.1** — the only applicable update. Transitive (via `minimatch@10` from @expo build tooling); bumped cleanly through root `overrides`/`resolutions` so no stray direct dependency is added.
- **`tar` / `undici`** — not present in the bun dependency tree at all (only the unrelated `undici-types`); nothing to update. The Dependabot PRs were bogus.
- **`node-forge`** — already at `1.3.3`, beyond the PR's `1.3.2` target; already patched, no action.
- **`.github/dependabot.yml`** — created enabling **only** the `github-actions` ecosystem (weekly), since Dependabot cannot read `bun.lock`.

## Validation

- `bun run build` passes (exit 0) — shared-types + backend tsc + frontend Expo web export (30 routes). This exercises the @expo → glob → minimatch → brace-expansion path.
- `bun install --frozen-lockfile` passes (exit 0); bun.lock is in sync.
- Backend & shared-types tests pass. Frontend `jest` test fails with `command not found` — a pre-existing condition (jest/jest-expo are not installed deps; identical on `main`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)