### PR TITLE
fix(auth): register the shared-identity reader plugin

### DIFF
--- a/packages/frontend/app.config.js
+++ b/packages/frontend/app.config.js
@@ -198,6 +198,11 @@ return {
                 // UID ("so.oxy.shared") so "Sign in with Oxy" reuses the device
                 // session across installed Oxy apps.
                 './plugins/withSharedUserId',
+                // Reader side of the shared-identity native module (ships in
+                // @oxyhq/services): request the signature permission + <queries>
+                // so cold boot can silently read the Commons-hosted shared
+                // identity (silent "Sign in with Oxy").
+                '@oxyhq/services/plugins/withSharedIdentityReader',
             ];
 
             // Only include expo-notifications for native builds (android/ios).


### PR DESCRIPTION
## Summary
- Allo already declared `sharedUserId` (Android shared-keychain UID `so.oxy.shared`) but never registered the reader half of `@oxyhq/services`, so `signInWithSharedIdentity()` silently resolved to `null` and shared cross-app sign-in never worked.
- Registers `@oxyhq/services/plugins/withSharedIdentityReader` alongside the existing `withSharedUserId` plugin in `packages/frontend/app.config.js`.

The failure was silent by design: `OxyIdentityModule.kt:21` documents "Every failure resolves to null / no-op", so there was no error to surface — cold boot just never found a shared identity to read.

## Test plan
- [x] Baseline gate: `git stash` → `bun run lint` + `bunx tsc --noEmit` in `packages/frontend` → 198 lint problems / 13 tsc errors (preexisting). `git stash pop` → re-ran both → same 198 / 13. Commit adds zero new reds.
- [x] `bun install --frozen-lockfile` passes (no dependency changes).
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)