### PR TITLE
fix(backend): Node 22 base image — unblock ECS deploy (Mongo/crypto crash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "~5.9.2"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.19.0",
     "bun": ">=1.0.0"
   },
   "dependencies": {

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,6 +1,13 @@
 # Backend Dockerfile (Express API).
 #
-# Runs on AWS Graviton (linux/arm64) as well as x86_64; base node:18-alpine.
+# Runs on AWS Graviton (linux/arm64) as well as x86_64; base node:22-alpine.
+# Node 22 (LTS) is required: mongoose 9 / mongodb 7 / bson 6 declare
+# engines.node >= 20.19.0 and the MongoDB driver's SCRAM auth now uses the
+# Web Crypto global (crypto.getRandomValues). Node 18 (EOL 2025-04) does NOT
+# expose globalThis.crypto when executing a script file, so @oxyhq/core's
+# crypto polyfill installed an RN-only getRandomValues stub that throws on
+# Node — crashing every task on Mongo connect. Node >= 20 exposes the global,
+# so the polyfill's guard is skipped and native crypto is used.
 # The repo is a Bun workspaces monorepo with a committed bun.lock, so we use
 # Bun for a deterministic install instead of npm. npm's strict ERESOLVE
 # resolver fails here because @oxyhq/services declares OPTIONAL peer deps
@@ -9,7 +16,7 @@
 # resolves the workspace cleanly. The backend itself only needs @oxyhq/core
 # (a shared root dependency) and never imports any expo/frontend package.
 
-FROM node:18-alpine
+FROM node:22-alpine
 
 # Pin Bun to the same version used in CI for reproducible installs.
 ENV BUN_VERSION=1.3.14


### PR DESCRIPTION
Allo backend tasks crashed on startup at MongoDB connect since ~2026-07-15, so `aws ecs wait services-stable` timed out and every deploy rolled back to the 07-15 tasks.

Root cause: mongoose 8→9.7.4 (commit 5eb20ad) pulled mongodb 7 (requires Node ≥20.19) whose `randomBytes` uses global `crypto.getRandomValues`. The backend base image was `node:18-alpine`, and Node 18 doesn't expose `globalThis.crypto` for script files, so @oxyhq/core's crypto polyfill installs an RN-only stub that throws on Node → the Mongo SCRAM handshake crashes the server (exit 1).

Fix: base image `node:18-alpine` → `node:22-alpine` (ecosystem LTS, satisfies the ≥20.19 floor); root `engines.node` → `>=20.19.0`. Verified: rebuilt the image as CI does and connected to a real SCRAM-auth MongoDB — the exact step that threw now logs 'Connected to MongoDB successfully'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)