### PR TITLE
chore(deps): bump GitHub Actions across workflows (#15-#19)

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add to Oxy Platform board
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/OxyHQ/projects/14
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -25,10 +25,10 @@ jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Configure AWS credentials (OIDC, no stored keys)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -15,8 +15,8 @@ jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - uses: oven-sh/setup-bun@v2
@@ -32,7 +32,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Applies the 5 open dependabot github-actions bumps in a single commit to avoid a 5-PR same-file conflict cascade (all touch `.github/workflows/*.yml`).

| Action | Old | New | Files |
|--------|-----|-----|-------|
| cloudflare/wrangler-action | v3 | v4 | deploy-frontends.yml |
| actions/checkout | v4 | v7 | deploy-aws.yml, deploy-frontends.yml |
| actions/setup-node | v4 | v6 | deploy-frontends.yml |
| actions/add-to-project | v1.0.2 | v2.0.0 | auto-project.yml |
| aws-actions/configure-aws-credentials | v4 | v6 | deploy-aws.yml |

Compatibility checks (deploy-affecting majors):
- `aws-actions/configure-aws-credentials@v6`: still uses `role-to-assume` + `aws-region`; OIDC `permissions: id-token: write` present. No input changes.
- `cloudflare/wrangler-action@v4`: still uses `apiToken`/`accountId`/`command`. No input changes.

Closes #15, closes #16, closes #17, closes #18, closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/allo/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->