### PR TITLE
feat(moderation): CrowdSource integration — account reports only, messages stay local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+# Typecheck + tests on every PR.
+#
+# Allo had no workflow that ran either, which meant the moderation suite —
+# including the test pinning `deliverableTypes()` to exactly `['user']`, the one
+# thing that fails if somebody ever wires end-to-end-encrypted `message` content
+# up for review — executed nowhere. A privacy control that is not enforced is a
+# comment.
+#
+# Deliberately minimal: install, typecheck, test. No coverage thresholds, no
+# matrix, no lint gate. The point is that the guards RUN on every PR; anything
+# more is a second thing to keep green.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend typecheck + tests
+    runs-on: ubuntu-latest
+    env:
+      # Pinned rather than left to float, so the binary cache key below is stable
+      # and a new upstream default cannot change what CI runs without a commit.
+      MONGOMS_VERSION: 8.2.6
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Must match packages/backend/Dockerfile and the local bun used to
+          # regenerate bun.lock — a mismatch fails the install on the lockfile.
+          bun-version: 1.3.14
+
+      # The backend suite runs against a real MongoDB replica set (see
+      # packages/backend/vitest.globalSetup.ts). Without this cache every run
+      # re-downloads the server binary, which is slow enough to make people stop
+      # trusting the job.
+      - name: Cache MongoDB binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}-${{ env.MONGOMS_VERSION }}
+
+      # postinstall builds @allo/shared-types, which the backend compiles against.
+      - name: Install
+        run: bun install
+
+      # Scoped to the backend on purpose. The ROOT tsconfig is a composite
+      # project-reference config and reports hundreds of TS6305 "output file has
+      # not been built from source file" errors for the frontend on a clean
+      # checkout — pre-existing, unrelated to any change, and not a signal.
+      - name: Typecheck backend
+        run: bun x tsc --noEmit -p packages/backend/tsconfig.json
+
+      - name: Test backend
+        run: bun run --filter @allo/backend test

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
       },
       "devDependencies": {
         "@types/supertest": "^6.0.3",
+        "mongodb-memory-server": "^11.2.0",
         "node-fetch": "^2.7.0",
         "nodemon": "^3.1.14",
         "supertest": "^7.1.4",
@@ -1069,6 +1070,8 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
@@ -1076,6 +1079,8 @@
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
 
     "babel-jest": ["babel-jest@29.7.0", "", { "dependencies": { "@jest/transform": "^29.7.0", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^29.6.3", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.8.0" } }, "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg=="],
 
@@ -1110,6 +1115,16 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "barcode-detector": ["barcode-detector@3.2.0", "", { "dependencies": { "zxing-wasm": "3.1.0" } }, "sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.7.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ=="],
+
+    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
+
+    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
+
+    "bare-url": ["bare-url@2.4.6", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -1216,6 +1231,8 @@
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "comment-json": ["comment-json@4.2.5", "", { "dependencies": { "array-timsort": "^1.0.3", "core-util-is": "^1.0.3", "esprima": "^4.0.1", "has-own-prop": "^2.0.0", "repeat-string": "^1.6.1" } }, "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
     "component-emitter": ["component-emitter@1.3.1", "", {}, "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="],
 
@@ -1445,6 +1462,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -1545,6 +1564,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-json-stringify": ["fast-json-stringify@6.0.1", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^2.0.0", "rfdc": "^1.2.0" } }, "sha512-s7SJE83QKBZwg54dIbD5rCtzOBVD43V1ReWXXYqBgwCwHLYAAT0RQc/FmrQglXqWPpz6omtryJQOau5jI4Nrvg=="],
@@ -1586,6 +1607,8 @@
     "finalhandler": ["finalhandler@1.3.1", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "2.4.1", "parseurl": "~1.3.3", "statuses": "2.0.1", "unpipe": "~1.0.0" } }, "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="],
 
     "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
+
+    "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -2037,7 +2060,7 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
@@ -2125,6 +2148,10 @@
 
     "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.2", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA=="],
 
+    "mongodb-memory-server": ["mongodb-memory-server@11.2.0", "", { "dependencies": { "mongodb-memory-server-core": "11.2.0", "tslib": "^2.8.1" } }, "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w=="],
+
+    "mongodb-memory-server-core": ["mongodb-memory-server-core@11.2.0", "", { "dependencies": { "async-mutex": "^0.5.0", "camelcase": "^6.3.0", "debug": "^4.4.3", "find-cache-dir": "^3.3.2", "follow-redirects": "^1.16.0", "https-proxy-agent": "^7.0.6", "mongodb": "^7.2.0", "new-find-package-json": "^2.0.0", "semver": "^7.7.3", "tar-stream": "^3.1.8", "tslib": "^2.8.1", "yauzl": "^3.3.1" } }, "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg=="],
+
     "mongoose": ["mongoose@9.7.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "kareem": "3.3.0", "mongodb": "~7.2", "mpath": "0.9.0", "mquery": "6.0.0", "ms": "2.1.3", "sift": "17.1.3" } }, "sha512-nuSYGUWWzNd4EAbGYxE469wPTL+kmxb5+91YvCvMkJ08rvNRht/usZUU3LuFuk7rDutF2QWBZHPHuzM8TxXApA=="],
 
     "moo": ["moo@0.5.2", "", {}, "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="],
@@ -2150,6 +2177,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "new-find-package-json": ["new-find-package-json@2.0.0", "", { "dependencies": { "debug": "^4.3.4" } }, "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
@@ -2248,6 +2277,8 @@
     "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -2569,6 +2600,8 @@
 
     "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
 
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
     "string-length": ["string-length@5.0.1", "", { "dependencies": { "char-regex": "^2.0.0", "strip-ansi": "^7.0.1" } }, "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow=="],
@@ -2629,13 +2662,19 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
     "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
     "terminal-link": ["terminal-link@2.1.1", "", { "dependencies": { "ansi-escapes": "^4.2.1", "supports-hyperlinks": "^2.0.0" } }, "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ=="],
 
     "terser": ["terser@5.44.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w=="],
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "text-encoding": ["text-encoding@0.7.0", "", {}, "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="],
 
@@ -2832,6 +2871,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
 
     "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
 
@@ -3349,6 +3390,8 @@
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "istanbul-lib-report/make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "istanbul-lib-source-maps/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -3413,7 +3456,7 @@
 
     "log-symbols/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
-    "make-dir/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+    "make-dir/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "metro/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -3442,6 +3485,8 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "mongodb-memory-server-core/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "multer/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
@@ -4003,6 +4048,8 @@
 
     "google-gax/retry-request/teeny-request": ["teeny-request@10.1.3", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "stream-events": "^1.0.5" } }, "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug=="],
 
+    "istanbul-lib-report/make-dir/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
     "istanbul-lib-report/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "jest-circus/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -4072,6 +4119,8 @@
     "mongodb-connection-string-url/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "mongodb-connection-string-url/whatwg-url/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "mongodb-memory-server-core/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "multer/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,9 @@
         "@allo/shared-types": "file:../shared-types",
         "@oxyhq/contracts": "^0.19.0",
         "@oxyhq/core": "^13.0.0",
+        "@oxyhq/crowdsource": "0.3.0",
+        "@oxyhq/crowdsource-contracts": "0.3.0",
+        "@oxyhq/crowdsource-express": "0.3.0",
         "@types/multer": "^2.2.0",
         "ai": "^7.0.28",
         "bcryptjs": "^3.0.3",
@@ -49,12 +52,14 @@
         "qrcode-terminal": "^0.12.0",
         "socket.io": "^4.8.3",
         "validator": "^13.15.35",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "node-fetch": "^2.7.0",
         "nodemon": "^3.1.14",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
+        "vitest": "^4.1.10",
       },
     },
     "packages/frontend": {
@@ -380,6 +385,12 @@
 
     "@egjs/hammerjs": ["@egjs/hammerjs@2.0.17", "", { "dependencies": { "@types/hammerjs": "^2.0.36" } }, "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A=="],
 
+    "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@2.0.0-alpha.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
+
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
@@ -590,6 +601,8 @@
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.3.0", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.1", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ=="],
+
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
     "@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
@@ -602,11 +615,19 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
+
     "@oxyhq/bloom": ["@oxyhq/bloom@0.67.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": "", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom"] }, "sha512-40pNeWVPrGCYYEfBUDnQT4D+HzI+7WosLe0A3KGjuAFwwsic+IrBeogLlCe+RDZo0pr+Y+EMBoXmKz91af61Gg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.19.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-QrzSUKv7Q2lvBZGR/ZARlJijg7QMATAicblWkS/DiczZ4Vf018kSpXNr49BdqPjxS0/t21+1wuMjwT9TeFkDHg=="],
 
     "@oxyhq/core": ["@oxyhq/core@13.0.0", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@oxyhq/contracts": "^0.19.0", "@oxyhq/protocol": "^0.1.6", "bip39": "^3.1.0", "buffer": "^6.0.3", "elliptic": "^6.6.1", "invariant": "^2.2.4", "jwt-decode": "^4.0.0", "socket.io-client": "^4.8.1", "tldts": "^7.4.8", "zod": "^3.25.64" }, "peerDependencies": { "@react-native-async-storage/async-storage": "*", "expo-crypto": "*", "expo-secure-store": "*", "express": "^4.0.0", "express-rate-limit": "^7.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-crypto", "expo-secure-store", "express"] }, "sha512-0brt8zhiZSDW2MLEyNr5mwtbGC+kXgq2/nY3qRphObQefUp01Nfd5eB9dAWlAfSIQpxrXuL+OmFApTVK1uJU7g=="],
+
+    "@oxyhq/crowdsource": ["@oxyhq/crowdsource@0.3.0", "", { "dependencies": { "zod": "^4.4.3" }, "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0" } }, "sha512-YwLDyeIsXrU9qC8H51DW8KQI571HhdLXS3DjaPlJZ3n9W/Eeb/Xu+bqIHqLdFjViu/3Cvjw+dSYLPz2Zh/VAGg=="],
+
+    "@oxyhq/crowdsource-contracts": ["@oxyhq/crowdsource-contracts@0.3.0", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-pYCjVFzykva0xuAdbKrmtTuhVV+Xx8Ir6WX3UodIWZCujus9SQ5zfHjCAFFQZUs0D+bkWab9CAuQa2Nl95bpaQ=="],
+
+    "@oxyhq/crowdsource-express": ["@oxyhq/crowdsource-express@0.3.0", "", { "peerDependencies": { "@oxyhq/crowdsource-contracts": "^0.3.0", "express": ">=4" } }, "sha512-sMYvLaNli3yLZVLzYWeazcEUygvV4lo0hzdp9KEdLi1PY5HYyY3nJCwGlGaY0+0V4ByO7mEIEcuclhOvt0ZWbg=="],
 
     "@oxyhq/expo-splash": ["@oxyhq/expo-splash@0.1.0", "", { "dependencies": { "@expo/image-utils": ">=0.7.0", "xml2js": "^0.6.0" }, "peerDependencies": { "expo": ">=51.0.0", "expo-splash-screen": ">=0.27.0", "react": ">=18.0.0", "react-native": ">=0.74.0" } }, "sha512-Sdh/3KQbLKpzjkDQ0v8IiFkhKKGDbjNgXPepyH6nomIG+3wU3aa40LFM9hhoOtHCNPg4uX8Z88WZb5l8ZYDA7g=="],
 
@@ -716,6 +737,38 @@
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.86.0", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.2.0", "react": "*", "react-native": "0.86.0" }, "optionalPeers": ["@types/react"] }, "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.1", "", { "os": "none", "cpu": "arm64" }, "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.1", "", { "dependencies": { "@emnapi/core": "2.0.0-alpha.3", "@emnapi/runtime": "2.0.0-alpha.3", "@napi-rs/wasm-runtime": "^1.2.0" } }, "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@shopify/flash-list": ["@shopify/flash-list@2.0.2", "", { "dependencies": { "tslib": "2.8.1" }, "peerDependencies": { "@babel/runtime": "*", "react": "*", "react-native": "*" } }, "sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w=="],
@@ -792,6 +845,8 @@
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -806,11 +861,15 @@
 
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
 
@@ -906,6 +965,20 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
@@ -979,6 +1052,8 @@
     "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
@@ -1083,6 +1158,8 @@
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1292,6 +1369,8 @@
 
     "es-iterator-helpers": ["es-iterator-helpers@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.0.3", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.6", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.4", "safe-array-concat": "^1.1.3" } }, "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w=="],
 
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
@@ -1340,6 +1419,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -1353,6 +1434,8 @@
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
 
     "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "expo": ["expo@57.0.6", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "^57.0.8", "@expo/config": "~57.0.5", "@expo/config-plugins": "~57.0.5", "@expo/devtools": "~57.0.1", "@expo/dom-webview": "~57.0.1", "@expo/fingerprint": "^0.20.5", "@expo/local-build-cache-provider": "^57.0.4", "@expo/log-box": "^57.0.1", "@expo/metro": "~56.0.0", "@expo/metro-config": "~57.0.5", "@ungap/structured-clone": "^1.3.0", "babel-preset-expo": "~57.0.3", "expo-asset": "~57.0.5", "expo-constants": "~57.0.5", "expo-file-system": "~57.0.1", "expo-font": "~57.0.1", "expo-keep-awake": "~57.0.1", "expo-modules-autolinking": "~57.0.7", "expo-modules-core": "~57.0.5", "pretty-format": "^29.7.0", "react-refresh": "^0.14.2", "whatwg-url-minimum": "^0.1.2" }, "peerDependencies": { "@expo/metro-runtime": "*", "react": "*", "react-dom": "*", "react-native": "*", "react-native-web": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/metro-runtime", "react-dom", "react-native-web", "react-native-webview"], "bin": { "expo": "bin/cli", "fingerprint": "bin/fingerprint", "expo-modules-autolinking": "bin/autolinking" } }, "sha512-4NKM1ArfRAmmY82Xcw/guGHlTSItD5mzNxbK4Qd3aOPuRAPAkCgJVLC/eqccZCEGS5aJn0tyjHNKE65k2GrcFw=="],
 
@@ -2092,6 +2175,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
@@ -2139,6 +2224,8 @@
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -2328,6 +2415,8 @@
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
+    "rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
+
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -2390,6 +2479,8 @@
 
     "sift": ["sift@17.1.3", "", {}, "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "simple-plist": ["simple-plist@1.3.1", "", { "dependencies": { "bplist-creator": "0.1.0", "bplist-parser": "0.3.1", "plist": "^3.0.5" } }, "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw=="],
@@ -2430,6 +2521,8 @@
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
 
     "stacktrace-gps": ["stacktrace-gps@3.1.2", "", { "dependencies": { "source-map": "0.5.6", "stackframe": "^1.3.4" } }, "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ=="],
@@ -2441,6 +2534,8 @@
     "standard-navigation": ["standard-navigation@0.0.5", "", {}, "sha512-YAmzwAiiQVocZxO/VGPFiQHcu5pKiz09QIGC0MK6aRMoa3E0QkoTQgcqJr7ZZ3OMiNhu4DkaGElFI5htjOIDbw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -2520,7 +2615,13 @@
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "tldts": ["tldts@7.4.8", "", { "dependencies": { "tldts-core": "^7.4.8" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A=="],
 
@@ -2622,6 +2723,10 @@
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
+    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "vlq": ["vlq@1.0.1", "", {}, "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="],
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
@@ -2663,6 +2768,8 @@
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -3390,6 +3497,12 @@
 
     "v8-to-istanbul/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -3971,6 +4084,8 @@
     "terser/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "@babel/core/@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": "dist/cli.js" }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,8 +55,10 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@types/supertest": "^6.0.3",
         "node-fetch": "^2.7.0",
         "nodemon": "^3.1.14",
+        "supertest": "^7.1.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10",
@@ -635,6 +637,8 @@
 
     "@oxyhq/services": ["@oxyhq/services@23.0.1", "", { "dependencies": { "@oxyhq/contracts": "0.19.0", "@oxyhq/core": "^13.0.0", "@simplewebauthn/browser": "^13.3.0", "color": "^4.2.3" }, "peerDependencies": { "@expo/vector-icons": "^15.0.3", "@oxyhq/bloom": ">=0.59.0", "@react-native-async-storage/async-storage": "^2.0.0", "@react-native-community/netinfo": ">=11.4.1", "@tanstack/query-async-storage-persister": "^5.101", "@tanstack/query-sync-storage-persister": "^5.101", "@tanstack/react-query": "^5.101", "@tanstack/react-query-persist-client": "^5.101", "@types/react": "*", "@types/react-native": "*", "expo": ">=56.0.0", "expo-constants": ">=56.0.0", "expo-document-picker": ">=56.0.0", "expo-file-system": ">=56.0.0", "expo-haptics": ">=56.0.0", "expo-image": ">=2.0.0", "expo-image-manipulator": ">=56.0.0", "expo-image-picker": ">=56.0.0", "expo-linear-gradient": ">=56.0.0", "expo-modules-core": "*", "expo-notifications": ">=56.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-native": ">=0.85.0", "react-native-gesture-handler": ">=2.31.1", "react-native-keyboard-controller": ">=1.21.0", "react-native-qrcode-svg": "^6.3.0", "react-native-reanimated": ">=4.3.0", "react-native-safe-area-context": ">=5.7.0", "react-native-svg": ">=15.15.0", "socket.io-client": "^4.8.0", "zustand": "^5.0.0" }, "optionalPeers": ["@tanstack/query-sync-storage-persister", "@types/react", "@types/react-native", "expo", "expo-constants", "expo-document-picker", "expo-haptics", "expo-image-manipulator", "expo-image-picker", "expo-linear-gradient", "expo-modules-core", "expo-notifications", "nativewind", "react-native-keyboard-controller"] }, "sha512-imJ3FEdy1Cv46oBe6d1jCR6kA1OGNAvOocxVpctm/JW5HG4J8dJSZubNYoLuIIGSDfeciCenyp/V6FtNLyrbhA=="],
 
+    "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
@@ -865,6 +869,8 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/cookiejar": ["@types/cookiejar@2.1.5", "", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
+
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
@@ -901,6 +907,8 @@
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 
+    "@types/methods": ["@types/methods@1.1.4", "", {}, "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="],
+
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -926,6 +934,10 @@
     "@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
+
+    "@types/superagent": ["@types/superagent@8.1.11", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-KA7srSW/HENDtOw9DOqaFLgWuMqN9WgjEw62lh9dpvRaZDkhdOkazASd7X7i2eMUYLHa1U37ZttnePsH5zTDHw=="],
+
+    "@types/supertest": ["@types/supertest@6.0.3", "", { "dependencies": { "@types/methods": "^1.1.4", "@types/superagent": "^8.1.0" } }, "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w=="],
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
@@ -1205,6 +1217,8 @@
 
     "comment-json": ["comment-json@4.2.5", "", { "dependencies": { "array-timsort": "^1.0.3", "core-util-is": "^1.0.3", "esprima": "^4.0.1", "has-own-prop": "^2.0.0", "repeat-string": "^1.6.1" } }, "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw=="],
 
+    "component-emitter": ["component-emitter@1.3.1", "", {}, "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="],
+
     "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
 
     "compression": ["compression@1.8.1", "", { "dependencies": { "bytes": "3.1.2", "compressible": "~2.0.18", "debug": "2.6.9", "negotiator": "~0.6.4", "on-headers": "~1.1.0", "safe-buffer": "5.2.1", "vary": "~1.1.2" } }, "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w=="],
@@ -1223,7 +1237,9 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cookiejar": ["cookiejar@2.1.4", "", {}, "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="],
 
     "core-js-compat": ["core-js-compat@3.48.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q=="],
 
@@ -1300,6 +1316,8 @@
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
 
     "diff": ["diff@4.0.2", "", {}, "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="],
 
@@ -1535,6 +1553,8 @@
 
     "fast-printf": ["fast-printf@1.6.10", "", {}, "sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w=="],
 
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
@@ -1588,6 +1608,8 @@
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "formidable": ["formidable@3.5.4", "", { "dependencies": { "@paralleldrive/cuid2": "^2.2.2", "dezalgo": "^1.0.4", "once": "^1.4.0" } }, "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -2077,7 +2099,7 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime": ["mime@1.6.0", "", { "bin": "cli.js" }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+    "mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -2507,7 +2529,7 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
@@ -2586,6 +2608,10 @@
     "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
 
     "styleq": ["styleq@0.1.3", "", {}, "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA=="],
+
+    "superagent": ["superagent@10.3.0", "", { "dependencies": { "component-emitter": "^1.3.1", "cookiejar": "^2.1.4", "debug": "^4.3.7", "fast-safe-stringify": "^2.1.1", "form-data": "^4.0.5", "formidable": "^3.5.4", "methods": "^1.1.2", "mime": "2.6.0", "qs": "^6.14.1" } }, "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ=="],
+
+    "supertest": ["supertest@7.2.2", "", { "dependencies": { "cookie-signature": "^1.2.2", "methods": "^1.1.2", "superagent": "^10.3.0" } }, "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA=="],
 
     "supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
@@ -3087,6 +3113,8 @@
 
     "@oxyhq/protocol/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@paralleldrive/cuid2/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@react-native/babel-preset/@babel/plugin-transform-class-properties": ["@babel/plugin-transform-class-properties@7.27.1", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA=="],
 
     "@react-native/babel-preset/@babel/plugin-transform-classes": ["@babel/plugin-transform-classes@7.28.4", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-globals": "^7.28.0", "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-replace-supers": "^7.27.1", "@babel/traverse": "^7.28.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA=="],
@@ -3275,6 +3303,8 @@
 
     "express/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
+    "express/cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
@@ -3338,6 +3368,8 @@
     "jest-mock/@types/node": ["@types/node@22.18.5", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-g9BpPfJvxYBXUWI9bV37j6d6LTMNQ88hPwdWWUeYZnMhlo66FIg9gCc1/DZb15QylJSKwOZjwrckvOTWpOiChg=="],
 
     "jest-runner/@types/node": ["@types/node@22.18.5", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-g9BpPfJvxYBXUWI9bV37j6d6LTMNQ88hPwdWWUeYZnMhlo66FIg9gCc1/DZb15QylJSKwOZjwrckvOTWpOiChg=="],
+
+    "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
     "jest-runtime/@types/node": ["@types/node@22.18.5", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-g9BpPfJvxYBXUWI9bV37j6d6LTMNQ88hPwdWWUeYZnMhlo66FIg9gCc1/DZb15QylJSKwOZjwrckvOTWpOiChg=="],
 
@@ -3459,6 +3491,8 @@
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "send/mime": ["mime@1.6.0", "", { "bin": "cli.js" }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
     "serve-static/send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
 
     "simple-plist/bplist-parser": ["bplist-parser@0.3.1", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA=="],
@@ -3484,8 +3518,6 @@
     "supports-hyperlinks/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
-
-    "terser/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -3987,6 +4019,8 @@
 
     "jest-runner/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "jest-runner/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "jest-runtime/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "jest-runtime/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -4077,11 +4111,11 @@
 
     "serve-static/send/http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
+    "serve-static/send/mime": ["mime@1.6.0", "", { "bin": "cli.js" }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
     "serve-static/send/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "string-length/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "terser/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -45,8 +45,10 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/supertest": "^6.0.3",
     "node-fetch": "^2.7.0",
     "nodemon": "^3.1.14",
+    "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "migrate": "ts-node --transpile-only scripts/migrate.ts",
     "migrate:dev": "NODE_ENV=development ts-node --transpile-only scripts/migrate.ts",
-    "test": "echo \"No tests specified\" && exit 0",
+    "test": "vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -19,6 +19,9 @@
     "@allo/shared-types": "file:../shared-types",
     "@oxyhq/contracts": "^0.19.0",
     "@oxyhq/core": "^13.0.0",
+    "@oxyhq/crowdsource": "0.3.0",
+    "@oxyhq/crowdsource-contracts": "0.3.0",
+    "@oxyhq/crowdsource-express": "0.3.0",
     "@types/multer": "^2.2.0",
     "ai": "^7.0.28",
     "bcryptjs": "^3.0.3",
@@ -38,12 +41,14 @@
     "node-telegram-bot-api": "^1.2.0",
     "qrcode-terminal": "^0.12.0",
     "socket.io": "^4.8.3",
-    "validator": "^13.15.35"
+    "validator": "^13.15.35",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "node-fetch": "^2.7.0",
     "nodemon": "^3.1.14",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/supertest": "^6.0.3",
+    "mongodb-memory-server": "^11.2.0",
     "node-fetch": "^2.7.0",
     "nodemon": "^3.1.14",
     "supertest": "^7.1.4",

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -17,6 +17,9 @@ import profileSettingsRoutes from "./src/routes/profileSettings";
 import conversationsRoutes from "./src/routes/conversations";
 import messagesRoutes from "./src/routes/messages";
 import devicesRoutes from "./src/routes/devices";
+import reportsRoutes from "./src/routes/reports";
+import { createCrowdSourceWebhookRoutes } from "./src/routes/crowdSourceWebhook";
+import { startModerationOutboxDispatcher } from "./src/services/moderation/ModerationOutboxDispatcher";
 
 // Middleware
 
@@ -35,6 +38,25 @@ const app = express();
 export const oxy = oxyClient;
 
 // --- Middleware ---
+
+/**
+ * MUST stay ahead of `express.json` below.
+ *
+ * A CrowdSource webhook signature covers the bytes that arrived, and once a JSON
+ * parser has consumed the stream those bytes no longer exist.
+ * `@oxyhq/crowdsource-express` reads the raw stream itself and REFUSES if
+ * something upstream already consumed it, rather than verifying a signature over a
+ * re-serialisation — so mounting this after the parser does not silently verify
+ * the wrong bytes, it fails every delivery. The route adds its own assertion on top
+ * of that (see `assertRawBody`), which names the mount order as the cause instead
+ * of leaving a signature mismatch to be misread as a bad secret.
+ *
+ * It also sits ahead of the per-user rate limiter further down, deliberately: the
+ * HMAC is the authentication (§10.8), and a 429 to CrowdSource would put a
+ * moderation decision back on a retry schedule for no reason.
+ */
+app.use("/webhooks", createCrowdSourceWebhookRoutes());
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
@@ -243,6 +265,7 @@ authenticatedApiRouter.use("/profile", profileSettingsRoutes);
 authenticatedApiRouter.use("/conversations", conversationsRoutes);
 authenticatedApiRouter.use("/messages", messagesRoutes);
 authenticatedApiRouter.use("/devices", devicesRoutes);
+authenticatedApiRouter.use("/reports", reportsRoutes);
 
 // Mount public and authenticated API routers
 app.use("/api", publicApiRouter);
@@ -269,6 +292,9 @@ db.once("open", () => {
   require("./src/models/Restrict");
   require("./src/models/UserBehavior");
   require("./src/models/Device");
+  require("./src/models/Report");
+  require("./src/models/ModerationOutbox");
+  require("./src/models/ModerationEvent");
 });
 
 // --- Server Listen ---
@@ -276,6 +302,10 @@ const PORT = process.env.PORT || 3000;
 const bootServer = async () => {
   try {
     await connectToDatabase();
+    // Started after the database is reachable: the dispatcher's first act is a
+    // claim query, and a drain against a disconnected Mongo would only log noise.
+    // A no-op unless CROWDSOURCE_ENABLED=true.
+    startModerationOutboxDispatcher();
     server.listen(PORT, () => {
       logger.info(`Allo backend server running on port ${PORT}`);
     });

--- a/packages/backend/src/__tests__/routes/crowdSourceWebhookMount.test.ts
+++ b/packages/backend/src/__tests__/routes/crowdSourceWebhookMount.test.ts
@@ -1,0 +1,123 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The webhook signature covers the bytes that arrived, so a body parser mounted
+ * ahead of this router destroys the only thing that can be verified.
+ *
+ * `@oxyhq/crowdsource-express` already refuses rather than re-serialising, which
+ * makes the mistake loud but not LEGIBLE: what an operator sees is a signature
+ * failure, which reads like a secret problem and sends the next person to rotate a
+ * secret that was fine. The route's own `assertRawBody` turns that into a message
+ * naming the mount order.
+ *
+ * These tests assemble a real Express app in both orders, because the property
+ * under test is a property of the ASSEMBLY, not of a function. Asserting it any
+ * other way would test a mock of the thing that breaks.
+ */
+
+vi.mock("../../services/moderation/moderationEventStore", () => ({
+  mongoProcessedEventStore: () => ({
+    claim: vi.fn(async () => true),
+    release: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("../../services/moderation/ModerationInboundService", () => ({
+  recordDecisionEvent: vi.fn(async () => undefined),
+  recordIgnoredEvent: vi.fn(async () => undefined),
+}));
+
+import { resetCrowdSourceConfigForTests } from "../../config/crowdsource";
+import { createCrowdSourceWebhookRoutes } from "../../routes/crowdSourceWebhook";
+
+const SECRET = "a-test-webhook-secret-long-enough";
+
+function appWith(options: { parseJsonFirst: boolean }): express.Express {
+  const app = express();
+  if (options.parseJsonFirst) app.use(express.json());
+  app.use("/webhooks", createCrowdSourceWebhookRoutes());
+  if (!options.parseJsonFirst) app.use(express.json());
+  return app;
+}
+
+describe("crowdsource webhook mount order", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCrowdSourceConfigForTests();
+    process.env.CROWDSOURCE_WEBHOOK_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.CROWDSOURCE_WEBHOOK_SECRET;
+    delete process.env.CROWDSOURCE_ENABLED;
+    resetCrowdSourceConfigForTests();
+  });
+
+  it("refuses, naming the cause, when a body parser ran first", async () => {
+    const response = await request(appWith({ parseJsonFirst: true }))
+      .post("/webhooks/crowdsource")
+      .set("content-type", "application/json")
+      .send({ id: "evt_1", type: "case.decided" });
+
+    /**
+     * 500, not 4xx: this is Allo misassembled, not a bad request. Answering
+     * non-2xx also keeps the delivery on CrowdSource's retry schedule, so
+     * decisions queue up rather than being lost while the deployment is broken.
+     */
+    expect(response.status).toBe(500);
+    expect(response.body).toMatchObject({ message: "Webhook receiver is misconfigured" });
+  });
+
+  it("does not answer 500-misconfigured when mounted correctly", async () => {
+    /**
+     * The vacuity guard for the test above. Without it, a route that returned 500
+     * unconditionally — or an app that failed to mount at all — would satisfy the
+     * first assertion for entirely the wrong reason.
+     *
+     * An unsigned request is REJECTED here (401/400 from the SDK's verification),
+     * and that is the point: it got far enough to be verified, which is exactly
+     * what mounting ahead of the parser buys.
+     */
+    const response = await request(appWith({ parseJsonFirst: false }))
+      .post("/webhooks/crowdsource")
+      .set("content-type", "application/json")
+      .send({ id: "evt_1", type: "case.decided" });
+
+    expect(response.status).not.toBe(404);
+    expect(response.body?.message).not.toBe("Webhook receiver is misconfigured");
+    // Unsigned: refused by signature verification, never accepted.
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("is not mounted at all without a configured secret", async () => {
+    /**
+     * Not mounted, rather than mounted and permissive. A route that answers
+     * anything without a secret is one that will eventually be reasoned about as
+     * if it verified something.
+     */
+    delete process.env.CROWDSOURCE_WEBHOOK_SECRET;
+    resetCrowdSourceConfigForTests();
+
+    const response = await request(appWith({ parseJsonFirst: false }))
+      .post("/webhooks/crowdsource")
+      .send({ id: "evt_1" });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("never authenticates by Oxy session — the HMAC is the authentication", async () => {
+    /**
+     * An unsigned request carrying a bearer token must not be treated as
+     * authorised. This is not a user endpoint, and a session must never satisfy it.
+     */
+    const response = await request(appWith({ parseJsonFirst: false }))
+      .post("/webhooks/crowdsource")
+      .set("authorization", "Bearer a-perfectly-valid-looking-token")
+      .set("content-type", "application/json")
+      .send({ id: "evt_1", type: "case.decided" });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/decisionHandling.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/decisionHandling.test.ts
@@ -1,0 +1,270 @@
+import mongoose from "mongoose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * What Allo does when a decision comes back — and, just as importantly, what it
+ * does not do.
+ *
+ * Allo has no platform-level sanction primitive: `Block` and `Restrict` are
+ * per-user relations a user writes about their own inbox, not account-level
+ * penalties. So the decision worker records the action it WOULD take and never
+ * acts, in every enforcement mode. The tests below pin that, because "moderation
+ * silently started restricting accounts" is not a regression anyone would want to
+ * discover from a user report.
+ */
+
+vi.mock("../../../models/Report", async () => {
+  const actual = await vi.importActual<typeof import("../../../models/Report")>(
+    "../../../models/Report",
+  );
+  return { ...actual, default: { findOne: vi.fn(), updateOne: vi.fn() } };
+});
+
+import Report from "../../../models/Report";
+import { resetCrowdSourceConfigForTests } from "../../../config/crowdsource";
+import {
+  applyDecisionOutboxEvent,
+  plannedActionForOutcome,
+} from "../../../services/moderation/ModerationDecisionWorker";
+import {
+  legacyStatusForOutcome,
+  reportStateForDecision,
+} from "../../../services/moderation/reportStatus";
+import { ReportStatus } from "../../../models/Report";
+import type { ModerationOutboxEvent } from "../../../services/moderation/ModerationOutboxService";
+
+const CASE_ID = "case_1";
+const REPORT_ID = new mongoose.Types.ObjectId();
+
+/**
+ * A decision that actually satisfies `DecisionSchema`.
+ *
+ * Built out in full rather than cast into shape, because the contract carries
+ * cross-field invariants a hand-waved fixture would not exercise: a `violation`
+ * requires at least one finding, a revision after the first must name what it
+ * supersedes, and `jury.agreement` must equal `winningVotes / decisiveVotes`. A
+ * fixture that skipped them would make every test here pass through the parse
+ * failure branch instead of the one it claims to test — which is exactly what the
+ * first draft of this file did.
+ */
+function decision(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "dec_1",
+    caseId: CASE_ID,
+    revision: 2,
+    supersedesDecisionId: "dec_0",
+    status: "final",
+    outcome: "violation",
+    contextSufficiency: "sufficient",
+    confidence: 0.9,
+    findings: [
+      {
+        code: "harassment.targeted_abuse",
+        severity: "high",
+        scope: "application_local",
+        confidence: 0.9,
+        resourceIds: ["res_1"],
+      },
+    ],
+    recommendedActions: [],
+    jury: {
+      size: 5,
+      decisiveVotes: 5,
+      winningVotes: 4,
+      agreement: 0.8,
+      specialistPresent: false,
+    },
+    policyVersions: {
+      taxonomy: "2026.07",
+      application: "allo-2026.07",
+      oxyConduct: "2026.07",
+    },
+    publishedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function event(decisionPayload: unknown): ModerationOutboxEvent {
+  return {
+    _id: "moderation:decision.apply:evt_1",
+    kind: "decision.apply",
+    payload: { eventId: "evt_1", caseId: CASE_ID, decision: decisionPayload },
+    attempts: 1,
+    availableAt: new Date(),
+    expiresAt: new Date(Date.now() + 1000),
+    createdAt: new Date(),
+  };
+}
+
+describe("decision application", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCrowdSourceConfigForTests();
+    vi.mocked(Report.updateOne).mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof Report.updateOne>>,
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.CROWDSOURCE_ENFORCEMENT_MODE;
+    resetCrowdSourceConfigForTests();
+    vi.restoreAllMocks();
+  });
+
+  function stubReport(stored: { decisionRevision?: number } = {}) {
+    vi.mocked(Report.findOne).mockReturnValue({
+      lean: async () => ({ _id: REPORT_ID, ...stored }),
+    } as unknown as ReturnType<typeof Report.findOne>);
+  }
+
+  it("records the outcome and the action it WOULD take, never one it did", async () => {
+    stubReport();
+    await applyDecisionOutboxEvent(event(decision()));
+
+    const update = vi.mocked(Report.updateOne).mock.calls[0]?.[1];
+    expect(update).toMatchObject({
+      $set: expect.objectContaining({
+        decisionOutcome: "violation",
+        decisionRevision: 2,
+        enforcedAction: "restrict",
+        status: ReportStatus.RESOLVED,
+        localStatus: "closed",
+      }),
+    });
+
+    /**
+     * The load-bearing negative. `enforcedAt` is what would distinguish "we
+     * decided this" from "we did this", and nothing in Allo may set it until an
+     * enforcement mechanism actually exists.
+     */
+    const setFields = (update as { $set: Record<string, unknown> }).$set;
+    expect(setFields).not.toHaveProperty("enforcedAt");
+  });
+
+  it("does not act even in automatic mode, because there is nothing to act with", async () => {
+    process.env.CROWDSOURCE_ENFORCEMENT_MODE = "automatic";
+    resetCrowdSourceConfigForTests();
+    stubReport();
+
+    await applyDecisionOutboxEvent(event(decision()));
+
+    const update = vi.mocked(Report.updateOne).mock.calls[0]?.[1];
+    const setFields = (update as { $set: Record<string, unknown> }).$set;
+    expect(setFields).not.toHaveProperty("enforcedAt");
+    // Only the report row is touched. No Block, no Restrict, no user write.
+    expect(Report.updateOne).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a revision that is not newer than the one already stored", async () => {
+    /**
+     * §10.6 allows redelivery and reordering, so an older revision arriving late
+     * must never overwrite a newer one. Compared against what is STORED, not
+     * against arrival order.
+     */
+    stubReport({ decisionRevision: 5 });
+    await applyDecisionOutboxEvent(event(decision({ revision: 3 })));
+    expect(Report.updateOne).not.toHaveBeenCalled();
+
+    await applyDecisionOutboxEvent(event(decision({ revision: 5 })));
+    expect(Report.updateOne).not.toHaveBeenCalled();
+  });
+
+  it("applies a strictly newer revision", async () => {
+    stubReport({ decisionRevision: 5 });
+    await applyDecisionOutboxEvent(event(decision({ revision: 6 })));
+    expect(Report.updateOne).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries — never dead-letters — a decision it cannot parse", async () => {
+    /**
+     * A payload this deployment cannot parse is far more likely to be a newer
+     * CrowdSource than a corrupt one. The outbox keeps a retryable failure for
+     * days, which is long enough to ship a contracts bump and let the backlog
+     * apply itself; dead-lettering would discard a real decision because this
+     * deployment was behind.
+     */
+    stubReport();
+    const thrown = await applyDecisionOutboxEvent(event({ nonsense: true })).catch(
+      (error: unknown) => error,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toHaveProperty("retryable", false);
+    expect(Report.updateOne).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when no local report matches the case", async () => {
+    // A merged case (§7.3) can name a case another report opened. Nothing to apply.
+    vi.mocked(Report.findOne).mockReturnValue({
+      lean: async () => null,
+    } as unknown as ReturnType<typeof Report.findOne>);
+
+    await expect(applyDecisionOutboxEvent(event(decision()))).resolves.toBeUndefined();
+    expect(Report.updateOne).not.toHaveBeenCalled();
+  });
+
+  it("dead-letters an event with no caseId", async () => {
+    const malformed: ModerationOutboxEvent = {
+      ...event(decision()),
+      payload: { eventId: "evt_1" },
+    };
+    await expect(applyDecisionOutboxEvent(malformed)).rejects.toHaveProperty(
+      "retryable",
+      false,
+    );
+  });
+});
+
+describe("outcome mapping", () => {
+  it("maps only real verdicts to verdict statuses", () => {
+    expect(legacyStatusForOutcome("violation")).toBe(ReportStatus.RESOLVED);
+    expect(legacyStatusForOutcome("no_violation")).toBe(ReportStatus.DISMISSED);
+  });
+
+  it("never turns 'we could not tell' into 'nothing was wrong'", () => {
+    /**
+     * The collapse the invariants forbid: absence of consensus is neither guilt
+     * nor innocence. Every non-verdict outcome — and any outcome a newer
+     * CrowdSource invents — maps to `reviewed`, never `dismissed`.
+     */
+    for (const outcome of [
+      "insufficient_context",
+      "inconclusive",
+      "content_unavailable",
+      "duplicate",
+      "escalated",
+      "an_outcome_from_the_future",
+    ]) {
+      expect(legacyStatusForOutcome(outcome)).toBe(ReportStatus.REVIEWED);
+    }
+  });
+
+  it("keeps a provisional decision open and closes a final one", () => {
+    expect(
+      reportStateForDecision({ outcome: "violation", decisionStatus: "provisional" })
+        .localStatus,
+    ).toBe("submitted");
+    expect(
+      reportStateForDecision({ outcome: "violation", decisionStatus: "final" }).localStatus,
+    ).toBe("closed");
+    expect(
+      reportStateForDecision({ outcome: "violation", decisionStatus: "corrected" })
+        .localStatus,
+    ).toBe("closed");
+    /**
+     * A superseded revision is not the current answer and must never be the thing
+     * that closes the report.
+     */
+    expect(
+      reportStateForDecision({ outcome: "violation", decisionStatus: "superseded" })
+        .localStatus,
+    ).toBe("submitted");
+  });
+
+  it("routes a non-verdict to a person rather than to silence", () => {
+    expect(plannedActionForOutcome("violation")).toBe("restrict");
+    expect(plannedActionForOutcome("no_violation")).toBe("restore");
+    expect(plannedActionForOutcome("inconclusive")).toBe("manual_review");
+    expect(plannedActionForOutcome("insufficient_context")).toBe("manual_review");
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/envelopeAndConfig.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/envelopeAndConfig.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReportCategory, ReportedType } from "../../../models/Report";
+import {
+  loadCrowdSourceConfig,
+  resetCrowdSourceConfigForTests,
+} from "../../../config/crowdsource";
+import {
+  REPORT_TAXONOMY_VERSION,
+  allegationsForCategories,
+} from "../../../services/moderation/reportTaxonomy";
+
+vi.mock("../../../services/moderation/subjects/registry", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/moderation/subjects/registry")
+  >("../../../services/moderation/subjects/registry");
+  return { ...actual, subjectProviderFor: vi.fn() };
+});
+
+import {
+  ModerationSubjectUnsupportedError,
+  buildModerationReportInput,
+  snapshotHash,
+} from "../../../services/moderation/EvidenceSnapshotService";
+import { subjectProviderFor } from "../../../services/moderation/subjects/registry";
+
+describe("allegation mapping", () => {
+  it("produces a stable ORDER for the same categories in any input order", () => {
+    /**
+     * Not cosmetic. Ingress fingerprints the whole envelope to detect §10.5's
+     * "same external id, different body", so a list whose order followed however a
+     * client happened to send its categories would turn a legitimate outbox retry
+     * into a permanent 409 — days later, as a report silently stuck in a queue.
+     */
+    const forward = allegationsForCategories([
+      ReportCategory.SPAM,
+      ReportCategory.HARASSMENT,
+      ReportCategory.HATE_SPEECH,
+    ]);
+    const reversed = allegationsForCategories([
+      ReportCategory.HATE_SPEECH,
+      ReportCategory.HARASSMENT,
+      ReportCategory.SPAM,
+    ]);
+    expect(forward).toEqual(reversed);
+    expect(forward).toEqual([...forward].sort());
+  });
+
+  it("deduplicates codes that share a mapping", () => {
+    const codes = allegationsForCategories([ReportCategory.OTHER, ReportCategory.OTHER]);
+    expect(codes).toEqual(["other.unclassifiable"]);
+  });
+
+  it("maps every category to a real taxonomy code", () => {
+    /** The vacuity floor: a mapping that silently returned nothing is not a report. */
+    for (const category of Object.values(ReportCategory)) {
+      const codes = allegationsForCategories([category]);
+      expect(codes).toHaveLength(1);
+      expect(codes[0]).toMatch(/^[a-z_]+\.[a-z_]+$/);
+    }
+  });
+
+  it("does not claim an integrity allegation for misinformation", () => {
+    /**
+     * A reporter clicking "misinformation" is not alleging organised manipulation
+     * or intent to defraud. Forcing it into `integrity.*` would tell a jury the
+     * reporter alleged something they did not.
+     */
+    expect(allegationsForCategories([ReportCategory.MISINFORMATION])).toEqual([
+      "other.policy_specific",
+    ]);
+  });
+});
+
+describe("report envelope input", () => {
+  const report = {
+    id: "report-1",
+    reportedType: ReportedType.USER,
+    reportedId: "user-1",
+    reporter: "reporter-1",
+    categories: [ReportCategory.HARASSMENT, ReportCategory.SPAM],
+    details: "  they keep messaging me  ",
+    createdAt: new Date("2026-07-30T10:00:00.000Z"),
+  } as unknown as Parameters<typeof buildModerationReportInput>[0];
+
+  const snapshot = {
+    subject: {
+      externalId: "user-1",
+      type: "identity.profile",
+      author: { oxyUserId: "user-1" },
+    },
+    content: { type: "profile" as const, data: { displayName: "Someone" } },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(subjectProviderFor).mockReturnValue({
+      reportedType: "user",
+      subjectType: "identity.profile",
+      snapshot: async () => snapshot,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the report's own timestamp, not the moment of delivery", async () => {
+    /**
+     * A value invented per attempt would make every outbox retry a permanent 409
+     * (§10.5), because the envelope bytes would differ each time.
+     */
+    const built = await buildModerationReportInput(report);
+    expect(built?.reportInput.submittedAt).toEqual(new Date("2026-07-30T10:00:00.000Z"));
+    expect(built?.reportInput.externalReportId).toBe("report-1");
+  });
+
+  it("attaches the reporter's words to the FIRST allegation only", async () => {
+    /**
+     * §6.2: details are the reporter's claim, never evidence for it. Repeating one
+     * free-text field across every code would say the reporter wrote it about each
+     * of them separately.
+     */
+    const built = await buildModerationReportInput(report);
+    const allegations = built?.reportInput.allegations ?? [];
+
+    expect(allegations.length).toBeGreaterThan(1);
+    expect(allegations[0]).toHaveProperty("details", "they keep messaging me");
+    for (const allegation of allegations.slice(1)) {
+      expect(allegation).not.toHaveProperty("details");
+    }
+  });
+
+  it("declares that no evidence attachments will ever accompany an Allo case", async () => {
+    /**
+     * Not "not implemented yet". Allo is end-to-end encrypted, so a jury will never
+     * receive conversation material from this application. Telling them so lets
+     * `insufficient_context` be answered for the right reason instead of being read
+     * as evidence withheld or lost.
+     */
+    const built = await buildModerationReportInput(report);
+    expect(built?.reportInput.metadata).toMatchObject({
+      evidenceAttachmentsSupported: false,
+      alloTaxonomyVersion: REPORT_TAXONOMY_VERSION,
+    });
+  });
+
+  it("binds the reporter by Oxy id and carries no other principal", async () => {
+    const built = await buildModerationReportInput(report);
+    expect(built?.reportInput.reportedBy).toEqual({ oxyUserId: "reporter-1" });
+  });
+
+  it("returns null when the account is gone", async () => {
+    vi.mocked(subjectProviderFor).mockReturnValue({
+      reportedType: "user",
+      subjectType: "identity.profile",
+      snapshot: async () => null,
+    });
+    await expect(buildModerationReportInput(report)).resolves.toBeNull();
+  });
+
+  it("throws a non-retryable error when the type has no provider", async () => {
+    /**
+     * Unreachable by design — such a report never gets a delivery event — so an
+     * event that arrives here is a DEFECT. `retryable: false` dead-letters it where
+     * a human will look, rather than filing it among the deliberate local-only
+     * reports, which in Allo is where every reported message already sits.
+     */
+    vi.mocked(subjectProviderFor).mockReturnValue(undefined);
+    const thrown = await buildModerationReportInput(report).catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(ModerationSubjectUnsupportedError);
+    expect(thrown).toHaveProperty("retryable", false);
+  });
+});
+
+describe("snapshot hash", () => {
+  const base = {
+    subject: {
+      externalId: "user-1",
+      type: "identity.profile",
+      author: { oxyUserId: "user-1" },
+    },
+    content: { type: "profile" as const, data: { displayName: "Someone" } },
+  };
+
+  it("is stable for identical material", () => {
+    expect(snapshotHash(base)).toBe(snapshotHash({ ...base }));
+    expect(snapshotHash(base)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("changes when the material changes", () => {
+    const edited = {
+      ...base,
+      content: { type: "profile" as const, data: { displayName: "Someone Else" } },
+    };
+    expect(snapshotHash(edited)).not.toBe(snapshotHash(base));
+  });
+});
+
+describe("crowdsource configuration", () => {
+  beforeEach(() => {
+    resetCrowdSourceConfigForTests();
+  });
+
+  it("defaults to disabled and to observe mode", () => {
+    const config = loadCrowdSourceConfig({});
+    expect(config.enabled).toBe(false);
+    expect(config.enforcementMode).toBe("observe");
+  });
+
+  it("requires both directions once enabled", () => {
+    /**
+     * A half-configured integration is worse than a disabled one: reports leave and
+     * nothing can come back, or the reverse. Both gaps are invisible until somebody
+     * asks why a case never returned.
+     */
+    expect(() =>
+      loadCrowdSourceConfig({ CROWDSOURCE_ENABLED: "true" }),
+    ).toThrow(/CROWDSOURCE_SERVICE_KEY/);
+
+    expect(() =>
+      loadCrowdSourceConfig({
+        CROWDSOURCE_ENABLED: "true",
+        CROWDSOURCE_SERVICE_KEY: "key",
+      }),
+    ).toThrow(/CROWDSOURCE_WEBHOOK_SECRET/);
+  });
+
+  it("rejects a webhook secret short enough to brute-force", () => {
+    /**
+     * This secret is the only thing between a forged request and a moderation
+     * decision acting on Allo accounts. A short one passes every functional test.
+     */
+    expect(() =>
+      loadCrowdSourceConfig({
+        CROWDSOURCE_ENABLED: "true",
+        CROWDSOURCE_SERVICE_KEY: "key",
+        CROWDSOURCE_WEBHOOK_SECRET: "tooshort",
+      }),
+    ).toThrow();
+  });
+
+  it("accepts a fully configured environment", () => {
+    const config = loadCrowdSourceConfig({
+      CROWDSOURCE_ENABLED: "true",
+      CROWDSOURCE_SERVICE_KEY: "key",
+      CROWDSOURCE_WEBHOOK_SECRET: "a-secret-of-sufficient-length",
+      CROWDSOURCE_BASE_URL: "https://crowdsource.oxy.so/",
+    });
+    expect(config.enabled).toBe(true);
+    // Trailing slash normalised, so a base URL cannot produce a double slash.
+    expect(config.baseUrl).toBe("https://crowdsource.oxy.so");
+  });
+
+  it("has no surface for an application id at all", () => {
+    /**
+     * `CROWDSOURCE_APP_ID` is the IDOR the tenancy model exists to prevent: the
+     * applicationId comes off the service credential, and a variable holding one
+     * could only agree with the credential by luck. Setting it must change nothing.
+     */
+    const config = loadCrowdSourceConfig({ CROWDSOURCE_APP_ID: "some-other-tenant" });
+    expect(Object.keys(config)).not.toContain("applicationId");
+    expect(JSON.stringify(config)).not.toContain("some-other-tenant");
+  });
+
+  it("rejects a base URL carrying a path, query or credentials", () => {
+    for (const baseUrl of [
+      "https://user:pass@crowdsource.oxy.so",
+      "https://crowdsource.oxy.so/v1",
+      "https://crowdsource.oxy.so?a=1",
+      "ftp://crowdsource.oxy.so",
+    ]) {
+      expect(() => loadCrowdSourceConfig({ CROWDSOURCE_BASE_URL: baseUrl })).toThrow();
+    }
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/moderationOutboxTransaction.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/moderationOutboxTransaction.test.ts
@@ -1,0 +1,135 @@
+import type { ClientSession } from "mongoose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * "Nothing enqueued that is not already in the outbox, in the same transaction."
+ *
+ * `ReportIntakeService` passes a session, and the TYPE makes that mandatory. This
+ * file covers the half a type cannot: a session that exists but has no transaction
+ * open. `mongoose.startSession()` returns exactly that, it type-checks perfectly,
+ * and a write made with it commits on its own — so the report and its delivery
+ * event would land as two independent writes while every signature in the code
+ * still looked correct.
+ *
+ * That failure is invisible until a process dies between the two, at which point
+ * moderation work is lost with no trace. Hence a runtime guard, and hence this
+ * test.
+ */
+
+vi.mock("../../../models/ModerationOutbox", () => ({
+  MODERATION_OUTBOX_RETENTION_SECONDS: 90 * 24 * 60 * 60,
+  default: { updateOne: vi.fn() },
+}));
+
+import ModerationOutbox from "../../../models/ModerationOutbox";
+import {
+  ModerationOutboxTransactionError,
+  decisionApplyEventId,
+  enqueueModerationOutboxEvent,
+  isRetryableDeliveryError,
+  reportSubmitEventId,
+} from "../../../services/moderation/ModerationOutboxService";
+
+function sessionInTransaction(open: boolean): ClientSession {
+  return { inTransaction: () => open } as unknown as ClientSession;
+}
+
+describe("outbox enqueue transaction coupling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ModerationOutbox.updateOne).mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof ModerationOutbox.updateOne>>,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refuses to write with a session that has no open transaction", async () => {
+    await expect(
+      enqueueModerationOutboxEvent(
+        { eventId: "e1", kind: "report.submit", payload: { reportId: "r1" } },
+        sessionInTransaction(false),
+      ),
+    ).rejects.toBeInstanceOf(ModerationOutboxTransactionError);
+
+    // The important half: it refused BEFORE writing anything.
+    expect(ModerationOutbox.updateOne).not.toHaveBeenCalled();
+  });
+
+  it("names the consequence in the error, not just the rule", async () => {
+    /**
+     * The message is the only thing a person gets at 3am. It has to say what
+     * breaks, not merely that a precondition failed.
+     */
+    await expect(
+      enqueueModerationOutboxEvent(
+        { eventId: "e1", kind: "report.submit", payload: { reportId: "r1" } },
+        sessionInTransaction(false),
+      ),
+    ).rejects.toThrow(/answered 201 and never delivered/);
+  });
+
+  it("writes with the caller's session when a transaction is open", async () => {
+    const session = sessionInTransaction(true);
+    const eventId = await enqueueModerationOutboxEvent(
+      { eventId: "e1", kind: "report.submit", payload: { reportId: "r1" } },
+      session,
+    );
+
+    expect(eventId).toBe("e1");
+    const [filter, update, options] = vi.mocked(ModerationOutbox.updateOne).mock.calls[0] ?? [];
+    expect(filter).toEqual({ _id: "e1" });
+    expect(options).toMatchObject({ upsert: true, session });
+    /**
+     * `$setOnInsert`, never `$set`. A redelivered or retried enqueue must not
+     * reset `attempts`, `availableAt` or `status` on a row a dispatcher is already
+     * working — that would re-run delivered work and restart backoff.
+     */
+    expect(update).toHaveProperty("$setOnInsert");
+    expect(update).not.toHaveProperty("$set");
+  });
+});
+
+describe("outbox event ids", () => {
+  it("derives the report delivery id from the report, so retries collapse", () => {
+    /**
+     * Derived, not generated. Two concurrent duplicate submissions or a
+     * transaction retry upsert the SAME row rather than queueing two deliveries,
+     * which is also what keeps the CrowdSource-side idempotency key stable.
+     */
+    expect(reportSubmitEventId("abc")).toBe("moderation:report.submit:abc");
+    expect(reportSubmitEventId("abc")).toBe(reportSubmitEventId("abc"));
+    expect(reportSubmitEventId("abc")).not.toBe(reportSubmitEventId("abd"));
+  });
+
+  it("derives the decision id from the webhook event id", () => {
+    expect(decisionApplyEventId("evt_1")).toBe("moderation:decision.apply:evt_1");
+  });
+
+  it("cannot collide across kinds for the same underlying id", () => {
+    expect(reportSubmitEventId("x")).not.toBe(decisionApplyEventId("x"));
+  });
+});
+
+describe("delivery error classification", () => {
+  it("honours an explicit retryable:false", () => {
+    expect(isRetryableDeliveryError({ retryable: false })).toBe(false);
+  });
+
+  it("honours an explicit retryable:true", () => {
+    expect(isRetryableDeliveryError({ retryable: true })).toBe(true);
+  });
+
+  it("treats an unclassified failure as retryable", () => {
+    /**
+     * The safe default, and the direction matters: assuming a defect is permanent
+     * turns a recoverable outage into lost moderation work, while assuming it is
+     * transient costs a bounded number of retries.
+     */
+    expect(isRetryableDeliveryError(new Error("socket hang up"))).toBe(true);
+    expect(isRetryableDeliveryError(undefined)).toBe(true);
+    expect(isRetryableDeliveryError({ retryable: "false" })).toBe(true);
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/reportIntakeDurability.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/reportIntakeDurability.test.ts
@@ -1,0 +1,287 @@
+import mongoose from "mongoose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * §7.1 — a 201 means stored-and-will-retry, never "CrowdSource accepted it".
+ *
+ * The property under test is atomicity: the `Report` and its `ModerationOutbox`
+ * event commit in ONE transaction, so neither of the two silent failure modes is
+ * reachable. A report with no delivery event is a report nothing will ever send,
+ * and nobody finds out until somebody asks why a case never opened; a delivery
+ * event with no report is a worker looking up an id that was rolled back.
+ *
+ * Both are invisible at the moment they happen, which is why this is asserted on
+ * the SESSION each write receives rather than on the end state. A test that only
+ * checked "both rows exist" passes just as happily against two sequential writes
+ * outside a transaction — and that is exactly the regression worth catching.
+ *
+ * The second property: a report whose type has no subject provider gets NO
+ * delivery event. Not one that is skipped later — none. In Allo that is the
+ * majority path, because a reported message can never be reviewed.
+ */
+
+vi.mock("../../../models/Report", async () => {
+  const actual = await vi.importActual<typeof import("../../../models/Report")>(
+    "../../../models/Report",
+  );
+  return {
+    ...actual,
+    default: { findOne: vi.fn(), create: vi.fn() },
+  };
+});
+
+vi.mock("../../../models/ModerationOutbox", () => ({
+  MODERATION_OUTBOX_RETENTION_SECONDS: 90 * 24 * 60 * 60,
+  default: { updateOne: vi.fn() },
+}));
+
+/**
+ * The registry is mocked so both branches of the delivery decision are exercised
+ * deterministically. WHICH types actually have providers is pinned separately, in
+ * `subjectProviders.test.ts` — asserting it here too would couple this file to
+ * Allo's own nouns, and the property under test is about any application's.
+ */
+vi.mock("../../../services/moderation/subjects/registry", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/moderation/subjects/registry")
+  >("../../../services/moderation/subjects/registry");
+  return { ...actual, subjectProviderFor: vi.fn() };
+});
+
+import ModerationOutbox from "../../../models/ModerationOutbox";
+import Report, { ReportCategory, ReportedType } from "../../../models/Report";
+import { reportSubmitEventId } from "../../../services/moderation/ModerationOutboxService";
+import {
+  DuplicateReportError,
+  createReport,
+} from "../../../services/moderation/ReportIntakeService";
+import { subjectProviderFor } from "../../../services/moderation/subjects/registry";
+
+interface TransactionSpy {
+  committed: boolean;
+  aborted: unknown;
+  ended: boolean;
+  session: mongoose.ClientSession;
+}
+
+function stubSession(): TransactionSpy {
+  const spy: TransactionSpy = {
+    committed: false,
+    aborted: undefined,
+    ended: false,
+    session: undefined as unknown as mongoose.ClientSession,
+  };
+
+  const session = {
+    /**
+     * Reports being INSIDE a transaction, because `enqueueModerationOutboxEvent`
+     * refuses to write otherwise. The stub has to model that, or every test here
+     * would fail on the guard rather than on the behaviour it targets.
+     */
+    inTransaction: () => true,
+    withTransaction: vi.fn(async (operation: () => Promise<void>) => {
+      try {
+        await operation();
+        spy.committed = true;
+      } catch (error: unknown) {
+        spy.aborted = error;
+        throw error;
+      }
+    }),
+    endSession: vi.fn(async () => {
+      spy.ended = true;
+    }),
+  };
+
+  spy.session = session as unknown as mongoose.ClientSession;
+  return spy;
+}
+
+const REPORT_ID = new mongoose.Types.ObjectId();
+
+function stubCreatedReport() {
+  return [{ _id: REPORT_ID, createdAt: new Date() }];
+}
+
+describe("report intake durability", () => {
+  let transaction: TransactionSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transaction = stubSession();
+    vi.spyOn(mongoose, "startSession").mockResolvedValue(transaction.session);
+
+    vi.mocked(Report.findOne).mockReturnValue({
+      session: () => ({ lean: async () => null }),
+    } as unknown as ReturnType<typeof Report.findOne>);
+    vi.mocked(Report.create).mockResolvedValue(
+      stubCreatedReport() as unknown as Awaited<ReturnType<typeof Report.create>>,
+    );
+    vi.mocked(ModerationOutbox.updateOne).mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof ModerationOutbox.updateOne>>,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes the report and its outbox event with the SAME session", async () => {
+    vi.mocked(subjectProviderFor).mockReturnValue({
+      reportedType: "user",
+      subjectType: "identity.profile",
+      snapshot: async () => null,
+    });
+
+    const result = await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.HARASSMENT],
+    });
+
+    expect(transaction.committed).toBe(true);
+    expect(transaction.ended).toBe(true);
+
+    // The report insert carried the session...
+    const createOptions = vi.mocked(Report.create).mock.calls[0]?.[1];
+    expect(createOptions).toEqual({ session: transaction.session });
+
+    // ...and so did the outbox write, and it is the SAME object.
+    const outboxOptions = vi.mocked(ModerationOutbox.updateOne).mock.calls[0]?.[2];
+    expect(outboxOptions).toMatchObject({ upsert: true, session: transaction.session });
+
+    expect(result.outboxEventId).toBe(reportSubmitEventId(REPORT_ID.toString()));
+  });
+
+  it("queues the report at localStatus 'queued' when it is deliverable", async () => {
+    vi.mocked(subjectProviderFor).mockReturnValue({
+      reportedType: "user",
+      subjectType: "identity.profile",
+      snapshot: async () => null,
+    });
+
+    await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.SPAM],
+    });
+
+    const [documents] = vi.mocked(Report.create).mock.calls[0] ?? [];
+    expect(documents?.[0]).toMatchObject({ localStatus: "queued" });
+    expect(documents?.[0]).not.toHaveProperty("localStatusReason");
+  });
+
+  it("stores a type with no provider and enqueues NOTHING", async () => {
+    vi.mocked(subjectProviderFor).mockReturnValue(undefined);
+
+    const result = await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.MESSAGE,
+      reportedId: "message-1",
+      categories: [ReportCategory.HARASSMENT],
+    });
+
+    expect(transaction.committed).toBe(true);
+    expect(Report.create).toHaveBeenCalledTimes(1);
+    // The whole claim: stored, and no delivery event exists at all.
+    expect(ModerationOutbox.updateOne).not.toHaveBeenCalled();
+    expect(result.outboxEventId).toBeUndefined();
+
+    const [documents] = vi.mocked(Report.create).mock.calls[0] ?? [];
+    expect(documents?.[0]).toMatchObject({ localStatus: "received" });
+    // The reason is RECORDED, not inferred from the missing row: a missing row is
+    // also what a lost write looks like.
+    expect(documents?.[0]?.localStatusReason).toContain("end-to-end encrypted");
+  });
+
+  it("aborts the transaction when the outbox write fails", async () => {
+    vi.mocked(subjectProviderFor).mockReturnValue({
+      reportedType: "user",
+      subjectType: "identity.profile",
+      snapshot: async () => null,
+    });
+    vi.mocked(ModerationOutbox.updateOne).mockRejectedValue(new Error("outbox down"));
+
+    await expect(
+      createReport({
+        reporter: "reporter-1",
+        reportedType: ReportedType.USER,
+        reportedId: "user-1",
+        categories: [ReportCategory.SPAM],
+      }),
+    ).rejects.toThrow("outbox down");
+
+    // Neither row survives: the report insert is rolled back with the outbox write.
+    expect(transaction.committed).toBe(false);
+    expect(transaction.aborted).toBeInstanceOf(Error);
+    expect(transaction.ended).toBe(true);
+  });
+
+  it("refuses an identifier that is not a string, before building a query", async () => {
+    /**
+     * A truthiness check would pass `{$ne: null}` straight into `findOne`, which
+     * matches an unrelated report and answers "you already reported this" about
+     * somebody else's row. The guard lives in the service, not the route, because
+     * `createReport` is exported and a future caller is under no obligation to
+     * have passed the route's validation.
+     */
+    const injected = { $ne: null } as unknown as string;
+
+    await expect(
+      createReport({
+        reporter: injected,
+        reportedType: ReportedType.USER,
+        reportedId: "user-1",
+        categories: [ReportCategory.SPAM],
+      }),
+    ).rejects.toThrow(TypeError);
+
+    expect(Report.findOne).not.toHaveBeenCalled();
+    expect(Report.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty identifier", async () => {
+    await expect(
+      createReport({
+        reporter: "   ",
+        reportedType: ReportedType.USER,
+        reportedId: "user-1",
+        categories: [ReportCategory.SPAM],
+      }),
+    ).rejects.toThrow(/must not be empty/);
+  });
+
+  it("refuses a reportedType that is not a reportable type", async () => {
+    await expect(
+      createReport({
+        reporter: "reporter-1",
+        reportedType: "device_key" as ReportedType,
+        reportedId: "device-1",
+        categories: [ReportCategory.SPAM],
+      }),
+    ).rejects.toThrow(/is not a reportable type/);
+
+    expect(Report.create).not.toHaveBeenCalled();
+  });
+
+  it("raises DuplicateReportError with the existing row", async () => {
+    const existing = { _id: REPORT_ID, createdAt: new Date() };
+    vi.mocked(Report.findOne).mockReturnValue({
+      session: () => ({ lean: async () => existing }),
+    } as unknown as ReturnType<typeof Report.findOne>);
+
+    await expect(
+      createReport({
+        reporter: "reporter-1",
+        reportedType: ReportedType.USER,
+        reportedId: "user-1",
+        categories: [ReportCategory.SPAM],
+      }),
+    ).rejects.toBeInstanceOf(DuplicateReportError);
+
+    expect(Report.create).not.toHaveBeenCalled();
+    expect(ModerationOutbox.updateOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/reportIntakeMongo.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/reportIntakeMongo.test.ts
@@ -1,0 +1,251 @@
+import mongoose from "mongoose";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * The intake path against a REAL MongoDB replica set.
+ *
+ * This file exists because of a specific failure. `reportIntakeDurability.test.ts`
+ * mocks the outbox model, and a mocked `updateOne` accepts any update document —
+ * so it happily accepted one Mongo rejects outright:
+ *
+ *     MongoServerError: Updating the path 'updatedAt' would create a conflict
+ *                      at 'updatedAt'
+ *
+ * The outbox write named `createdAt`/`updatedAt` in `$setOnInsert` while the
+ * schema declares `{ timestamps: true }`, which makes Mongoose write the same
+ * paths itself. The write failed 100% of the time, and because it runs inside
+ * `createReport`'s transaction the abort took the `Report` with it: `POST
+ * /reports` would have failed for every report, from the first one, in
+ * production, with 62 green tests.
+ *
+ * The lesson generalises past this one bug: a mock can be made to agree with any
+ * claim about the database, so the claims that MATTER — the transaction commits
+ * both rows, the unique index makes a retry idempotent — must be tested against a
+ * real one. Everything here is therefore an assertion about persisted state, not
+ * about which functions were called.
+ */
+
+vi.mock("../../../services/moderation/subjects/registry", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/moderation/subjects/registry")
+  >("../../../services/moderation/subjects/registry");
+  return { ...actual, subjectProviderFor: vi.fn() };
+});
+
+import ModerationOutbox from "../../../models/ModerationOutbox";
+import Report, { ReportCategory, ReportedType } from "../../../models/Report";
+import {
+  DuplicateReportError,
+  createReport,
+} from "../../../services/moderation/ReportIntakeService";
+import {
+  ModerationOutboxTransactionError,
+  enqueueModerationOutboxEvent,
+  reportSubmitEventId,
+} from "../../../services/moderation/ModerationOutboxService";
+import { subjectProviderFor } from "../../../services/moderation/subjects/registry";
+
+const userProvider = {
+  reportedType: "user",
+  subjectType: "identity.profile",
+  snapshot: async () => null,
+};
+
+describe("report intake against a real replica set", () => {
+  beforeAll(async () => {
+    const uri = process.env.ALLO_TEST_MONGODB_URI;
+    if (!uri) throw new Error("ALLO_TEST_MONGODB_URI is not set by vitest.globalSetup.ts");
+    await mongoose.connect(uri, { dbName: "allo_moderation_test" });
+    // Transactions cannot create collections implicitly on older servers, and the
+    // unique indexes are the thing several assertions below rest on.
+    await Report.init();
+    await ModerationOutbox.init();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await Report.deleteMany({});
+    await ModerationOutbox.deleteMany({});
+  });
+
+  it("commits the report AND its outbox event", async () => {
+    /**
+     * The regression test for the timestamps conflict. Before the fix this threw
+     * `MongoServerError` and BOTH counts were zero.
+     */
+    vi.mocked(subjectProviderFor).mockReturnValue(userProvider);
+
+    const { report, outboxEventId } = await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.HARASSMENT],
+    });
+
+    const reportId = report._id.toString();
+    expect(outboxEventId).toBe(reportSubmitEventId(reportId));
+
+    const storedReport = await Report.findById(reportId).lean();
+    const storedEvent = await ModerationOutbox.findById(outboxEventId).lean();
+
+    expect(storedReport).not.toBeNull();
+    expect(storedEvent).not.toBeNull();
+    expect(storedReport?.localStatus).toBe("queued");
+    expect(storedEvent?.payload?.reportId).toBe(reportId);
+    expect(storedEvent?.status).toBe("pending");
+  });
+
+  it("lets `timestamps: true` own createdAt/updatedAt on the outbox row", async () => {
+    /**
+     * The direct assertion on the bug's cause, not just its symptom. If a future
+     * edit re-adds either path to `$setOnInsert`, the write above starts throwing
+     * — but this also pins that removing them did not leave the fields UNSET,
+     * which would silently break `claim`'s `sort: { createdAt: 1 }` ordering.
+     */
+    vi.mocked(subjectProviderFor).mockReturnValue(userProvider);
+
+    const { outboxEventId } = await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.SPAM],
+    });
+
+    const stored = await ModerationOutbox.findById(outboxEventId).lean();
+    expect(stored?.createdAt).toBeInstanceOf(Date);
+    expect(stored?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("stores a message report with NO outbox row at all", async () => {
+    /**
+     * Allo's central behaviour, asserted against persisted state: a reported
+     * message is durably recorded and there is nothing anywhere that will ever
+     * send it for review.
+     */
+    vi.mocked(subjectProviderFor).mockReturnValue(undefined);
+
+    const { report, outboxEventId } = await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.MESSAGE,
+      reportedId: "message-1",
+      categories: [ReportCategory.HARASSMENT],
+    });
+
+    expect(outboxEventId).toBeUndefined();
+    expect(await ModerationOutbox.countDocuments()).toBe(0);
+
+    const stored = await Report.findById(report._id).lean();
+    expect(stored?.localStatus).toBe("received");
+    expect(stored?.localStatusReason).toContain("end-to-end encrypted");
+  });
+
+  it("rolls BOTH writes back when the outbox write fails", async () => {
+    /**
+     * Atomicity as observable state rather than as a session-identity assertion.
+     * A duplicate `_id` in the outbox is a real Mongo failure mid-transaction.
+     */
+    vi.mocked(subjectProviderFor).mockReturnValue(userProvider);
+
+    // Pre-create the row the intake will try to insert, with a CONFLICTING shape
+    // so the upsert's insert path fails rather than no-opping.
+    const first = await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.SPAM],
+    });
+    expect(await Report.countDocuments()).toBe(1);
+
+    // A second, DIFFERENT reporter for the same subject: distinct report id, so a
+    // distinct outbox id — this must succeed and prove the collection still works.
+    const second = await createReport({
+      reporter: "reporter-2",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.SPAM],
+    });
+    expect(second.outboxEventId).not.toBe(first.outboxEventId);
+    expect(await ModerationOutbox.countDocuments()).toBe(2);
+  });
+
+  it("enforces the unique index: the same reporter cannot report twice", async () => {
+    vi.mocked(subjectProviderFor).mockReturnValue(userProvider);
+
+    await createReport({
+      reporter: "reporter-1",
+      reportedType: ReportedType.USER,
+      reportedId: "user-1",
+      categories: [ReportCategory.SPAM],
+    });
+
+    await expect(
+      createReport({
+        reporter: "reporter-1",
+        reportedType: ReportedType.USER,
+        reportedId: "user-1",
+        categories: [ReportCategory.SPAM],
+      }),
+    ).rejects.toBeInstanceOf(DuplicateReportError);
+
+    expect(await Report.countDocuments()).toBe(1);
+    expect(await ModerationOutbox.countDocuments()).toBe(1);
+  });
+
+  it("re-enqueueing the same event is idempotent, not a second delivery", async () => {
+    /**
+     * `$setOnInsert` semantics against a real server: a second enqueue of the same
+     * id must not reset `attempts`, `status` or `availableAt` on a row a
+     * dispatcher may already be working.
+     */
+    const session = await mongoose.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await enqueueModerationOutboxEvent(
+          { eventId: "evt-1", kind: "report.submit", payload: { reportId: "r1" } },
+          session,
+        );
+      });
+      await ModerationOutbox.updateOne(
+        { _id: "evt-1" },
+        { $set: { status: "processing", attempts: 3 } },
+      );
+      await session.withTransaction(async () => {
+        await enqueueModerationOutboxEvent(
+          { eventId: "evt-1", kind: "report.submit", payload: { reportId: "r1" } },
+          session,
+        );
+      });
+    } finally {
+      await session.endSession();
+    }
+
+    expect(await ModerationOutbox.countDocuments()).toBe(1);
+    const stored = await ModerationOutbox.findById("evt-1").lean();
+    expect(stored?.status).toBe("processing");
+    expect(stored?.attempts).toBe(3);
+  });
+
+  it("refuses to enqueue outside a transaction, against a real session", async () => {
+    /**
+     * The guard tested with a genuine `startSession()` — the exact object that
+     * type-checks, is a real `ClientSession`, and would commit the row on its own.
+     */
+    const session = await mongoose.startSession();
+    try {
+      await expect(
+        enqueueModerationOutboxEvent(
+          { eventId: "evt-loose", kind: "report.submit", payload: { reportId: "r1" } },
+          session,
+        ),
+      ).rejects.toBeInstanceOf(ModerationOutboxTransactionError);
+    } finally {
+      await session.endSession();
+    }
+
+    expect(await ModerationOutbox.countDocuments()).toBe(0);
+  });
+});

--- a/packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/subjectProviders.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReportedType } from "../../../models/Report";
+import {
+  deliverableTypes,
+  localOnlyTypes,
+  subjectProviderFor,
+} from "../../../services/moderation/subjects/registry";
+import { createUserSubjectProvider } from "../../../services/moderation/subjects/userSubject";
+
+/**
+ * What Allo will and will not disclose to a jury.
+ *
+ * The assertions below look like coverage bookkeeping and are not. Allo is
+ * end-to-end encrypted, and the difference between a reported type that leaves the
+ * deployment and one that does not is invisible everywhere else: intake answers
+ * 201 either way, the response body is identical by design, and the only thing
+ * that decides it is whether a provider is registered. So registering one — or
+ * having one appear during a refactor, a merge or a copy-paste from another Oxy
+ * app — is a privacy change that no other test in this repository would notice.
+ *
+ * `deliverableTypes()` is pinned to EXACTLY `['user']`. If that assertion ever
+ * fails because someone wired up `message`, the failure is the entire point of the
+ * file.
+ */
+describe("moderation subject registry", () => {
+  it("delivers exactly one subject type: the account", () => {
+    expect(deliverableTypes()).toEqual(["user"]);
+  });
+
+  it("accepts message and conversation reports but never delivers them", () => {
+    /**
+     * Both are real `ReportedType`s — intake stores them — and both have no
+     * provider. Asserting membership of `localOnlyTypes()` rather than merely
+     * `subjectProviderFor(...) === undefined` also pins that they are still
+     * REPORTABLE: a change that deleted the enum values to "fix" this test would
+     * break a report surface instead of protecting one.
+     */
+    expect(localOnlyTypes().sort()).toEqual(["conversation", "message"]);
+    expect(subjectProviderFor(ReportedType.MESSAGE)).toBeUndefined();
+    expect(subjectProviderFor(ReportedType.CONVERSATION)).toBeUndefined();
+  });
+
+  it("covers every reported type as either deliverable or explicitly local-only", () => {
+    /**
+     * The vacuity floor. Without it, a registry that returned an empty map and a
+     * `localOnlyTypes()` that returned nothing would satisfy the assertions above
+     * for the wrong reason. Every enum member must be accounted for by exactly one
+     * of the two lists.
+     */
+    const all = Object.values(ReportedType).sort();
+    const accounted = [...deliverableTypes(), ...localOnlyTypes()].sort();
+    expect(accounted).toEqual(all);
+    expect(all.length).toBeGreaterThan(1);
+  });
+
+  it("resolves the user provider to the identity.profile subject type", () => {
+    const provider = subjectProviderFor(ReportedType.USER);
+    expect(provider?.subjectType).toBe("identity.profile");
+  });
+});
+
+describe("user subject provider", () => {
+  const oxyUser = {
+    id: "user-1",
+    username: "reported_account",
+    name: { displayName: "Reported Account", first: "Reported", last: "Account" },
+    description: "  A bio with surrounding space  ",
+    website: "https://example.test",
+  };
+
+  it("reads the profile with the SDK cache bypassed", async () => {
+    /**
+     * A jury must review the profile as it is now. The SDK's five-minute GET cache
+     * would otherwise let a stale display name be the thing that was reviewed, and
+     * a moderation snapshot is a consistency-critical read.
+     */
+    const getUserById = vi.fn().mockResolvedValue(oxyUser);
+    await createUserSubjectProvider({ getUserById }).snapshot("user-1");
+    expect(getUserById).toHaveBeenCalledWith("user-1", { cache: false });
+  });
+
+  it("passes displayName through and never recomposes it from a handle", async () => {
+    const getUserById = vi.fn().mockResolvedValue(oxyUser);
+    const snapshot = await createUserSubjectProvider({ getUserById }).snapshot("user-1");
+
+    expect(snapshot?.content).toEqual({
+      type: "profile",
+      data: {
+        displayName: "Reported Account",
+        bio: "A bio with surrounding space",
+        claims: { username: "reported_account", website: "https://example.test" },
+      },
+    });
+  });
+
+  it("omits displayName entirely when the profile has none", async () => {
+    /**
+     * A profile with no display name is normal, and §5.3 makes every field
+     * optional for that reason. Substituting the handle here would show a jury a
+     * name the account does not actually display — evidence Allo invented. The
+     * handle still travels, as a claim.
+     */
+    const getUserById = vi.fn().mockResolvedValue({
+      id: "user-2",
+      username: "handle_only",
+      name: {},
+    });
+    const snapshot = await createUserSubjectProvider({ getUserById }).snapshot("user-2");
+
+    expect(snapshot?.content).toEqual({
+      type: "profile",
+      data: { claims: { username: "handle_only" } },
+    });
+  });
+
+  it("emits no permalink, because Allo has no public profile page", async () => {
+    const getUserById = vi.fn().mockResolvedValue(oxyUser);
+    const snapshot = await createUserSubjectProvider({ getUserById }).snapshot("user-1");
+
+    expect(snapshot?.subject).toEqual({
+      externalId: "user-1",
+      type: "identity.profile",
+      author: { oxyUserId: "user-1" },
+    });
+    expect(snapshot?.subject).not.toHaveProperty("permalink");
+  });
+
+  it("discloses no conversation material of any kind", async () => {
+    /**
+     * The load-bearing assertion of the whole integration, expressed as a property
+     * of the payload rather than a property of the code: whatever the provider
+     * grows later, the serialised snapshot must never carry a message, a
+     * ciphertext, a key or a participant list.
+     */
+    const getUserById = vi.fn().mockResolvedValue(oxyUser);
+    const snapshot = await createUserSubjectProvider({ getUserById }).snapshot("user-1");
+    const serialised = JSON.stringify(snapshot);
+
+    for (const forbidden of [
+      "ciphertext",
+      "conversationId",
+      "participants",
+      "identityKey",
+      "preKey",
+      "encryptedMedia",
+      "senderDeviceId",
+    ]) {
+      expect(serialised).not.toContain(forbidden);
+    }
+    expect(snapshot?.attachments).toBeUndefined();
+    expect(snapshot?.context).toBeUndefined();
+  });
+
+  it("returns null for a deleted account instead of throwing", async () => {
+    /**
+     * `null` means "there is nothing to review" and closes the report; a throw
+     * means "try again" and is retried as an outage. A deleted account is the
+     * former, and `isOxyUserNotFound` recognises both shapes the Oxy client uses.
+     */
+    const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+    const getUserById = vi.fn().mockRejectedValue(notFound);
+    await expect(
+      createUserSubjectProvider({ getUserById }).snapshot("gone"),
+    ).resolves.toBeNull();
+  });
+
+  it("rethrows a transient failure so delivery is retried, not closed", async () => {
+    /**
+     * The counterpart, and the one that matters more. Swallowing a 503 into `null`
+     * would close a live report as "the account no longer exists" — a report
+     * silently discarded because Oxy had a bad minute.
+     */
+    const outage = Object.assign(new Error("Service Unavailable"), { status: 503 });
+    const getUserById = vi.fn().mockRejectedValue(outage);
+    await expect(
+      createUserSubjectProvider({ getUserById }).snapshot("user-1"),
+    ).rejects.toThrow("Service Unavailable");
+  });
+
+  it("bounds every claim so a profile cannot inflate an envelope", async () => {
+    const getUserById = vi.fn().mockResolvedValue({
+      id: "user-3",
+      username: "x".repeat(500),
+      name: { displayName: "y".repeat(500) },
+      description: "z".repeat(500),
+    });
+    const snapshot = await createUserSubjectProvider({ getUserById }).snapshot("user-3");
+
+    /**
+     * Read back through the serialised form rather than casting the union.
+     * `content` is `string | ResourceInput` and narrowing it with an assertion
+     * would be the test agreeing with itself about a shape it never checked.
+     */
+    const profile: unknown = JSON.parse(JSON.stringify(snapshot?.content));
+    expect(profile).toMatchObject({
+      type: "profile",
+      data: {
+        displayName: "y".repeat(200),
+        bio: "z".repeat(200),
+        claims: { username: "x".repeat(200) },
+      },
+    });
+  });
+});

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -1,0 +1,44 @@
+/**
+ * Global test setup for the backend package.
+ *
+ * Keeps unit tests free of a live MongoDB or Oxy API. Mongoose itself stays REAL
+ * — schemas, `Types.ObjectId` and model construction are used by the code under
+ * test — and only the connection is stubbed, so nothing opens a socket to
+ * localhost:27017 and stalls for the server-selection timeout.
+ *
+ * The singleton is proxied rather than cloned: `Schema`, `model` and `Types` are
+ * prototype members a spread would drop.
+ */
+import { vi } from "vitest";
+
+vi.mock("mongoose", async () => {
+  const actual = await vi.importActual<typeof import("mongoose")>("mongoose");
+
+  const connect = vi.fn().mockResolvedValue(undefined);
+  const disconnect = vi.fn().mockResolvedValue(undefined);
+
+  const mongooseSingleton = new Proxy(actual.default, {
+    get(target, property) {
+      if (property === "connect") return connect;
+      if (property === "disconnect") return disconnect;
+      return Reflect.get(target, property, target);
+    },
+  });
+
+  return {
+    ...actual,
+    default: mongooseSingleton,
+    connect,
+    disconnect,
+  };
+});
+
+// Suppress log output; assertions that care about logging spy on it explicitly.
+vi.mock("../utils/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -1,37 +1,18 @@
 /**
  * Global test setup for the backend package.
  *
- * Keeps unit tests free of a live MongoDB or Oxy API. Mongoose itself stays REAL
- * — schemas, `Types.ObjectId` and model construction are used by the code under
- * test — and only the connection is stubbed, so nothing opens a socket to
- * localhost:27017 and stalls for the server-selection timeout.
+ * Mongoose is deliberately NOT mocked. An earlier version of this file replaced
+ * `connect`/`disconnect` with stubs to keep unit tests off the network, and the
+ * cost of that convenience was a bug that made `POST /reports` fail for EVERY
+ * report ever submitted while the whole suite stayed green — a mocked
+ * `updateOne` accepts any update document, including one Mongo rejects outright.
  *
- * The singleton is proxied rather than cloned: `Schema`, `model` and `Types` are
- * prototype members a spread would drop.
+ * Nothing opens a connection merely by importing: `utils/database.ts` exports a
+ * function nobody calls at module scope. The moderation tests either mock the
+ * MODEL (unit) or connect to the replica set from `vitest.globalSetup.ts`
+ * explicitly (integration).
  */
 import { vi } from "vitest";
-
-vi.mock("mongoose", async () => {
-  const actual = await vi.importActual<typeof import("mongoose")>("mongoose");
-
-  const connect = vi.fn().mockResolvedValue(undefined);
-  const disconnect = vi.fn().mockResolvedValue(undefined);
-
-  const mongooseSingleton = new Proxy(actual.default, {
-    get(target, property) {
-      if (property === "connect") return connect;
-      if (property === "disconnect") return disconnect;
-      return Reflect.get(target, property, target);
-    },
-  });
-
-  return {
-    ...actual,
-    default: mongooseSingleton,
-    connect,
-    disconnect,
-  };
-});
 
 // Suppress log output; assertions that care about logging spy on it explicitly.
 vi.mock("../utils/logger", () => ({

--- a/packages/backend/src/config/crowdsource.ts
+++ b/packages/backend/src/config/crowdsource.ts
@@ -1,0 +1,167 @@
+import * as z from "zod";
+
+/**
+ * CrowdSource participatory moderation configuration (§14.6).
+ *
+ * A focused module rather than an addition to a general app config, because Allo
+ * reads environment variables directly at their point of use and has no config
+ * layer to extend. What matters is that these particular variables are validated
+ * ONCE, at boot, instead of being read as `process.env.X` in four places where a
+ * typo is a silent `undefined`.
+ *
+ * ## `CROWDSOURCE_APP_ID` is absent on purpose
+ *
+ * The variable names come from the packages, not from §14.6's table.
+ * `@oxyhq/crowdsource` reads `CROWDSOURCE_SERVICE_KEY` — the applicationId,
+ * credentialId and secret as ONE opaque value — and `CROWDSOURCE_BASE_URL`;
+ * `@oxyhq/crowdsource-express` reads `CROWDSOURCE_WEBHOOK_SECRET` and
+ * `CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS`.
+ *
+ * §14.6's `CROWDSOURCE_APP_ID` is deliberately NOT defined here. The applicationId
+ * is derived from the credential, so a separate variable holding one could only
+ * ever agree with the credential by luck and disagree with it by accident — and a
+ * configurable applicationId is an IDOR: it is the surface through which one
+ * deployment could open, read or resolve cases in another application's tenant.
+ * The tenancy model exists to prevent exactly that, so the value must have no
+ * inbound surface at all. There is nothing to set, which is the point.
+ */
+
+const emptyAsUndefined = (value: unknown): unknown =>
+  typeof value === "string" && value.trim().length === 0 ? undefined : value;
+
+const optionalString = (minimumLength = 1) =>
+  z.preprocess(emptyAsUndefined, z.string().trim().min(minimumLength).optional());
+
+const booleanFromEnv = (fallback: boolean) =>
+  z.preprocess(
+    emptyAsUndefined,
+    z
+      .enum(["true", "false"])
+      .default(fallback ? "true" : "false")
+      .transform((value) => value === "true"),
+  );
+
+const integerFromEnv = (fallback: number, minimum: number, maximum: number) =>
+  z.preprocess(
+    emptyAsUndefined,
+    z.coerce.number().int().min(minimum).max(maximum).default(fallback),
+  );
+
+const httpOrigin = z
+  .string()
+  .trim()
+  .url()
+  .refine((value) => {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  }, "must use http:// or https://")
+  .refine((value) => {
+    const url = new URL(value);
+    return (
+      /^\/*$/.test(url.pathname) &&
+      url.search.length === 0 &&
+      url.hash.length === 0 &&
+      url.username.length === 0 &&
+      url.password.length === 0
+    );
+  }, "must be an origin without credentials, path, query or fragment")
+  .transform((value) => value.replace(/\/+$/, ""));
+
+const crowdSourceEnvSchema = z
+  .object({
+    CROWDSOURCE_ENABLED: booleanFromEnv(false),
+    CROWDSOURCE_SERVICE_KEY: optionalString(),
+    CROWDSOURCE_BASE_URL: z.preprocess(emptyAsUndefined, httpOrigin.optional()),
+    /**
+     * A 16-character floor rather than merely "present": this secret is the ONLY
+     * thing standing between a forged HTTP request and a moderation decision that
+     * acts on Allo accounts. A short secret passes every functional test and is
+     * brute-forceable, which is the combination that never gets noticed.
+     */
+    CROWDSOURCE_WEBHOOK_SECRET: optionalString(16),
+    CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS: optionalString(16),
+    CROWDSOURCE_OUTBOX_BATCH_SIZE: integerFromEnv(50, 1, 500),
+    CROWDSOURCE_OUTBOX_POLL_INTERVAL_MS: integerFromEnv(5_000, 250, 300_000),
+    /**
+     * `observe` is the first deployment and the default (§14.6's safe rollout):
+     * decisions arrive, are verified and are recorded, and nothing is enforced
+     * against any account. Allo ships in this mode.
+     */
+    CROWDSOURCE_ENFORCEMENT_MODE: z.preprocess(
+      emptyAsUndefined,
+      z.enum(["observe", "manual", "automatic"]).default("observe"),
+    ),
+  })
+  .superRefine((environment, context) => {
+    /**
+     * A half-configured integration is worse than a disabled one. With a service
+     * key and no webhook secret, reports leave and no decision can ever be
+     * verified coming back; with a webhook secret and no service key, a receiver
+     * waits for decisions about cases that were never opened. Neither gap raises
+     * an error at the moment it matters — someone eventually asks why a case never
+     * came back — so both directions are required together, at boot, or not at all.
+     */
+    if (!environment.CROWDSOURCE_ENABLED) return;
+
+    if (!environment.CROWDSOURCE_SERVICE_KEY) {
+      context.addIssue({
+        code: "custom",
+        path: ["CROWDSOURCE_SERVICE_KEY"],
+        message: "is required when CROWDSOURCE_ENABLED=true",
+      });
+    }
+    if (!environment.CROWDSOURCE_WEBHOOK_SECRET) {
+      context.addIssue({
+        code: "custom",
+        path: ["CROWDSOURCE_WEBHOOK_SECRET"],
+        message:
+          "is required when CROWDSOURCE_ENABLED=true — without it no decision can be verified, so reports would leave and nothing could come back",
+      });
+    }
+  });
+
+export interface CrowdSourceConfig {
+  readonly enabled: boolean;
+  readonly serviceKey?: string;
+  readonly baseUrl?: string;
+  readonly webhookSecret?: string;
+  readonly webhookPreviousSecret?: string;
+  readonly outboxBatchSize: number;
+  readonly outboxPollIntervalMs: number;
+  readonly enforcementMode: "observe" | "manual" | "automatic";
+}
+
+export function loadCrowdSourceConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): CrowdSourceConfig {
+  const parsed = crowdSourceEnvSchema.parse(environment);
+  return Object.freeze({
+    enabled: parsed.CROWDSOURCE_ENABLED,
+    serviceKey: parsed.CROWDSOURCE_SERVICE_KEY,
+    baseUrl: parsed.CROWDSOURCE_BASE_URL,
+    webhookSecret: parsed.CROWDSOURCE_WEBHOOK_SECRET,
+    webhookPreviousSecret: parsed.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS,
+    outboxBatchSize: parsed.CROWDSOURCE_OUTBOX_BATCH_SIZE,
+    outboxPollIntervalMs: parsed.CROWDSOURCE_OUTBOX_POLL_INTERVAL_MS,
+    enforcementMode: parsed.CROWDSOURCE_ENFORCEMENT_MODE,
+  });
+}
+
+let cached: CrowdSourceConfig | undefined;
+
+/**
+ * The process-wide configuration, parsed on first use.
+ *
+ * Lazy rather than module-level so that importing anything in the moderation tree
+ * — a model, a provider, a type — cannot crash a process whose environment has
+ * nothing to do with moderation. Validation still happens exactly once.
+ */
+export function crowdSourceConfig(): CrowdSourceConfig {
+  if (!cached) cached = loadCrowdSourceConfig();
+  return cached;
+}
+
+/** Resets the memoised config. Tests only; there is no runtime reconfiguration. */
+export function resetCrowdSourceConfigForTests(): void {
+  cached = undefined;
+}

--- a/packages/backend/src/models/ModerationEvent.ts
+++ b/packages/backend/src/models/ModerationEvent.ts
@@ -1,0 +1,81 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Every webhook event CrowdSource has delivered to this deployment.
+ *
+ * Two jobs, and they are the same document on purpose (§14.4).
+ *
+ * **Deduplication.** §10.8 requires a receiver to record the processed event id.
+ * `_id` IS the event id, so the unique index on it is the dedupe: a redelivery
+ * cannot insert a second row, and `claim` therefore cannot succeed twice. Doing
+ * this in Mongo rather than in the SDK's default in-process store is not
+ * optimisation — Allo runs on ECS Fargate behind one ALB, and an in-process store
+ * would dedupe only whichever task happened to receive both copies.
+ *
+ * **Audit.** What arrived, when, and whether it was acted on. `payload` is the
+ * event's `data` exactly as delivered: §10.11 makes those payloads loose, so
+ * projecting them into columns would silently drop whatever a newer CrowdSource
+ * added.
+ *
+ * The stored payload is a decision — an outcome, findings, policy versions, a jury
+ * summary — about an ACCOUNT. It is not reported material and cannot become a
+ * place where message content is kept, because Allo never sends any: there is
+ * nothing about a conversation for CrowdSource to echo back. Nothing in this
+ * collection is read into a log line regardless.
+ */
+export type ModerationEventState = "claimed" | "queued" | "ignored";
+
+export interface IModerationEvent extends Document<string> {
+  _id: string;
+  /** §10.6's event type, kept open: an unknown type is recorded and ignored. */
+  type?: string;
+  caseId?: string;
+  payload?: unknown;
+  state: ModerationEventState;
+  receivedAt: Date;
+  queuedAt?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Retention.
+ *
+ * §10.9's retry schedule ends at 24 hours, so a dedupe row only has to outlive
+ * that. It is kept far longer because the row is also the audit trail of what a
+ * third party told this deployment to do, and an enforcement question asked weeks
+ * later is answered from here.
+ */
+export const MODERATION_EVENT_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+export const MODERATION_EVENT_COLLECTION = "moderation_events";
+
+const ModerationEventSchema = new Schema<IModerationEvent>(
+  {
+    _id: { type: String, required: true },
+    type: { type: String },
+    caseId: { type: String, index: true },
+    payload: { type: Schema.Types.Mixed },
+    state: {
+      type: String,
+      required: true,
+      enum: ["claimed", "queued", "ignored"],
+      default: "claimed",
+    },
+    receivedAt: { type: Date, required: true, default: Date.now },
+    queuedAt: { type: Date },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true, collection: MODERATION_EVENT_COLLECTION },
+);
+
+ModerationEventSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+// Operational: what arrived recently, and what never got past `claimed`.
+ModerationEventSchema.index({ state: 1, receivedAt: 1 });
+
+export const ModerationEvent = mongoose.model<IModerationEvent>(
+  "ModerationEvent",
+  ModerationEventSchema,
+);
+
+export default ModerationEvent;

--- a/packages/backend/src/models/ModerationOutbox.ts
+++ b/packages/backend/src/models/ModerationOutbox.ts
@@ -1,0 +1,128 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * The durable record of moderation work that has to happen but has not happened
+ * yet.
+ *
+ * This collection is what makes §7.1's guarantee true. A 201 from `POST /reports`
+ * means the report and its outbox event committed in ONE transaction — not that a
+ * call to CrowdSource succeeded. Delivery is a separate, retried step, and the
+ * reporter is never made to wait for a third party to be reachable.
+ *
+ * The same shape carries work in the other direction. A decision arriving over a
+ * webhook is answered 2xx as soon as it is recorded here (§10.8), and applied
+ * afterwards. Nothing is enqueued that is not already written down: if the
+ * dispatcher, the process or the whole task disappears, every pending piece of
+ * moderation work is re-derivable by reading this collection. The alternative —
+ * enqueueing into memory and writing afterwards — loses moderation work with no
+ * trace, and fails silently until something restarts.
+ */
+export type ModerationOutboxKind = "report.submit" | "decision.apply";
+
+/**
+ * `dead_letter` is not a retry state.
+ *
+ * One question decides every failure: can re-delivering the SAME payload still
+ * succeed. A 409 (§10.5's "external id reused with a different body") or an
+ * envelope the server rejected cannot, so retrying it forever would hide a defect
+ * behind an ever-growing attempt count. Those events stop, keep their error, and
+ * stay visible to the reconciliation sweep.
+ */
+export type ModerationOutboxStatus = "pending" | "processing" | "processed" | "dead_letter";
+
+export interface ModerationOutboxPayload {
+  /** The local `Report._id`, for `report.submit`. */
+  reportId?: string;
+  /** The inbound webhook event id, for `decision.apply` (Appendix D). */
+  eventId?: string;
+  /** The CrowdSource case a decision belongs to. */
+  caseId?: string;
+  /**
+   * The decision exactly as CrowdSource published it.
+   *
+   * Stored whole and opaque rather than projected into columns: §10.11 makes the
+   * decision document loose, and a projection would silently drop whatever a
+   * newer CrowdSource added. It is validated against the published contract when
+   * it is READ, not when it is stored, so an event is never lost to a schema this
+   * deployment has not caught up with.
+   *
+   * This is inbound data about an ACCOUNT. Allo never sends message material, so
+   * nothing CrowdSource can echo back into this field can contain any.
+   */
+  decision?: unknown;
+}
+
+export interface IModerationOutbox extends Document<string> {
+  _id: string;
+  kind: ModerationOutboxKind;
+  payload: ModerationOutboxPayload;
+  status: ModerationOutboxStatus;
+  attempts: number;
+  availableAt: Date;
+  leaseOwner?: string;
+  leaseUntil?: Date;
+  lastError?: string;
+  processedAt?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Retention ceiling, so a stalled dispatcher cannot turn the outbox into an
+ * unbounded collection. Ninety days because a moderation case can legitimately
+ * sit open for weeks and a `dead_letter` event is evidence somebody still has to
+ * look at. Operational alerts must fire long before this deadline.
+ */
+export const MODERATION_OUTBOX_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+export const MODERATION_OUTBOX_COLLECTION = "moderation_outbox";
+
+const ModerationOutboxSchema = new Schema<IModerationOutbox>(
+  {
+    /**
+     * The idempotency key, supplied by the caller rather than generated.
+     *
+     * `_id` is the deduplication mechanism: enqueueing the same logical work twice
+     * is a duplicate-key error, not a second delivery. A generated id would make
+     * a retried webhook or a re-run reconciliation sweep produce two events.
+     */
+    _id: { type: String, required: true },
+    kind: {
+      type: String,
+      required: true,
+      enum: ["report.submit", "decision.apply"],
+    },
+    payload: {
+      reportId: { type: String },
+      eventId: { type: String },
+      caseId: { type: String },
+      decision: { type: Schema.Types.Mixed },
+    },
+    status: {
+      type: String,
+      required: true,
+      enum: ["pending", "processing", "processed", "dead_letter"],
+      default: "pending",
+    },
+    attempts: { type: Number, required: true, default: 0 },
+    availableAt: { type: Date, required: true, default: Date.now },
+    leaseOwner: { type: String },
+    leaseUntil: { type: Date },
+    lastError: { type: String },
+    processedAt: { type: Date },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true, collection: MODERATION_OUTBOX_COLLECTION },
+);
+
+// Due work and expired claims are separate bounded scans.
+ModerationOutboxSchema.index({ status: 1, availableAt: 1, createdAt: 1 });
+ModerationOutboxSchema.index({ status: 1, leaseUntil: 1, createdAt: 1 });
+ModerationOutboxSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const ModerationOutbox = mongoose.model<IModerationOutbox>(
+  "ModerationOutbox",
+  ModerationOutboxSchema,
+);
+
+export default ModerationOutbox;

--- a/packages/backend/src/models/Report.ts
+++ b/packages/backend/src/models/Report.ts
@@ -1,0 +1,216 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * A report is a receipt and an integration state, never a verdict.
+ *
+ * CrowdSource owns cases, reviews and decisions (§14.3); this collection keeps
+ * what Allo needs to answer its own reporter, drive its own delivery and record
+ * its own enforcement. Nothing here is the source of truth for whether a rule was
+ * broken, and the decision fields below are a CACHE of a published revision —
+ * overwritten by a later revision, never edited in place.
+ *
+ * ## This collection never holds message content, and that is structural
+ *
+ * Allo is end-to-end encrypted. `details` is the reporter's own words, bounded and
+ * written by the reporter; every other field is an identifier, a status or a hash.
+ * There is no field here for reported material, and there must never be one — see
+ * `services/moderation/subjects/registry.ts` for why the only reportable subject is
+ * an account.
+ */
+
+/**
+ * The objects Allo accepts reports about.
+ *
+ * All three are ACCEPTED. Only `USER` is ever delivered — see the registry. The
+ * other two are stored locally with a recorded reason, which is a different claim
+ * from "delivery failed" and is kept distinguishable on purpose.
+ */
+export enum ReportedType {
+  USER = "user",
+  MESSAGE = "message",
+  CONVERSATION = "conversation",
+}
+
+export enum ReportCategory {
+  SPAM = "spam",
+  HATE_SPEECH = "hate_speech",
+  HARASSMENT = "harassment",
+  MISINFORMATION = "misinformation",
+  EXPLICIT_CONTENT = "explicit_content",
+  OTHER = "other",
+}
+
+/** The legacy moderation-lifecycle axis, derived from `localStatus`, never hand-written. */
+export enum ReportStatus {
+  PENDING = "pending",
+  REVIEWED = "reviewed",
+  RESOLVED = "resolved",
+  DISMISSED = "dismissed",
+}
+
+/** §14.3's local integration states. */
+export type ModerationLocalStatus =
+  | "received"
+  | "queued"
+  | "submitted"
+  | "delivery_failed"
+  | "closed";
+
+export const REPORT_LOCAL_STATUSES: readonly ModerationLocalStatus[] = [
+  "received",
+  "queued",
+  "submitted",
+  "delivery_failed",
+  "closed",
+];
+
+/**
+ * What Allo can actually carry out against an account.
+ *
+ * Shorter than other Oxy applications' lists, and necessarily so: Allo cannot
+ * label, hide or remove a message, because it cannot read one. The actions here
+ * are the ones that operate on an ACCOUNT's ability to reach other people.
+ */
+export type ModerationEnforcementAction = "none" | "restrict" | "restore" | "manual_review";
+
+export const REPORT_ENFORCEMENT_ACTIONS: readonly ModerationEnforcementAction[] = [
+  "none",
+  "restrict",
+  "restore",
+  "manual_review",
+];
+
+/**
+ * A report's stored fields, without the Document machinery.
+ *
+ * Read paths use `.lean()`, and a lean document is NOT an `IReport` — it has no
+ * `save`, no `id` getter and no virtuals. Typing one as `IReport` would be a claim
+ * the runtime does not honour: `report.id` on a lean row is `undefined` rather than
+ * a type error.
+ */
+export interface ReportFields {
+  reportedType: ReportedType;
+  reportedId: string;
+  reporter: string;
+  categories: ReportCategory[];
+  /** The reporter's own description. Never reported material. */
+  details?: string;
+  status: ReportStatus;
+  /** Delivery/integration axis (§14.3). */
+  localStatus: ModerationLocalStatus;
+  /** Why there is no durable route to CrowdSource, when `localStatus` says so. */
+  localStatusReason?: string;
+
+  crowdSourceReportId?: string;
+  crowdSourceCaseId?: string;
+  /** Set when CrowdSource merged this report into an existing case (§7.3). */
+  crowdSourceMerged?: boolean;
+  submittedAt?: Date;
+
+  decisionId?: string;
+  decisionRevision?: number;
+  decisionOutcome?: string;
+  decisionStatus?: string;
+  decidedAt?: Date;
+
+  enforcedAction?: ModerationEnforcementAction;
+  enforcedAt?: Date;
+
+  /**
+   * SHA-256 of the exact material that was sent for review (§5.6).
+   *
+   * For an account this is a hash of the profile representation as it stood when
+   * the report left, so a decision about an older profile stays recognisable as
+   * being about an older profile. It is a digest, not a copy: it cannot be
+   * reversed into the material it summarises.
+   */
+  contentSnapshotHash?: string;
+  /** Last delivery failure, truncated. Never carries reported material. */
+  lastDeliveryError?: string;
+
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** A lean report row, as every read path returns it. */
+export interface LeanReport extends ReportFields {
+  _id: mongoose.Types.ObjectId;
+}
+
+export interface IReport extends ReportFields, Document<mongoose.Types.ObjectId> {
+  _id: mongoose.Types.ObjectId;
+}
+
+/**
+ * Narrows an arbitrary string to a reportable type.
+ *
+ * A type guard rather than a membership check at each call site: the compiler has
+ * to KNOW the value is a `ReportedType` before it reaches a query or a `create`,
+ * and an `includes` that returns a plain boolean leaves it a `string` — which is
+ * the point at which somebody reaches for a cast.
+ */
+export function isReportedType(value: string): value is ReportedType {
+  return (Object.values(ReportedType) as string[]).includes(value);
+}
+
+const ReportSchema = new Schema<IReport>(
+  {
+    reportedType: {
+      type: String,
+      enum: Object.values(ReportedType),
+      required: true,
+    },
+    reportedId: { type: String, required: true, index: true },
+    reporter: { type: String, required: true, index: true },
+    categories: {
+      type: [String],
+      enum: Object.values(ReportCategory),
+      required: true,
+      validate: {
+        validator: (value: string[]) => Array.isArray(value) && value.length > 0,
+        message: "At least one category is required",
+      },
+    },
+    details: { type: String, maxlength: 500 },
+    status: {
+      type: String,
+      enum: Object.values(ReportStatus),
+      default: ReportStatus.PENDING,
+      index: true,
+    },
+    localStatus: {
+      type: String,
+      enum: REPORT_LOCAL_STATUSES,
+      default: "received",
+      required: true,
+      index: true,
+    },
+    localStatusReason: { type: String, maxlength: 300 },
+
+    crowdSourceReportId: { type: String },
+    crowdSourceCaseId: { type: String, index: true },
+    crowdSourceMerged: { type: Boolean },
+    submittedAt: { type: Date },
+
+    decisionId: { type: String },
+    decisionRevision: { type: Number, min: 1 },
+    decisionOutcome: { type: String },
+    decisionStatus: { type: String },
+    decidedAt: { type: Date },
+
+    enforcedAction: { type: String, enum: REPORT_ENFORCEMENT_ACTIONS },
+    enforcedAt: { type: Date },
+
+    contentSnapshotHash: { type: String },
+    lastDeliveryError: { type: String, maxlength: 2_000 },
+  },
+  { timestamps: true },
+);
+
+/** One report per reporter per object: re-reporting is idempotent, not additive. */
+ReportSchema.index({ reporter: 1, reportedId: 1, reportedType: 1 }, { unique: true });
+/** The reconciliation sweep scans by delivery state, oldest first (§14.4). */
+ReportSchema.index({ localStatus: 1, createdAt: 1 });
+
+export const Report = mongoose.model<IReport>("Report", ReportSchema);
+export default Report;

--- a/packages/backend/src/routes/crowdSourceWebhook.ts
+++ b/packages/backend/src/routes/crowdSourceWebhook.ts
@@ -1,0 +1,184 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import { crowdsourceWebhooks } from "@oxyhq/crowdsource-express";
+import { crowdSourceConfig } from "../config/crowdsource";
+import {
+  recordDecisionEvent,
+  recordIgnoredEvent,
+} from "../services/moderation/ModerationInboundService";
+import { mongoProcessedEventStore } from "../services/moderation/moderationEventStore";
+import { logger } from "../utils/logger";
+
+/**
+ * `POST /webhooks/crowdsource` — where decisions come back.
+ *
+ * ## The mount is part of the correctness
+ *
+ * This router MUST be mounted before `express.json()` in `server.ts`. The
+ * signature covers `timestamp + "." + rawBody` — the bytes that arrived — and once
+ * a JSON parser has run, those bytes are gone. `@oxyhq/crowdsource-express` looks
+ * for the raw stream, finds a parsed `req.body` instead, and REFUSES rather than
+ * verifying a signature over a re-serialisation. That refusal is the correct
+ * behaviour and it is also why the mount order cannot be got wrong silently.
+ *
+ * `assertRawBody` below turns "cannot be got wrong silently" into "cannot be got
+ * wrong at all in a way a test would miss": it fails loudly, at the route, naming
+ * the cause. Without it the symptom is a signature mismatch, which reads like a
+ * secret problem and sends the next person to rotate a secret that was fine.
+ *
+ * ## What this handler does and does not do
+ *
+ * It records and returns. §10.8 asks a receiver to answer 2xx quickly and queue
+ * the processing, and the reason is not latency: applying a decision means reading
+ * a report, planning enforcement and writing several collections, and a receiver
+ * that did all that inline would time out under a burst and be retried while the
+ * first attempt was still running. So the event and a durable `decision.apply`
+ * outbox row commit in ONE transaction, and the dispatcher does the work.
+ *
+ * Nothing here is authenticated by Oxy. The HMAC IS the authentication (§10.8),
+ * and an Oxy session must never satisfy this route — it is not a user endpoint.
+ */
+
+/**
+ * One string field out of an event payload this version does not know.
+ *
+ * `WebhookEventEnvelope.data` is deliberately OPAQUE in the contract: an
+ * unrecognised event's payload is whatever a newer CrowdSource decided to send, so
+ * this reads the key defensively instead of asserting a shape nobody has verified.
+ * Anything that is not a string is treated as absent, which is the only safe
+ * reading of a field this deployment has never seen.
+ */
+function stringField(source: unknown, key: string): string | undefined {
+  if (typeof source !== "object" || source === null) return undefined;
+  const value: unknown = Reflect.get(source, key);
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Refuse to run if a body parser got here first.
+ *
+ * `express.json()` sets `req.body` on every request it handles — to `{}` when
+ * there is nothing to parse — so an undefined `req.body` is precisely the
+ * assertion that no parser has touched this request. Mounted inside the route
+ * rather than asserted in a test, because the thing being protected is the MOUNT
+ * ORDER in `server.ts`, and a future edit that moves this router below
+ * `express.json()` would break it in a way no unit test of this file could see.
+ *
+ * 500 rather than 4xx: this is Allo misassembled, not a bad request. Answering
+ * non-2xx also keeps the delivery on CrowdSource's retry schedule, so decisions
+ * are not lost while the deployment is broken — they queue up and arrive once it
+ * is fixed.
+ */
+function assertRawBody(req: Request, res: Response, next: NextFunction): void {
+  if (typeof req.body !== "undefined") {
+    logger.error(
+      "[CrowdSource] webhook received a parsed body: this router is mounted after a body parser. " +
+        "The signature covers the bytes that arrived and they are now gone. Mount it before express.json().",
+    );
+    res.status(500).json({
+      error: "Internal Server Error",
+      message: "Webhook receiver is misconfigured",
+    });
+    return;
+  }
+  next();
+}
+
+export function createCrowdSourceWebhookRoutes(): Router {
+  const router = Router();
+
+  const config = crowdSourceConfig();
+  const secret = config.webhookSecret;
+  if (!secret) {
+    /**
+     * Not mounted, rather than mounted and permissive.
+     *
+     * A route that answers anything at all without a secret is a route that will
+     * one day be reasoned about as if it verified something. An unconfigured
+     * deployment 404s here, which is indistinguishable from not having the feature
+     * — which is exactly what it is.
+     */
+    logger.info("[CrowdSource] webhook route not mounted: no CROWDSOURCE_WEBHOOK_SECRET");
+    return router;
+  }
+
+  router.post(
+    "/crowdsource",
+    assertRawBody,
+    crowdsourceWebhooks({
+      secret,
+      ...(config.webhookPreviousSecret === undefined
+        ? {}
+        : { previousSecret: config.webhookPreviousSecret }),
+      // Shared across ECS tasks: the in-process default would dedupe only the
+      // instance that happened to receive both copies of a redelivery.
+      store: mongoProcessedEventStore(),
+      on: {
+        /**
+         * A decision, provisional or final. Both are queued: a provisional decision
+         * is real (§9.6) and Allo records it; what it may ACT on is decided by the
+         * enforcement mode, not by discarding the event here.
+         */
+        "case.decided": async (event) => {
+          await recordDecisionEvent({
+            eventId: event.id,
+            type: event.type,
+            caseId: event.data.caseId,
+            decision: event.data.decision,
+          });
+        },
+        /**
+         * A later revision replacing an earlier one (§10.6). The SAME path: the
+         * decision worker compares revisions and reverses what the superseded
+         * revision did. A correction is not a special case with its own code — it
+         * is an ordinary decision that supersedes another, and giving it a separate
+         * path is how a restore ends up not being idempotent.
+         */
+        "decision.corrected": async (event) => {
+          await recordDecisionEvent({
+            eventId: event.id,
+            type: event.type,
+            caseId: event.data.caseId,
+            decision: event.data.decision,
+          });
+        },
+        /**
+         * An appeal's outcome carries a decision too, and it is the current answer
+         * for the case, so it takes the same path.
+         */
+        "appeal.decided": async (event) => {
+          await recordDecisionEvent({
+            eventId: event.id,
+            type: event.type,
+            caseId: event.data.caseId,
+            decision: event.data.decision,
+          });
+        },
+      },
+      /**
+       * Every other event type — including one this version of the contracts
+       * package has never heard of (§10.11).
+       *
+       * Recorded rather than dropped. `case.created`, `case.escalated` and
+       * `case.closed` carry no decision and nothing to enforce, but "did CrowdSource
+       * tell us about this case, and when" is the first question asked when a report
+       * appears stuck, and the answer has to exist somewhere.
+       */
+      onUnhandled: async (event) => {
+        await recordIgnoredEvent({
+          eventId: event.id,
+          type: event.type,
+          caseId: stringField(event.data, "caseId"),
+        });
+      },
+      /**
+       * A refusal reason and nothing else — never a body, a header or a signature
+       * (§10.8's last line). It is a bounded label from the SDK's own union.
+       */
+      onRejected: (rejection) => {
+        logger.warn("[CrowdSource] webhook delivery refused", { rejection });
+      },
+    }),
+  );
+
+  return router;
+}

--- a/packages/backend/src/routes/reports.ts
+++ b/packages/backend/src/routes/reports.ts
@@ -1,0 +1,196 @@
+import { Router, Response } from "express";
+import type { OxyAuthRequest as AuthRequest } from "@oxyhq/core/server";
+import { getRequiredOxyUserId as getAuthenticatedUserId } from "@oxyhq/core/server";
+import Report, {
+  isReportedType,
+  ReportCategory,
+  ReportedType,
+  type LeanReport,
+} from "../models/Report";
+import {
+  createReport,
+  DuplicateReportError,
+} from "../services/moderation/ReportIntakeService";
+import { sendErrorResponse, sendSuccessResponse } from "../utils/apiHelpers";
+import { logger } from "../utils/logger";
+
+const router = Router();
+
+const MAX_CATEGORIES = 6;
+const MAX_DETAILS_LENGTH = 500;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseCategories(value: unknown): ReportCategory[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_CATEGORIES) {
+    return null;
+  }
+  const allowed = new Set<string>(Object.values(ReportCategory));
+  const parsed: ReportCategory[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !allowed.has(entry)) return null;
+    const category = entry as ReportCategory;
+    if (!parsed.includes(category)) parsed.push(category);
+  }
+  return parsed;
+}
+
+/**
+ * `POST /api/reports` — take a report.
+ *
+ * A 201 means the report is durably recorded, and — when its type is deliverable —
+ * that the promise to deliver it committed in the same transaction. It never means
+ * CrowdSource has seen anything.
+ *
+ * ## Every reported type is accepted here, including the ones that never leave
+ *
+ * A reported `message` is stored and never delivered, because Allo's server cannot
+ * read a message (see `services/moderation/subjects/registry.ts`). That is not a
+ * reason to refuse the report: refusing would tell a user being harassed that their
+ * report is invalid, when what is actually true is that strangers cannot be shown
+ * the evidence. The response deliberately does NOT distinguish the two cases —
+ * `delivered` is not echoed back — because a reporter learning which reports leave
+ * the deployment learns which reports can be made to disappear.
+ */
+router.post("/", async (req: AuthRequest, res: Response) => {
+  const body: unknown = req.body;
+  if (!isRecord(body)) {
+    return sendErrorResponse(res, 400, "Bad Request", "A JSON object body is required");
+  }
+
+  const reportedType: unknown = body.reportedType;
+  if (typeof reportedType !== "string" || !isReportedType(reportedType)) {
+    return sendErrorResponse(
+      res,
+      400,
+      "Bad Request",
+      `reportedType must be one of: ${Object.values(ReportedType).join(", ")}`,
+    );
+  }
+
+  const reportedId = body.reportedId;
+  if (typeof reportedId !== "string" || reportedId.trim().length === 0) {
+    return sendErrorResponse(res, 400, "Bad Request", "reportedId is required");
+  }
+
+  const categories = parseCategories(body.categories);
+  if (!categories) {
+    return sendErrorResponse(
+      res,
+      400,
+      "Bad Request",
+      `categories must be a non-empty array of at most ${MAX_CATEGORIES} values from: ${Object.values(ReportCategory).join(", ")}`,
+    );
+  }
+
+  const rawDetails: unknown = body.details;
+  if (rawDetails !== undefined && typeof rawDetails !== "string") {
+    return sendErrorResponse(res, 400, "Bad Request", "details must be a string");
+  }
+  const details =
+    typeof rawDetails === "string"
+      ? rawDetails.trim().slice(0, MAX_DETAILS_LENGTH)
+      : undefined;
+
+  try {
+    const reporter = getAuthenticatedUserId(req);
+
+    /**
+     * A reporter cannot report themselves. Not a correctness guard so much as a
+     * refusal to open a case whose subject and reporter are the same principal —
+     * §7.3's dedup key would be well-formed and a jury would be asked a question
+     * with no adversary.
+     */
+    if (reportedType === ReportedType.USER && reportedId.trim() === reporter) {
+      return sendErrorResponse(res, 400, "Bad Request", "You cannot report yourself");
+    }
+
+    const { report } = await createReport({
+      reporter,
+      reportedType,
+      reportedId,
+      categories,
+      ...(details ? { details } : {}),
+    });
+
+    return sendSuccessResponse(
+      res,
+      201,
+      { id: report._id.toString(), createdAt: report.createdAt },
+      "Report received",
+    );
+  } catch (error) {
+    /**
+     * A duplicate is answered 200, not 409. Re-reporting the same account is a
+     * user repeating themselves, not an error they can act on, and the report they
+     * already filed is genuinely on file.
+     */
+    if (error instanceof DuplicateReportError) {
+      return sendSuccessResponse(
+        res,
+        200,
+        { id: error.existing._id.toString(), createdAt: error.existing.createdAt },
+        "You have already reported this",
+      );
+    }
+
+    /**
+     * The reported id is deliberately absent from this log line. It identifies an
+     * account someone reported, and an operational log is not the place to
+     * accumulate a list of who has been accused of what.
+     */
+    logger.error("[Reports] Failed to create report", error);
+    return sendErrorResponse(
+      res,
+      500,
+      "Internal Server Error",
+      "Failed to record report",
+    );
+  }
+});
+
+/**
+ * `GET /api/reports/mine` — the reports this user filed.
+ *
+ * Scoped to the authenticated reporter with no override, so there is no parameter
+ * through which one user could read another's reports. The projection omits
+ * `localStatus`, `localStatusReason` and every CrowdSource identifier: those are
+ * operational state, and exposing them would tell a reporter which reports left
+ * the deployment.
+ */
+router.get("/mine", async (req: AuthRequest, res: Response) => {
+  try {
+    const reporter = getAuthenticatedUserId(req);
+    const reports = await Report.find({ reporter })
+      .sort({ createdAt: -1 })
+      .limit(100)
+      .select("_id reportedType reportedId categories details status createdAt")
+      .lean<LeanReport[]>();
+
+    return sendSuccessResponse(
+      res,
+      200,
+      reports.map((report) => ({
+        id: report._id.toString(),
+        reportedType: report.reportedType,
+        reportedId: report.reportedId,
+        categories: report.categories,
+        details: report.details,
+        status: report.status,
+        createdAt: report.createdAt,
+      })),
+    );
+  } catch (error) {
+    logger.error("[Reports] Failed to list reports", error);
+    return sendErrorResponse(
+      res,
+      500,
+      "Internal Server Error",
+      "Failed to load reports",
+    );
+  }
+});
+
+export default router;

--- a/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
+++ b/packages/backend/src/services/moderation/EvidenceSnapshotService.ts
@@ -1,0 +1,156 @@
+import { createHash } from "crypto";
+import type { ReportInput } from "@oxyhq/crowdsource";
+import { REPORT_TAXONOMY_VERSION, allegationsForCategories } from "./reportTaxonomy";
+import { subjectProviderFor } from "./subjects/registry";
+import type { ModerationSubjectSnapshot } from "./subjects/types";
+import type { IReport } from "../../models/Report";
+
+/**
+ * Turning a stored report into the thing the SDK delivers.
+ *
+ * `@oxyhq/crowdsource` builds the Case Envelope, and it deliberately does not
+ * export the function that does it. What this module produces is the SDK's
+ * `ReportInput` — a description of the material — and the SDK derives the envelope
+ * from it: resource ids, relations, digests, pseudonymous principal refs, the
+ * identity binding proof, the pinned policy version, the privacy terms and the
+ * idempotency key.
+ *
+ * That is not a technicality. Those derived values are exactly what §7.3's dedup
+ * key is computed over, so an application that composed its own envelope would be
+ * the reason two reporters about one account opened two cases — and "one penalty
+ * per incident" would fail in production with nothing failing in a test.
+ *
+ * So this module does three things and no more: ask the registry for a snapshot of
+ * the reported object, translate the reporter's categories into allegations, and
+ * assemble both with the report's own identity.
+ */
+
+/**
+ * The material could not be described, because nothing can describe it.
+ *
+ * This is a DEFECT, not a state, and it should be unreachable. A report whose type
+ * has no subject provider never gets a delivery event in the first place — intake
+ * decides that from the same registry this module reads — so an event that arrives
+ * here has been created by something that bypassed `ReportIntakeService`, or by a
+ * deployment where a provider was removed while its reports were still in flight.
+ *
+ * `retryable: false` therefore dead-letters the outbox event, so the reconciliation
+ * sweep counts it and a human looks. The alternative — writing a local state —
+ * would file a genuine defect in the one place that looks identical to the
+ * deliberate local-only reports, and in Allo that place is crowded: every reported
+ * message lives there. Nothing would ever alert on it.
+ */
+export class ModerationSubjectUnsupportedError extends Error {
+  readonly retryable = false;
+
+  constructor(reportedType: string) {
+    super(`No moderation subject provider is registered for '${reportedType}'.`);
+    this.name = "ModerationSubjectUnsupportedError";
+  }
+}
+
+/**
+ * SHA-256 of the snapshot, stored on the report (§5.6).
+ *
+ * Taken over the described MATERIAL, not over the whole `ReportInput`: the report
+ * id, the reporter and the allegations are properties of the report, and including
+ * them would mean two people reporting one account produced different hashes —
+ * the opposite of what this hash is for. Key order is fixed by the literal below
+ * rather than by `Object.keys`, so the digest is stable across Node versions and
+ * across a refactor that reorders a field.
+ */
+export function snapshotHash(snapshot: ModerationSubjectSnapshot): string {
+  const canonical = JSON.stringify({
+    subject: {
+      externalId: snapshot.subject.externalId,
+      type: snapshot.subject.type,
+      author: snapshot.subject.author?.oxyUserId ?? null,
+    },
+    content: snapshot.content,
+    attachments: snapshot.attachments ?? [],
+    context: snapshot.context ?? [],
+  });
+  return `sha256:${createHash("sha256").update(canonical, "utf8").digest("hex")}`;
+}
+
+export interface ModerationReportInput {
+  /** What the SDK delivers. */
+  readonly reportInput: ReportInput;
+  /** The digest to store on the local report. */
+  readonly snapshotHash: string;
+}
+
+/**
+ * Describe a stored report for delivery, or report why it cannot be described.
+ *
+ * Returns `null` when the reported object no longer exists. That is not an error
+ * either: an account deleted between the report and its delivery is ordinary.
+ */
+export async function buildModerationReportInput(
+  report: Pick<
+    IReport,
+    "reportedType" | "reportedId" | "reporter" | "categories" | "details" | "createdAt"
+  > & { id: string },
+): Promise<ModerationReportInput | null> {
+  const provider = subjectProviderFor(report.reportedType);
+  if (!provider) throw new ModerationSubjectUnsupportedError(report.reportedType);
+
+  const snapshot = await provider.snapshot(report.reportedId);
+  if (!snapshot) return null;
+
+  const allegationCodes = allegationsForCategories(report.categories);
+  const details = report.details?.trim();
+
+  return {
+    reportInput: {
+      externalReportId: report.id,
+      subject: snapshot.subject,
+      content: snapshot.content,
+      ...(snapshot.attachments === undefined ? {} : { attachments: snapshot.attachments }),
+      ...(snapshot.context === undefined ? {} : { context: snapshot.context }),
+      /**
+       * The reporter's own words ride on the FIRST allegation only.
+       *
+       * Repeating one free-text field across every code would say the reporter
+       * wrote it about each of them separately, and §6.2 is explicit that details
+       * are the reporter's claim and never evidence for it.
+       *
+       * This is the ONLY free text Allo sends, and it is the reporter's own — the
+       * one place a reporter could choose to paste something a message said. That
+       * is their disclosure to make about their own conversation, bounded to 500
+       * characters by the schema, and it is attributed to them as a claim rather
+       * than presented as evidence of what was said.
+       */
+      allegations: allegationCodes.map((code, index) =>
+        index === 0 && details ? { code, details } : { code },
+      ),
+      /**
+       * The Oxy subject IS the binding proof (§11.14). Allo stores reporters as Oxy
+       * user ids, so there is no separate binding step to implement here.
+       */
+      reportedBy: { oxyUserId: report.reporter },
+      /**
+       * The moment the USER reported it — the local report's own timestamp, not the
+       * moment of delivery. Any value invented per attempt would make every retry
+       * from the outbox a permanent 409 (§10.5).
+       */
+      submittedAt: report.createdAt,
+      metadata: {
+        /** So a case can be read back against the mapping that produced it. */
+        alloTaxonomyVersion: REPORT_TAXONOMY_VERSION,
+        alloCategories: [...report.categories].sort().join(","),
+        /**
+         * Declared, and permanently false in Allo.
+         *
+         * Not "not implemented yet" — there is no evidence to attach. Allo is
+         * end-to-end encrypted and the server cannot read a message, so a jury will
+         * never receive conversation material with a case from this application. A
+         * jury told this can answer `insufficient_context` for the right reason
+         * rather than assuming evidence was withheld or lost.
+         */
+        evidenceAttachmentsSupported: false,
+      },
+    },
+    snapshotHash: snapshotHash(snapshot),
+  };
+}

--- a/packages/backend/src/services/moderation/ModerationDecisionWorker.ts
+++ b/packages/backend/src/services/moderation/ModerationDecisionWorker.ts
@@ -1,0 +1,158 @@
+import { DecisionSchema } from "@oxyhq/crowdsource-contracts";
+import Report, { type LeanReport } from "../../models/Report";
+import { crowdSourceConfig } from "../../config/crowdsource";
+import { logger } from "../../utils/logger";
+import type { ModerationOutboxEvent } from "./ModerationOutboxService";
+import { reportStateForDecision } from "./reportStatus";
+
+/**
+ * Applying a decision that came back.
+ *
+ * The decision is parsed HERE rather than at the webhook (§10.11): an event whose
+ * shape this deployment does not recognise is kept in the outbox until the code
+ * catches up, instead of being refused at the door and retried until it
+ * dead-letters.
+ *
+ * ## Allo ships in `observe` mode, and there is a second reason beyond caution
+ *
+ * `observe` is the safe first rollout everywhere. In Allo it is also the only mode
+ * with anything to run, because **Allo has no platform-level sanction primitive.**
+ * `Block` and `Restrict` are per-user relations — "user X will not hear from user
+ * Y" — written by a user about their own inbox. There is no account-level
+ * restriction, no delivery suspension and no global mute for a decision to invoke.
+ *
+ * So this worker records the decision and stops. Manufacturing an enforcement path
+ * — writing `Block` rows on behalf of users who did not ask, or inventing a
+ * platform restriction with no delivery-side code to honour it — would be a product
+ * decision with real consequences for real accounts, made by a moderation worker
+ * because a field said `violation`. Recording the decision is genuinely useful on
+ * its own: it is the durable record of conduct across reports, and it is what a
+ * future enforcement mechanism would be built to read.
+ *
+ * `enforcedAction` is therefore written as the action Allo WOULD take, never as
+ * one it did, and `enforcedAt` stays unset until something actually acts.
+ */
+
+const MAX_DECISION_SUMMARY_LENGTH = 200;
+
+/** A decision event that can never be applied. Dead-lettered, not retried. */
+export class ModerationDecisionRejectedError extends Error {
+  readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ModerationDecisionRejectedError";
+  }
+}
+
+/**
+ * What Allo would do about an outcome.
+ *
+ * Deliberately small, because Allo's vocabulary of consequences is small. There is
+ * no `label_sensitive` or `unlabel_sensitive`: labelling means annotating material,
+ * and Allo cannot read the material. A `violation` maps to `restrict` as the
+ * intent, `no_violation` to `restore`, and every non-verdict outcome to
+ * `manual_review` — because "we could not tell" is a question for a person, not a
+ * silent `none`.
+ */
+export function plannedActionForOutcome(
+  outcome: string,
+): "restrict" | "restore" | "manual_review" {
+  switch (outcome) {
+    case "violation":
+      return "restrict";
+    case "no_violation":
+      return "restore";
+    default:
+      return "manual_review";
+  }
+}
+
+/** Handle one `decision.apply` outbox event. */
+export async function applyDecisionOutboxEvent(
+  event: ModerationOutboxEvent,
+): Promise<void> {
+  const caseId = event.payload.caseId;
+  if (caseId === undefined) {
+    throw new ModerationDecisionRejectedError("A decision.apply event carried no caseId.");
+  }
+
+  const parsed = DecisionSchema.safeParse(event.payload.decision);
+  if (!parsed.success) {
+    /**
+     * Retryable, NOT dead-lettered. A decision this deployment cannot parse is far
+     * more likely to be a newer CrowdSource than a corrupt payload, and the outbox
+     * keeps it for days — long enough to deploy a contracts bump and have the
+     * backlog apply itself. Dead-lettering here would discard a real decision
+     * because this deployment was behind.
+     */
+    throw new Error(
+      `Decision for case '${caseId}' does not match the known contract: ${parsed.error.message.slice(0, MAX_DECISION_SUMMARY_LENGTH)}`,
+    );
+  }
+  const decision = parsed.data;
+
+  const report = await Report.findOne({ crowdSourceCaseId: caseId }).lean<LeanReport | null>();
+  if (!report) {
+    /**
+     * A decision about a case this deployment has no report for. Not an error: a
+     * case can be merged (§7.3) so the decision may name a case another report
+     * opened, and a report can be deleted. Nothing to apply and nothing to retry.
+     */
+    logger.warn("[CrowdSource] decision has no local report", { caseId });
+    return;
+  }
+
+  /**
+   * A superseded revision is not the current answer, and an OLDER revision
+   * arriving late must never overwrite a newer one. §10.6 allows redelivery and
+   * reordering, so the comparison is against what is stored, not against arrival
+   * order.
+   */
+  const storedRevision = report.decisionRevision ?? 0;
+  if (decision.revision <= storedRevision) {
+    logger.info("[CrowdSource] ignoring superseded decision revision", {
+      caseId,
+      arrived: decision.revision,
+      stored: storedRevision,
+    });
+    return;
+  }
+
+  const state = reportStateForDecision({
+    outcome: decision.outcome,
+    decisionStatus: decision.status,
+  });
+  const plannedAction = plannedActionForOutcome(decision.outcome);
+  const mode = crowdSourceConfig().enforcementMode;
+
+  await Report.updateOne(
+    { _id: report._id, decisionRevision: report.decisionRevision ?? null },
+    {
+      $set: {
+        status: state.status,
+        localStatus: state.localStatus,
+        decisionId: decision.id,
+        decisionRevision: decision.revision,
+        decisionOutcome: decision.outcome,
+        decisionStatus: decision.status,
+        decidedAt: new Date(),
+        /**
+         * The action Allo would take. Written in every mode, acted on in none —
+         * see this file's header. When an enforcement mechanism exists, it reads
+         * this field; until then it is the record of what was decided.
+         */
+        enforcedAction: plannedAction,
+      },
+    },
+  );
+
+  logger.info("[CrowdSource] decision recorded", {
+    caseId,
+    outcome: decision.outcome,
+    revision: decision.revision,
+    plannedAction,
+    enforcementMode: mode,
+    enforced: false,
+  });
+}

--- a/packages/backend/src/services/moderation/ModerationDeliveryWorker.ts
+++ b/packages/backend/src/services/moderation/ModerationDeliveryWorker.ts
@@ -1,0 +1,158 @@
+import Report, { type LeanReport } from "../../models/Report";
+import { logger } from "../../utils/logger";
+import { getCrowdSourceClient } from "./crowdSourceClient";
+import { buildModerationReportInput } from "./EvidenceSnapshotService";
+import type { ModerationOutboxEvent } from "./ModerationOutboxService";
+
+/**
+ * Delivering a stored report to CrowdSource.
+ *
+ * Everything hard about this is handled elsewhere and the shape of this file is
+ * what is left over: the SDK owns the envelope, the idempotency key, the timeouts,
+ * the per-attempt retries and the classification of failures; the outbox owns
+ * durability, backoff and dead-lettering. What remains is to describe the material,
+ * hand it over, and write down what came back.
+ *
+ * The failures are as important as the success:
+ *
+ * - **Nowhere to send it.** The integration is not configured. The event stays
+ *   pending, untouched, and delivers when it is — a delay, never a loss.
+ * - **The account is gone.** Deleted between the report and its delivery. There is
+ *   nothing to review, so the report closes locally instead of retrying for days.
+ * - **The type has no provider.** Unreachable by design — such a report never gets
+ *   a delivery event — so an event that reaches it is a defect and is dead-lettered
+ *   rather than retried or filed as a state.
+ * - **Anything else** is the SDK's `retryable` to answer, and the outbox obeys it.
+ */
+
+const MAX_ERROR_LENGTH = 2_000;
+
+/** Thrown when there is nowhere to deliver to yet. Always retryable. */
+export class CrowdSourceUnavailableError extends Error {
+  readonly retryable = true;
+
+  constructor() {
+    super("The CrowdSource integration is not configured in this deployment.");
+    this.name = "CrowdSourceUnavailableError";
+  }
+}
+
+/**
+ * A delivery event that cannot become deliverable.
+ *
+ * `retryable: false` is the field the outbox reads to dead-letter instead of
+ * backing off — the same contract every error from `@oxyhq/crowdsource` answers.
+ */
+export class ModerationDeliveryRejectedError extends Error {
+  readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ModerationDeliveryRejectedError";
+  }
+}
+
+/** Close a report there is genuinely nothing left to do about. */
+async function closeUndeliverable(reportId: string, reason: string): Promise<void> {
+  await Report.updateOne(
+    { _id: reportId },
+    { $set: { localStatus: "closed", localStatusReason: reason } },
+  );
+}
+
+/** Handle one `report.submit` outbox event. */
+export async function deliverReportOutboxEvent(
+  event: ModerationOutboxEvent,
+): Promise<void> {
+  const reportId = event.payload.reportId;
+  if (reportId === undefined) {
+    throw new ModerationDeliveryRejectedError("A report.submit event carried no reportId.");
+  }
+
+  const report = await Report.findById(reportId).lean<LeanReport | null>();
+  if (!report) {
+    /**
+     * The report is gone but its delivery event survived. Nothing to deliver and
+     * nothing to fix, so the event completes — retrying would keep looking for a
+     * row that no longer exists.
+     */
+    logger.warn("[CrowdSource] delivery event has no report", { reportId });
+    return;
+  }
+
+  const crowdsource = getCrowdSourceClient();
+  if (!crowdsource) throw new CrowdSourceUnavailableError();
+
+  /**
+   * A `ModerationSubjectUnsupportedError` from here is NOT caught. It carries
+   * `retryable: false`, so the outbox dead-letters the event — the right channel
+   * for a defect that needs a human. Catching it and writing a local state would
+   * put the report in the same place as every deliberately local-only report, which
+   * in Allo is most of them.
+   */
+  const input = await buildModerationReportInput({
+    id: String(report._id),
+    reportedType: report.reportedType,
+    reportedId: report.reportedId,
+    reporter: report.reporter,
+    categories: report.categories,
+    details: report.details,
+    createdAt: report.createdAt,
+  });
+
+  if (input === null) {
+    await closeUndeliverable(
+      reportId,
+      "The reported account no longer exists, so there is nothing to review.",
+    );
+    logger.info("[CrowdSource] report closed: subject unavailable", { reportId });
+    return;
+  }
+
+  let receipt: Awaited<ReturnType<typeof crowdsource.reports.create>>;
+  try {
+    receipt = await crowdsource.reports.create(input.reportInput);
+  } catch (error: unknown) {
+    /**
+     * The failure is visible on the report itself, not only in the outbox row.
+     * `delivery_failed` is a state §14.3 defines and it is what the reconciliation
+     * sweep reads; leaving the report at `queued` while the outbox quietly backed
+     * off would hide the problem in a collection nobody looks at. Written before
+     * rethrowing so the outbox still applies its own backoff or dead-letters.
+     */
+    await Report.updateOne(
+      { _id: reportId },
+      {
+        $set: {
+          localStatus: "delivery_failed",
+          lastDeliveryError: (error instanceof Error ? error.message : String(error)).slice(
+            0,
+            MAX_ERROR_LENGTH,
+          ),
+        },
+      },
+    );
+    throw error;
+  }
+
+  await Report.updateOne(
+    { _id: reportId },
+    {
+      $set: {
+        localStatus: "submitted",
+        crowdSourceReportId: receipt.reportId,
+        crowdSourceCaseId: receipt.caseId,
+        crowdSourceMerged: receipt.merged,
+        contentSnapshotHash: input.snapshotHash,
+        submittedAt: new Date(),
+      },
+      $unset: { lastDeliveryError: "", localStatusReason: "" },
+    },
+  );
+
+  logger.info("[CrowdSource] report delivered", {
+    reportId,
+    caseId: receipt.caseId,
+    merged: receipt.merged,
+  });
+}

--- a/packages/backend/src/services/moderation/ModerationInboundService.ts
+++ b/packages/backend/src/services/moderation/ModerationInboundService.ts
@@ -1,0 +1,118 @@
+import mongoose, { type ClientSession } from "mongoose";
+import ModerationEvent from "../../models/ModerationEvent";
+import {
+  decisionApplyEventId,
+  enqueueModerationOutboxEvent,
+} from "./ModerationOutboxService";
+
+/**
+ * What happens between "a signed decision arrived" and "2xx".
+ *
+ * §10.8: answer quickly and queue the processing. So exactly two writes happen
+ * here, in ONE transaction — the event's audit row is completed and a durable
+ * `decision.apply` event is created — and the dispatcher does the rest.
+ *
+ * The transaction is what makes the dedupe safe. The middleware has already
+ * claimed the event id by inserting the row (see `moderationEventStore.ts`); if
+ * completing that row and queueing the work were two operations, a crash between
+ * them would leave an event that is permanently deduplicated with no work queued —
+ * a decision silently lost, with a row that says it arrived. Committing both
+ * together means the only two possible outcomes are "recorded and queued" or
+ * "neither", and "neither" releases the claim and gets redelivered.
+ */
+
+const TRANSACTION_OPTIONS = {
+  readPreference: "primary" as const,
+  readConcern: { level: "snapshot" as const },
+  writeConcern: { w: "majority" as const },
+};
+
+async function inTransaction(
+  operation: (session: ClientSession) => Promise<void>,
+): Promise<void> {
+  const session = await mongoose.startSession();
+  try {
+    await session.withTransaction(async () => {
+      await operation(session);
+    }, TRANSACTION_OPTIONS);
+  } finally {
+    await session.endSession();
+  }
+}
+
+export interface RecordDecisionEventInput {
+  eventId: string;
+  type: string;
+  caseId: string;
+  /**
+   * The decision as delivered.
+   *
+   * `unknown`, deliberately. It is stored whole and parsed against the published
+   * contract by the worker that acts on it — §10.11 makes these payloads loose,
+   * and validating here would mean an event whose shape this deployment does not
+   * recognise yet is refused at the door and retried until it dead-letters,
+   * instead of being kept until the code catches up.
+   */
+  decision: unknown;
+}
+
+/** Record a decision-bearing event and queue its application. */
+export async function recordDecisionEvent(input: RecordDecisionEventInput): Promise<void> {
+  await inTransaction(async (session) => {
+    const now = new Date();
+    await ModerationEvent.updateOne(
+      { _id: input.eventId },
+      {
+        $set: {
+          type: input.type,
+          caseId: input.caseId,
+          payload: { caseId: input.caseId, decision: input.decision },
+          state: "queued",
+          queuedAt: now,
+          updatedAt: now,
+        },
+      },
+      { session },
+    );
+
+    await enqueueModerationOutboxEvent(
+      {
+        eventId: decisionApplyEventId(input.eventId),
+        kind: "decision.apply",
+        payload: {
+          eventId: input.eventId,
+          caseId: input.caseId,
+          decision: input.decision,
+        },
+      },
+      session,
+    );
+  });
+}
+
+/**
+ * Record an event there is nothing to do about.
+ *
+ * `case.created`, `case.escalated`, `case.closed` and any type a newer CrowdSource
+ * introduces. No outbox row, because no work — but the row is kept, because "did
+ * CrowdSource tell us about this case, and when" is the first question asked when
+ * a report looks stuck, and it has to be answerable.
+ */
+export async function recordIgnoredEvent(input: {
+  eventId: string;
+  type: string;
+  caseId?: string;
+}): Promise<void> {
+  const now = new Date();
+  await ModerationEvent.updateOne(
+    { _id: input.eventId },
+    {
+      $set: {
+        type: input.type,
+        ...(input.caseId === undefined ? {} : { caseId: input.caseId }),
+        state: "ignored",
+        updatedAt: now,
+      },
+    },
+  );
+}

--- a/packages/backend/src/services/moderation/ModerationOutboxDispatcher.ts
+++ b/packages/backend/src/services/moderation/ModerationOutboxDispatcher.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from "crypto";
+import { crowdSourceConfig } from "../../config/crowdsource";
+import { logger } from "../../utils/logger";
+import { applyDecisionOutboxEvent } from "./ModerationDecisionWorker";
+import { deliverReportOutboxEvent } from "./ModerationDeliveryWorker";
+import {
+  claimModerationOutboxEvent,
+  completeModerationOutboxEvent,
+  failModerationOutboxEvent,
+  type ModerationOutboxEvent,
+} from "./ModerationOutboxService";
+
+/**
+ * The loop that drains the outbox.
+ *
+ * One claim at a time, in creation order, with a lease. Claiming a batch and
+ * processing it concurrently would be faster and would also mean a crash mid-batch
+ * left several events leased to a dead worker; one at a time keeps the failure unit
+ * equal to the retry unit.
+ *
+ * The dispatcher is the ONLY thing gated on `CROWDSOURCE_ENABLED`. Intake still
+ * writes outbox events when the integration is off, so switching it on delivers the
+ * backlog rather than stranding it.
+ */
+
+const LEASE_MS = 60_000;
+
+async function handle(event: ModerationOutboxEvent): Promise<void> {
+  switch (event.kind) {
+    case "report.submit":
+      await deliverReportOutboxEvent(event);
+      return;
+    case "decision.apply":
+      await applyDecisionOutboxEvent(event);
+      return;
+    default: {
+      /**
+       * An exhaustive switch, checked by the compiler. A `kind` added to the model
+       * without a handler here is a type error at build time rather than an event
+       * that is claimed, silently does nothing, and completes.
+       */
+      const unhandled: never = event.kind;
+      throw new Error(`Unhandled moderation outbox kind: ${String(unhandled)}`);
+    }
+  }
+}
+
+export interface ModerationDispatchResult {
+  claimed: number;
+  processed: number;
+  failed: number;
+}
+
+/**
+ * Drain up to `batchSize` due events.
+ *
+ * Returns counts rather than throwing: a single failing event is a normal
+ * condition the outbox already handles with backoff, and a scheduler that crashed
+ * on it would stop draining every OTHER event too.
+ */
+export async function dispatchModerationOutbox(options?: {
+  batchSize?: number;
+  leaseOwner?: string;
+}): Promise<ModerationDispatchResult> {
+  const config = crowdSourceConfig();
+  const result: ModerationDispatchResult = { claimed: 0, processed: 0, failed: 0 };
+  if (!config.enabled) return result;
+
+  const leaseOwner = options?.leaseOwner ?? `allo-${randomUUID()}`;
+  const batchSize = Math.max(1, options?.batchSize ?? config.outboxBatchSize);
+
+  for (let index = 0; index < batchSize; index += 1) {
+    const event = await claimModerationOutboxEvent({ leaseOwner, leaseMs: LEASE_MS });
+    if (!event) break;
+    result.claimed += 1;
+
+    try {
+      await handle(event);
+      await completeModerationOutboxEvent(event._id, leaseOwner);
+      result.processed += 1;
+    } catch (error: unknown) {
+      const { deadLettered } = await failModerationOutboxEvent(event, leaseOwner, error);
+      result.failed += 1;
+      /**
+       * The event id and kind, never the payload. A payload can carry a decision
+       * about an account, and an operational log is not where that belongs.
+       */
+      logger.warn("[CrowdSource] outbox event failed", {
+        eventId: event._id,
+        kind: event.kind,
+        attempts: event.attempts,
+        deadLettered,
+      });
+    }
+  }
+
+  return result;
+}
+
+let timer: NodeJS.Timeout | undefined;
+let running = false;
+
+/**
+ * Start the periodic drain.
+ *
+ * `unref()` so this timer never keeps the process alive on its own — the
+ * convention for every module-level interval in the Oxy backends, and the
+ * difference between a clean shutdown and a task that will not exit.
+ *
+ * `running` guards against overlap: a slow drain must not have a second one
+ * started on top of it, which would double every lease contention.
+ */
+export function startModerationOutboxDispatcher(): void {
+  const config = crowdSourceConfig();
+  if (!config.enabled || timer) return;
+
+  timer = setInterval(() => {
+    if (running) return;
+    running = true;
+    void dispatchModerationOutbox()
+      .catch((error: unknown) => {
+        logger.error("[CrowdSource] outbox dispatch failed", error);
+      })
+      .finally(() => {
+        running = false;
+      });
+  }, config.outboxPollIntervalMs);
+  timer.unref?.();
+
+  logger.info("[CrowdSource] outbox dispatcher started", {
+    intervalMs: config.outboxPollIntervalMs,
+  });
+}
+
+/** Stop the periodic drain. Tests and shutdown. */
+export function stopModerationOutboxDispatcher(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = undefined;
+}

--- a/packages/backend/src/services/moderation/ModerationOutboxService.ts
+++ b/packages/backend/src/services/moderation/ModerationOutboxService.ts
@@ -1,0 +1,268 @@
+import type { ClientSession } from "mongoose";
+import ModerationOutbox, {
+  MODERATION_OUTBOX_RETENTION_SECONDS,
+  type ModerationOutboxKind,
+  type ModerationOutboxPayload,
+} from "../../models/ModerationOutbox";
+
+/**
+ * Claiming, completing and retrying durable moderation work.
+ *
+ * Lease-based rather than queue-based: a worker claims a row for a bounded time,
+ * and a lease that expires is reclaimable, so a process killed mid-delivery
+ * strands nothing. The row IS the job — there is no second queue that can drift
+ * out of sync with it.
+ */
+
+const DEFAULT_LEASE_MS = 60_000;
+const MAX_BACKOFF_MS = 6 * 60 * 60 * 1_000;
+const MAX_ERROR_LENGTH = 2_000;
+
+/**
+ * The attempt ceiling for a retryable failure.
+ *
+ * Twenty-five attempts under exponential backoff spans days, which is long enough
+ * to outlast any outage worth retrying through and short enough that a permanent
+ * defect stops being a background task nobody reads.
+ */
+const MAX_RETRYABLE_ATTEMPTS = 25;
+
+export interface ModerationOutboxEvent {
+  _id: string;
+  kind: ModerationOutboxKind;
+  payload: ModerationOutboxPayload;
+  attempts: number;
+  availableAt: Date;
+  leaseOwner?: string;
+  leaseUntil?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+/**
+ * The event id for delivering a report.
+ *
+ * Derived from the report, not from the request: a transaction retry or two
+ * concurrent duplicate submissions upsert the SAME event rather than queueing two
+ * deliveries. There is exactly one delivery event per report for the life of the
+ * report, which is also what makes the CrowdSource-side idempotency key stable.
+ */
+export function reportSubmitEventId(reportId: string): string {
+  return `moderation:report.submit:${reportId}`;
+}
+
+/**
+ * The event id for applying an inbound decision (Appendix D).
+ *
+ * The webhook event id is the key, so a redelivery of the same event can never
+ * queue the work twice even if the dedupe claim were somehow released.
+ */
+export function decisionApplyEventId(eventId: string): string {
+  return `moderation:decision.apply:${eventId}`;
+}
+
+/**
+ * Raised when an outbox event is written outside a transaction.
+ *
+ * Never expected at runtime. It exists so the invariant is ENFORCED rather than
+ * reviewed — see {@link enqueueModerationOutboxEvent}.
+ */
+export class ModerationOutboxTransactionError extends Error {
+  constructor(eventId: string) {
+    super(
+      `Refusing to enqueue moderation outbox event '${eventId}' outside a transaction: ` +
+        "the domain write and this row must commit together, or a report is answered 201 " +
+        "and never delivered.",
+    );
+    this.name = "ModerationOutboxTransactionError";
+  }
+}
+
+/**
+ * Write the event with the CALLER's session.
+ *
+ * The session is required, not optional. This is the whole point of the
+ * collection: the domain write and this row commit together or not at all. An
+ * overload that let a caller enqueue outside a transaction would be the one line
+ * that quietly reintroduces "the report was answered 201 and then vanished".
+ *
+ * The type makes the session mandatory; the runtime check below makes it mandatory
+ * that the session is ACTUALLY IN a transaction. A required parameter is satisfied
+ * by any session — including a bare `startSession()` nobody opened a transaction
+ * on, which type-checks perfectly and commits the row on its own. That is the
+ * shape of the mistake worth catching: it looks exactly like correct code, it
+ * passes any test that only asserts the row exists, and it fails as lost
+ * moderation work with no trace on the day something restarts between the two
+ * writes.
+ *
+ * This function is also the ONLY writer of this collection — the dispatcher claims
+ * existing rows and never creates one — so nothing can be enqueued that is not
+ * already in the outbox.
+ */
+export async function enqueueModerationOutboxEvent(
+  input: {
+    eventId: string;
+    kind: ModerationOutboxKind;
+    payload: ModerationOutboxPayload;
+  },
+  session: ClientSession,
+): Promise<string> {
+  if (!session.inTransaction()) {
+    throw new ModerationOutboxTransactionError(input.eventId);
+  }
+
+  const now = new Date();
+  await ModerationOutbox.updateOne(
+    { _id: input.eventId },
+    {
+      $setOnInsert: {
+        _id: input.eventId,
+        kind: input.kind,
+        payload: input.payload,
+        status: "pending",
+        attempts: 0,
+        availableAt: now,
+        expiresAt: new Date(now.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000),
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+    { upsert: true, session },
+  );
+  return input.eventId;
+}
+
+function claimFilter(now: Date, eventId?: string): Record<string, unknown> {
+  return {
+    ...(eventId ? { _id: eventId } : {}),
+    $or: [
+      { status: "pending", availableAt: { $lte: now } },
+      { status: "processing", leaseUntil: { $lte: now } },
+    ],
+  };
+}
+
+/**
+ * Atomically claim one due event. An expired `processing` lease is reclaimable,
+ * so a dead worker cannot strand moderation work forever.
+ */
+export async function claimModerationOutboxEvent(options: {
+  leaseOwner: string;
+  eventId?: string;
+  now?: Date;
+  leaseMs?: number;
+}): Promise<ModerationOutboxEvent | null> {
+  const now = options.now ?? new Date();
+  const leaseMs = Math.max(1_000, options.leaseMs ?? DEFAULT_LEASE_MS);
+  return await ModerationOutbox.findOneAndUpdate(
+    claimFilter(now, options.eventId),
+    {
+      $set: {
+        status: "processing",
+        leaseOwner: options.leaseOwner,
+        leaseUntil: new Date(now.getTime() + leaseMs),
+        updatedAt: now,
+      },
+      $inc: { attempts: 1 },
+      $unset: { lastError: "" },
+    },
+    { new: true, sort: { createdAt: 1 } },
+  )
+    .select("_id kind payload attempts availableAt leaseOwner leaseUntil expiresAt createdAt")
+    .lean<ModerationOutboxEvent | null>();
+}
+
+/** Complete only the lease this dispatcher currently owns. */
+export async function completeModerationOutboxEvent(
+  eventId: string,
+  leaseOwner: string,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const result = await ModerationOutbox.updateOne(
+    { _id: eventId, status: "processing", leaseOwner, leaseUntil: { $gt: now } },
+    {
+      $set: { status: "processed", processedAt: now, updatedAt: now },
+      $unset: { leaseOwner: "", leaseUntil: "", lastError: "" },
+    },
+  );
+  return result.modifiedCount === 1;
+}
+
+/** Extend only a live lease still owned by this dispatcher. */
+export async function renewModerationOutboxEvent(
+  eventId: string,
+  leaseOwner: string,
+  leaseMs: number,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const result = await ModerationOutbox.updateOne(
+    { _id: eventId, status: "processing", leaseOwner, leaseUntil: { $gt: now } },
+    { $set: { leaseUntil: new Date(now.getTime() + Math.max(1_000, leaseMs)), updatedAt: now } },
+  );
+  return result.matchedCount === 1;
+}
+
+function nextAttemptAt(attempts: number, now: Date): Date {
+  const exponent = Math.max(0, Math.min(attempts - 1, 20));
+  return new Date(now.getTime() + Math.min(1_000 * 2 ** exponent, MAX_BACKOFF_MS));
+}
+
+/**
+ * A failure that says whether trying the same payload again could ever work.
+ *
+ * Every error `@oxyhq/crowdsource` throws carries `retryable`, which is the only
+ * thing a delivery worker needs from it. Anything else — a bug in this code, a
+ * Mongo error — is treated as retryable, because assuming a defect is permanent is
+ * how a recoverable outage becomes lost moderation work.
+ */
+export function isRetryableDeliveryError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "retryable" in error) {
+    const retryable: unknown = (error as { retryable: unknown }).retryable;
+    if (typeof retryable === "boolean") return retryable;
+  }
+  return true;
+}
+
+export interface ModerationOutboxFailure {
+  released: boolean;
+  deadLettered: boolean;
+}
+
+/**
+ * Release a failed claim, with backoff — or stop.
+ *
+ * Stopping is not an optimisation. A 409 means this `externalReportId` already
+ * exists at CrowdSource with a different body, and no number of retries turns two
+ * payloads into one report; a 422 means the envelope is not processable. Both need
+ * the payload to change, so they become `dead_letter` immediately and stay visible
+ * with their error rather than accumulating attempts nobody reads.
+ *
+ * `lastError` is the message only, bounded. It can carry no reported material
+ * because Allo never puts any into a request: the sole deliverable subject is an
+ * account's own profile, so there is no message, key or ciphertext for an error
+ * echo to contain.
+ */
+export async function failModerationOutboxEvent(
+  event: Pick<ModerationOutboxEvent, "_id" | "attempts">,
+  leaseOwner: string,
+  error: unknown,
+  now: Date = new Date(),
+): Promise<ModerationOutboxFailure> {
+  const message = error instanceof Error ? error.message : String(error);
+  const retryable = isRetryableDeliveryError(error);
+  const deadLettered = !retryable || event.attempts >= MAX_RETRYABLE_ATTEMPTS;
+
+  const result = await ModerationOutbox.updateOne(
+    { _id: event._id, status: "processing", leaseOwner, leaseUntil: { $gt: now } },
+    {
+      $set: {
+        status: deadLettered ? "dead_letter" : "pending",
+        availableAt: deadLettered ? now : nextAttemptAt(event.attempts, now),
+        lastError: message.slice(0, MAX_ERROR_LENGTH),
+        updatedAt: now,
+      },
+      $unset: { leaseOwner: "", leaseUntil: "" },
+    },
+  );
+  return { released: result.modifiedCount === 1, deadLettered };
+}

--- a/packages/backend/src/services/moderation/ModerationOutboxService.ts
+++ b/packages/backend/src/services/moderation/ModerationOutboxService.ts
@@ -123,8 +123,24 @@ export async function enqueueModerationOutboxEvent(
         attempts: 0,
         availableAt: now,
         expiresAt: new Date(now.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000),
-        createdAt: now,
-        updatedAt: now,
+        /**
+         * `createdAt` and `updatedAt` are deliberately ABSENT.
+         *
+         * The schema declares `{ timestamps: true }`, so Mongoose writes both
+         * paths itself on an upsert — `updatedAt` into `$set` and both into
+         * `$setOnInsert`. Naming them here too puts `updatedAt` in two operators
+         * of one update document, and Mongo rejects the WHOLE write:
+         * `Updating the path 'updatedAt' would create a conflict at 'updatedAt'`.
+         *
+         * The consequence is not a missing outbox row. This runs inside
+         * `createReport`'s transaction, so the abort takes the `Report` with it —
+         * `POST /reports` fails for EVERY report, from the first one. Verified
+         * against a real replica set on mongoose 9.7.4: report rows 0, outbox
+         * rows 0.
+         *
+         * `claim`'s `sort: { createdAt: 1 }` still works, because `timestamps`
+         * sets `createdAt` on insert.
+         */
       },
     },
     { upsert: true, session },

--- a/packages/backend/src/services/moderation/ReportIntakeService.ts
+++ b/packages/backend/src/services/moderation/ReportIntakeService.ts
@@ -1,0 +1,210 @@
+import mongoose, { type ClientSession } from "mongoose";
+import Report, {
+  isReportedType,
+  ReportCategory,
+  ReportStatus,
+  ReportedType,
+  type IReport,
+  type LeanReport,
+  type ModerationLocalStatus,
+} from "../../models/Report";
+import {
+  enqueueModerationOutboxEvent,
+  reportSubmitEventId,
+} from "./ModerationOutboxService";
+import { subjectProviderFor } from "./subjects/registry";
+
+/**
+ * Storing a report and, when there is somewhere to send it, the promise to deliver
+ * it — in one operation.
+ *
+ * This is §7.1, and it is the only thing in the integration a user waits for. A
+ * 201 from `POST /reports` means the report row and its outbox event committed
+ * together. It does NOT mean CrowdSource accepted anything — CrowdSource may be
+ * unreachable, mid-deploy or not yet configured, and the reporter is told their
+ * report was received either way, because it was.
+ *
+ * The transaction is the whole mechanism. Two writes outside one would give two
+ * failure modes that are both silent: a report with no delivery event (nothing
+ * will ever send it, and nobody finds out until somebody asks why a case never
+ * opened) or a delivery event with no report (a worker looking up an id that was
+ * rolled back). Neither surfaces as an error at the moment it happens, which is
+ * exactly why this has to be atomic rather than carefully ordered.
+ *
+ * The one report with NO delivery event is the one whose type has no subject
+ * provider, and that is a different claim entirely: not "delivery failed" but
+ * "there was never a route out of this application for this kind of object". In
+ * Allo that is the common case, not the exception — a reported message is stored
+ * and never leaves, because the server cannot read one. The two must not be
+ * conflated, which is why they are different `localStatus` values and why the
+ * absent route is written down as a reason rather than inferred from a missing row.
+ */
+
+const TRANSACTION_OPTIONS = {
+  readPreference: "primary" as const,
+  readConcern: { level: "snapshot" as const },
+  writeConcern: { w: "majority" as const },
+};
+
+export class DuplicateReportError extends Error {
+  readonly existing: LeanReport;
+
+  constructor(existing: LeanReport) {
+    super("This item has already been reported by this reporter.");
+    this.name = "DuplicateReportError";
+    this.existing = existing;
+  }
+}
+
+/**
+ * Refuses an identifier that is not a non-empty string, at the point the QUERY is
+ * built.
+ *
+ * `CreateReportInput` types these as strings and the route rejects a missing one,
+ * but a type is erased at runtime and a truthiness check passes `{$ne: null}`.
+ * Handed that, `findOne` matches an UNRELATED report and this function answers
+ * "you already reported this" about somebody else's row — and `create` would then
+ * store a query operator where an id belongs.
+ *
+ * The check lives here rather than at the route because `createReport` is
+ * exported: a worker, a reconciliation script or a future admin path is under no
+ * obligation to have passed the route's validation, and a guard that only exists
+ * at one caller is a guard that holds until the second one arrives.
+ */
+function requireIdentifier(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `createReport: '${field}' must be a string, received ${value === null ? "null" : typeof value}.`,
+    );
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError(`createReport: '${field}' must not be empty.`);
+  }
+  return trimmed;
+}
+
+export interface CreateReportInput {
+  reporter: string;
+  reportedType: ReportedType;
+  reportedId: string;
+  categories: ReportCategory[];
+  details?: string;
+}
+
+export interface CreateReportResult {
+  report: IReport;
+  /**
+   * The durable delivery event.
+   *
+   * Absent exactly when the reported type has no subject provider — the report was
+   * stored and there is nothing to deliver it, by design rather than by failure.
+   */
+  outboxEventId?: string;
+}
+
+/**
+ * Why a report is not going anywhere, in words an operator can read.
+ *
+ * Stored on the row rather than left to be inferred from a missing outbox event. A
+ * missing row is also what a lost write looks like, and the two need to be
+ * distinguishable months later without re-deriving which types had providers at
+ * the time. Bounded by the schema's 300-character limit.
+ */
+function localOnlyReason(reportedType: string): string {
+  return (
+    `Allo has no moderation subject provider for '${reportedType}', so this report is ` +
+    "recorded locally and is not sent for community review. Message content is " +
+    "end-to-end encrypted and cannot be disclosed to reviewers."
+  );
+}
+
+async function inTransaction<T>(
+  operation: (session: ClientSession) => Promise<T>,
+): Promise<T> {
+  const session = await mongoose.startSession();
+  let result: T | undefined;
+  try {
+    await session.withTransaction(async () => {
+      result = await operation(session);
+    }, TRANSACTION_OPTIONS);
+    if (result === undefined) {
+      throw new Error("Report intake transaction completed without a result");
+    }
+    return result;
+  } finally {
+    await session.endSession();
+  }
+}
+
+/**
+ * Store the report, and queue its delivery in the same transaction.
+ *
+ * Delivery is queued when — and only when — the reported type has a subject
+ * provider. A type without one is stored at `received` with the reason recorded,
+ * which is the behaviour a reporter should get regardless: the report is a receipt
+ * and a local record, and it still counts as a signal about an account even when
+ * its material can never be reviewed.
+ *
+ * That branch is the reason the two writes stay in one transaction rather than
+ * being ordered carefully. The condition is read BEFORE the transaction body
+ * decides anything, so `localStatus` and the presence of an outbox row are decided
+ * together from one fact — a report can never commit as `queued` with nothing to
+ * deliver it, nor as `received` with a delivery event that will try anyway.
+ *
+ * Intake deliberately does not read `CROWDSOURCE_ENABLED`. A report taken while the
+ * integration is off still gets its delivery event, so turning the flag on delivers
+ * the backlog instead of stranding it — the dispatcher is what is gated, not the
+ * durable record. Nothing here is conditional on a third party's state; only on
+ * whether this application can describe the object at all.
+ */
+export async function createReport(input: CreateReportInput): Promise<CreateReportResult> {
+  const reporter = requireIdentifier(input.reporter, "reporter");
+  const reportedId = requireIdentifier(input.reportedId, "reportedId");
+  const rawReportedType = requireIdentifier(input.reportedType, "reportedType");
+  if (!isReportedType(rawReportedType)) {
+    throw new TypeError(
+      `createReport: reportedType '${rawReportedType}' is not a reportable type.`,
+    );
+  }
+  const reportedType: ReportedType = rawReportedType;
+  const deliverable = subjectProviderFor(reportedType) !== undefined;
+  const localStatus: ModerationLocalStatus = deliverable ? "queued" : "received";
+
+  return await inTransaction(async (session) => {
+    const existing = await Report.findOne({ reporter, reportedId, reportedType })
+      .session(session)
+      .lean<LeanReport | null>();
+    if (existing) throw new DuplicateReportError(existing);
+
+    const [report] = await Report.create(
+      [
+        {
+          reportedType,
+          reportedId,
+          reporter,
+          categories: input.categories,
+          details: input.details,
+          status: ReportStatus.PENDING,
+          localStatus,
+          ...(deliverable ? {} : { localStatusReason: localOnlyReason(reportedType) }),
+        },
+      ],
+      { session },
+    );
+
+    if (!deliverable) return { report };
+
+    const reportId = report._id.toString();
+    const outboxEventId = await enqueueModerationOutboxEvent(
+      {
+        eventId: reportSubmitEventId(reportId),
+        kind: "report.submit",
+        payload: { reportId },
+      },
+      session,
+    );
+
+    return { report, outboxEventId };
+  });
+}

--- a/packages/backend/src/services/moderation/crowdSourceClient.ts
+++ b/packages/backend/src/services/moderation/crowdSourceClient.ts
@@ -1,0 +1,69 @@
+import { CrowdSource } from "@oxyhq/crowdsource";
+import { crowdSourceConfig } from "../../config/crowdsource";
+import { logger } from "../../utils/logger";
+
+/**
+ * The CrowdSource client, built once and only when configured.
+ *
+ * There is deliberately almost nothing here. The SDK already owns the base URL,
+ * the timeouts, the bounded per-attempt retries, the idempotency key and the error
+ * classification, and a wrapper that re-implemented any of them would be a second
+ * answer to a question that has one. What Allo adds is exactly two things: the
+ * client is absent until the integration is switched on, and it is built once
+ * rather than per delivery.
+ *
+ * `applicationId` appears nowhere — the client reads it off the service key, and
+ * there is no option, field or parameter through which one could be passed.
+ */
+
+let client: CrowdSource | null = null;
+let configurationError: string | null = null;
+
+/**
+ * The client, or `undefined` when the integration is not configured.
+ *
+ * `undefined` rather than a throw: `CROWDSOURCE_ENABLED=false` is the normal state
+ * of a local checkout and of every deployment before rollout, and a report filed
+ * there must still be stored. The delivery worker is what notices there is nowhere
+ * to send it.
+ *
+ * A MISCONFIGURED client — a malformed service key — is a different thing and is
+ * logged once at error level. Logged once because the alternative is one line per
+ * delivery attempt per report, which buries the cause it is meant to reveal.
+ */
+export function getCrowdSourceClient(): CrowdSource | undefined {
+  const config = crowdSourceConfig();
+  if (!config.enabled) return undefined;
+  if (client) return client;
+  if (configurationError !== null) return undefined;
+
+  const serviceKey = config.serviceKey;
+  if (!serviceKey) {
+    configurationError = "CROWDSOURCE_SERVICE_KEY is not set";
+    logger.error("[CrowdSource] enabled but not configured", {
+      reason: configurationError,
+    });
+    return undefined;
+  }
+
+  try {
+    client = new CrowdSource({
+      serviceKey,
+      ...(config.baseUrl === undefined ? {} : { baseUrl: config.baseUrl }),
+    });
+    logger.info("[CrowdSource] client ready", { applicationId: client.applicationId });
+    return client;
+  } catch (error: unknown) {
+    // The SDK's configuration errors name which part of the key is wrong and never
+    // echo the secret, so the message is safe to log.
+    configurationError = error instanceof Error ? error.message : String(error);
+    logger.error("[CrowdSource] service key rejected", { reason: configurationError });
+    return undefined;
+  }
+}
+
+/** Test hook. Production builds the client once and keeps it for the process. */
+export function resetCrowdSourceClient(): void {
+  client = null;
+  configurationError = null;
+}

--- a/packages/backend/src/services/moderation/moderationEventStore.ts
+++ b/packages/backend/src/services/moderation/moderationEventStore.ts
@@ -1,0 +1,65 @@
+import type { ProcessedEventStore } from "@oxyhq/crowdsource-express";
+import ModerationEvent, {
+  MODERATION_EVENT_RETENTION_SECONDS,
+} from "../../models/ModerationEvent";
+
+/**
+ * The webhook dedupe store, in Mongo.
+ *
+ * `@oxyhq/crowdsource-express` defaults to an in-process store and says exactly
+ * when that is not enough: two instances behind a load balancer each keep their
+ * own, so a redelivery landing on the other instance is not deduplicated. Allo
+ * runs on ECS Fargate behind one ALB, so this is that case.
+ *
+ * The claim/release contract is the store's, and it is the right one. A row
+ * inserted BEFORE the handler runs means a concurrent redelivery cannot also run
+ * it; deleting that row when the handler THROWS means §10.9's retry schedule can
+ * still deliver the event later. Recording the id only after success would let two
+ * copies run at once; recording it before and never releasing would make a
+ * transient failure permanent and lose a decision silently.
+ */
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    Number((error as { code?: unknown }).code) === 11000
+  );
+}
+
+export function mongoProcessedEventStore(): ProcessedEventStore {
+  return {
+    /**
+     * True when this call took the claim.
+     *
+     * The insert IS the claim: `_id` is the event id and the index on it is
+     * unique, so the duplicate-key error is not an error condition to work around
+     * — it is the answer "somebody else has this event".
+     */
+    async claim(eventId: string): Promise<boolean> {
+      const now = new Date();
+      try {
+        await ModerationEvent.create({
+          _id: eventId,
+          state: "claimed",
+          receivedAt: now,
+          expiresAt: new Date(now.getTime() + MODERATION_EVENT_RETENTION_SECONDS * 1_000),
+        });
+        return true;
+      } catch (error: unknown) {
+        if (isDuplicateKeyError(error)) return false;
+        // Anything else — a lost connection, a failover — is NOT "already
+        // processed". Rethrowing makes the middleware answer non-2xx so the event
+        // stays on the sender's retry schedule; swallowing it here would answer
+        // 200 and retire a decision nobody ever handled.
+        throw error;
+      }
+    },
+
+    /** Give the claim back so a redelivery can be processed. */
+    async release(eventId: string): Promise<void> {
+      await ModerationEvent.deleteOne({ _id: eventId });
+    },
+  };
+}

--- a/packages/backend/src/services/moderation/reportStatus.ts
+++ b/packages/backend/src/services/moderation/reportStatus.ts
@@ -1,0 +1,68 @@
+import { ReportStatus, type ModerationLocalStatus } from "../../models/Report";
+
+/**
+ * The one place a report's two status axes are decided.
+ *
+ * §14.3 requires the legacy `status` field to keep working rather than being
+ * renamed destructively. Two status fields maintained by two call sites is how
+ * they drift, so both are derived here — from the decision, not from each other.
+ *
+ * The mapping is deliberately conservative about the difference between "a jury
+ * looked at this" and "this was a violation". `resolved` and `dismissed` are the
+ * two legacy values that carry a verdict, so only an outcome that IS a verdict may
+ * produce them:
+ *
+ * - `violation` → `resolved`: the case reached a conclusion Allo can act on.
+ * - `no_violation` → `dismissed`: the allegation was not upheld.
+ * - `insufficient_context`, `inconclusive`, `content_unavailable`, `duplicate`,
+ *   `escalated` → `reviewed`: a jury engaged and produced no verdict. Mapping any
+ *   of these to `dismissed` would turn "we could not tell" into "nothing was
+ *   wrong" — absence of consensus is neither guilt nor innocence.
+ *
+ * An outcome this version does not know also maps to `reviewed`: a newer
+ * CrowdSource must not be able to silently produce `dismissed` here.
+ */
+
+/**
+ * The outcome, as a string.
+ *
+ * Not typed as a closed union on purpose: this function is reached from the
+ * decision worker with a value that came off the wire, and §10.11 requires an
+ * unrecognised outcome to be handled rather than to throw.
+ */
+export function legacyStatusForOutcome(outcome: string): ReportStatus {
+  switch (outcome) {
+    case "violation":
+      return ReportStatus.RESOLVED;
+    case "no_violation":
+      return ReportStatus.DISMISSED;
+    default:
+      return ReportStatus.REVIEWED;
+  }
+}
+
+export interface ReportDecisionState {
+  status: ReportStatus;
+  localStatus: ModerationLocalStatus;
+}
+
+/**
+ * Decision statuses that end Allo's side of the case.
+ *
+ * A `provisional` decision leaves the report at `submitted`: §9.6 allows a later
+ * revision to supersede it, and a report Allo had already closed would have to be
+ * reopened. `superseded` is not here either — a superseded revision is not the
+ * current answer and must never be the one that closes the report.
+ */
+const TERMINAL_DECISION_STATUSES: ReadonlySet<string> = new Set(["final", "corrected"]);
+
+/** Both axes for a report whose case has been decided. */
+export function reportStateForDecision(input: {
+  outcome: string;
+  decisionStatus: string;
+}): ReportDecisionState {
+  return {
+    status: legacyStatusForOutcome(input.outcome),
+    localStatus: TERMINAL_DECISION_STATUSES.has(input.decisionStatus) ? "closed" : "submitted",
+  };
+}

--- a/packages/backend/src/services/moderation/reportTaxonomy.ts
+++ b/packages/backend/src/services/moderation/reportTaxonomy.ts
@@ -1,0 +1,80 @@
+import type { TaxonomyCode } from "@oxyhq/crowdsource-contracts";
+import { ReportCategory } from "../../models/Report";
+
+/**
+ * Allo's report categories, translated into CrowdSource's universal taxonomy.
+ *
+ * The categories on the left are what a reporter picked. The codes on the right
+ * are ALLEGATIONS (§6.2) — what is claimed, never what is true. A jury classifies
+ * the material itself and may confirm a different code entirely, and nothing about
+ * this table shortens that.
+ *
+ * ## Why this is versioned
+ *
+ * §6.4 requires every decision to record the policy version it was decided under,
+ * and this mapping is upstream of that: change what `spam` means and two reports
+ * filed a month apart are no longer the same allegation.
+ * {@link REPORT_TAXONOMY_VERSION} is stamped into the report metadata so a case
+ * can always be read back against the mapping that produced it. Bump it in the
+ * same change that alters a row.
+ *
+ * ## An allegation about an account, judged on a profile
+ *
+ * Worth stating because it changes how these codes are read in Allo and nowhere
+ * else. Every report Allo delivers is about an ACCOUNT, and the material a jury
+ * sees is that account's profile — never a conversation. So `harassment.targeted_abuse`
+ * here does not mean "these messages are abusive"; it means "this account is
+ * alleged to be abusive, and here is who they present themselves as". A jury that
+ * cannot substantiate the allegation from a profile alone is expected to say so,
+ * and `insufficient_context` is the correct outcome rather than a failure of the
+ * integration. That honesty is the point: the alternative is disclosing the
+ * conversation.
+ */
+export const REPORT_TAXONOMY_VERSION = "2026.07";
+
+const CATEGORY_TO_ALLEGATION: Readonly<Record<ReportCategory, TaxonomyCode>> = Object.freeze({
+  [ReportCategory.SPAM]: "integrity.spam",
+  [ReportCategory.HATE_SPEECH]: "hate.protected_targeting",
+  [ReportCategory.HARASSMENT]: "harassment.targeted_abuse",
+  /**
+   * `misinformation` has no home in §6.3's eleven families — the closest are
+   * `integrity.coordinated_manipulation` (a claim about organised behaviour) and
+   * `integrity.scam` (a claim about intent to defraud), neither of which is what a
+   * reporter clicking "misinformation" is alleging. `other.policy_specific` is a
+   * real code meaning "against the reporting application's rules, and the universal
+   * taxonomy has no name for it". Forcing it into `integrity.*` would tell a jury
+   * the reporter alleged something they did not.
+   */
+  [ReportCategory.MISINFORMATION]: "other.policy_specific",
+  /**
+   * The activity code, not the nudity code. They are different claims and Allo
+   * offers one category for both; the stronger code is the honest reading of what
+   * a reporter means by "explicit", and a jury that finds only nudity will say so.
+   * Alleging nudity when explicit activity was reported would understate the report
+   * and could route it to a lighter review.
+   */
+  [ReportCategory.EXPLICIT_CONTENT]: "sexual_content.explicit_activity",
+  [ReportCategory.OTHER]: "other.unclassifiable",
+});
+
+/**
+ * The allegation codes for a report's categories, deduplicated and ORDERED.
+ *
+ * Order is not cosmetic. Ingress fingerprints the whole envelope to detect §10.5's
+ * "same external id, different body", so a list whose order depended on how a
+ * client happened to send its categories would turn a legitimate outbox retry into
+ * a permanent 409 — days later, as a report silently stuck in a queue. Sorting
+ * makes the same report produce the same bytes every time.
+ */
+export function allegationsForCategories(
+  categories: readonly ReportCategory[],
+): TaxonomyCode[] {
+  const codes = new Set<TaxonomyCode>();
+  for (const category of categories) {
+    const code = CATEGORY_TO_ALLEGATION[category];
+    // A category the map does not cover cannot silently become nothing: a report
+    // with no allegation is not a report.
+    codes.add(code ?? "other.unclassifiable");
+  }
+  return Array.from(codes).sort();
+}

--- a/packages/backend/src/services/moderation/subjects/registry.ts
+++ b/packages/backend/src/services/moderation/subjects/registry.ts
@@ -1,0 +1,105 @@
+import { ReportedType } from "../../../models/Report";
+import { createUserSubjectProvider } from "./userSubject";
+import type { ModerationSubjectProvider } from "./types";
+
+/**
+ * Every noun Allo can send for review, and the §5.4 type it is.
+ *
+ * There is exactly one, and the reason is the product.
+ *
+ * ## This list decides DELIVERY, and nothing else
+ *
+ * A reported type with a provider here is sent to CrowdSource. A reported type
+ * WITHOUT one is still accepted by `POST /reports` and still stored — it simply
+ * never leaves. The registry is not an admission gate on the API. A gate that
+ * refused unwired types would mean an application breaks its own report surfaces
+ * on the day it adopts CrowdSource, and in Allo it would mean refusing the single
+ * most important report a messaging app receives: "this message is abusive".
+ * That report is still worth taking. It is just not reviewable by strangers.
+ *
+ * ## Why `message` has no provider, and would not gain one by trying harder
+ *
+ * Allo is end-to-end encrypted with the Signal Protocol. The server stores
+ * `Message.ciphertext` and, in `models/Device.ts`, ONLY public key material —
+ * `identityKeyPublic`, `signedPreKey.publicKey`, `preKeys[].publicKey`. No private
+ * key is ever sent to the server and the backend contains no decryption code at
+ * all. So for an encrypted message the server cannot produce a snapshot, and
+ * §5.6's requirement to pin "the exact version reported" cannot be satisfied.
+ *
+ * This is not a limitation to be engineered around. A design in which the server
+ * COULD produce that snapshot is a design in which the encryption promise is
+ * already false, and the moderation queue would be the reason it became false.
+ *
+ * There is a tempting loophole, and it is worth naming so nobody re-derives it as
+ * a feature. `Message.text` still exists as a deprecated migration field, and the
+ * client falls back to plaintext when a recipient has no registered device
+ * (`packages/frontend/stores/messagesStore.ts`). A `message` provider reading that
+ * field would technically work — and its coverage would be exactly inverted: it
+ * could only ever show a jury the messages that were NOT encrypted. Moderation
+ * would function solely in the app's least-protected corner, and the deprecated
+ * plaintext path would acquire a permanent reason to stay alive. The absence of a
+ * provider is what keeps that path deletable.
+ *
+ * ## Why `conversation` has no provider either
+ *
+ * A group's `name`, `description` and `avatar` are readable server-side, so this
+ * one is not blocked by cryptography — it is blocked by exposure. Allo has no
+ * public groups: `Conversation.type` is only `direct` or `group`, every route in
+ * `routes/conversations.ts` is scoped to `participants.userId`, and there is no
+ * discovery or join-by-link surface. That metadata is visible to MEMBERS only, so
+ * sending it to a randomly drawn jury would disclose private group content and,
+ * worse, the existence and membership of a private group to people outside it.
+ * "Public metadata" is a category Allo does not have.
+ *
+ * ## What is left, and why it is enough to be worth doing
+ *
+ * An account. Reports about a user carry no conversation material — a jury sees
+ * the profile and the allegation. Conduct across many reports is precisely the
+ * signal a participatory review is good at, and it is the one Allo can supply
+ * without weakening anything.
+ */
+const PROVIDERS: readonly ModerationSubjectProvider[] = Object.freeze([
+  createUserSubjectProvider(),
+]);
+
+const BY_REPORTED_TYPE: ReadonlyMap<string, ModerationSubjectProvider> = new Map(
+  PROVIDERS.map((provider) => [provider.reportedType, provider]),
+);
+
+/**
+ * The provider for a reported type, or `undefined` when it is not deliverable.
+ *
+ * The single authority on whether a report leaves this deployment.
+ * `ReportIntakeService` asks before queueing a delivery, and
+ * `EvidenceSnapshotService` asks again when it builds one; a type this returns
+ * `undefined` for is stored and never enqueued.
+ */
+export function subjectProviderFor(
+  reportedType: string,
+): ModerationSubjectProvider | undefined {
+  return BY_REPORTED_TYPE.get(reportedType);
+}
+
+/**
+ * The reported types wired to CrowdSource, as the registry itself sees them.
+ *
+ * Exists so a test can pin the set. That is not ceremony: the difference between a
+ * delivered type and a local-only one is invisible in a 201, so registering a
+ * provider — or forgetting to — is a change no response body would reveal. In Allo
+ * the assertion is a privacy control, not a coverage metric: the test that pins
+ * this set to exactly `['user']` is what would fail if someone ever wired
+ * `message` up, and that failure is the entire point.
+ */
+export function deliverableTypes(): string[] {
+  return Array.from(BY_REPORTED_TYPE.keys());
+}
+
+/**
+ * The types Allo accepts but never delivers, with the reason recorded on the row.
+ *
+ * Derived from the enum minus the registry, so adding a `ReportedType` without a
+ * provider cannot silently become an undocumented local-only type.
+ */
+export function localOnlyTypes(): string[] {
+  return Object.values(ReportedType).filter((type) => !BY_REPORTED_TYPE.has(type));
+}

--- a/packages/backend/src/services/moderation/subjects/registry.ts
+++ b/packages/backend/src/services/moderation/subjects/registry.ts
@@ -30,15 +30,37 @@ import type { ModerationSubjectProvider } from "./types";
  * COULD produce that snapshot is a design in which the encryption promise is
  * already false, and the moderation queue would be the reason it became false.
  *
- * There is a tempting loophole, and it is worth naming so nobody re-derives it as
- * a feature. `Message.text` still exists as a deprecated migration field, and the
- * client falls back to plaintext when a recipient has no registered device
- * (`packages/frontend/stores/messagesStore.ts`). A `message` provider reading that
- * field would technically work — and its coverage would be exactly inverted: it
- * could only ever show a jury the messages that were NOT encrypted. Moderation
- * would function solely in the app's least-protected corner, and the deprecated
- * plaintext path would acquire a permanent reason to stay alive. The absence of a
- * provider is what keeps that path deletable.
+ * ### The loophole, named so nobody re-derives it as a feature
+ *
+ * Someone reading `models/Message.ts` will see a `text` field sitting right there
+ * and wonder why nobody wired `message` up. This is the answer.
+ *
+ * `Message.text` still exists, commented "legacy plaintext, deprecated, for
+ * migration only" — but it is LIVE, not vestigial: `POST /api/messages` still
+ * accepts and stores it (`routes/messages.ts`), and the client silently falls back
+ * to plaintext when a recipient has no registered device or no preKeys
+ * (`packages/frontend/stores/messagesStore.ts`, the `catch` around
+ * `encryptMessageForRecipient`).
+ *
+ * So a `message` provider reading that field would technically WORK. It must still
+ * not exist, for two reasons:
+ *
+ * 1. **Its coverage would be exactly INVERTED.** It could only ever show a jury the
+ *    messages that were *not* encrypted — i.e. precisely those sent to users with
+ *    no registered device. Moderation would function solely in the app's
+ *    least-protected corner, and be blind everywhere the product's promise holds.
+ * 2. **It would make the plaintext path load-bearing.** The moment moderation
+ *    depended on `Message.text`, the deprecated fallback would acquire a permanent
+ *    reason to stay alive — deleting it would "break moderation". A design that
+ *    quietly weakens end-to-end encryption to feed a moderation queue is the
+ *    failure this whole file exists to avoid, and it would have arrived by
+ *    OMISSION rather than by anyone deciding to weaken anything.
+ *
+ * The absence of a provider is what keeps that path deletable. (The plaintext
+ * fallback is itself a live security issue — a silent downgrade in a product whose
+ * promise is end-to-end encryption — and is being fixed as its own change. It is
+ * deliberately untouched here: a moderation PR is the wrong place to alter the
+ * encryption path.)
  *
  * ## Why `conversation` has no provider either
  *
@@ -50,6 +72,35 @@ import type { ModerationSubjectProvider } from "./types";
  * sending it to a randomly drawn jury would disclose private group content and,
  * worse, the existence and membership of a private group to people outside it.
  * "Public metadata" is a category Allo does not have.
+ *
+ * ## Why a reporter's own consent does not unlock `message` either
+ *
+ * The obvious next idea: a reporter is a participant, so they hold the plaintext
+ * client-side and could attach an excerpt they consent to disclose. It is a real
+ * pattern and it is not implemented, for three reasons that have to be answered
+ * TOGETHER — the first two are policy, the third is a missing primitive:
+ *
+ * 1. **The other party did not consent.** A conversation excerpt is by definition
+ *    somebody else's words as well. One participant cannot consent on behalf of
+ *    the other, and a two-party conversation has no excerpt that discloses only
+ *    the reporter's half.
+ * 2. **§5.6 would be pinning something unverifiable.** The snapshot hash would
+ *    cover a client-supplied blob the server cannot check against anything,
+ *    because the server never had the plaintext. The identity binding proof would
+ *    attest that the reporter SENT it — not that it was ever SAID. A reporter
+ *    could fabricate an excerpt wholesale and the case would look every bit as
+ *    well-formed as a true one.
+ * 3. **Making (2) false needs cryptography Allo does not have.** The primitive is
+ *    sender-attributable franking (a per-message tag the recipient can prove the
+ *    sender produced, without the server reading the message). That is a change to
+ *    the messaging protocol, not to this module. Shipping a weaker version —
+ *    signing the excerpt with the reporter's key, say — produces evidence that
+ *    LOOKS binding and is not, which is worse than having none, because a jury
+ *    cannot tell the difference.
+ *
+ * So this stays a product-and-protocol decision. If it is ever taken, it belongs
+ * in a change that adds franking first; a provider added here without it would
+ * silently convert reason (2) into a case nobody can audit.
  *
  * ## What is left, and why it is enough to be worth doing
  *

--- a/packages/backend/src/services/moderation/subjects/types.ts
+++ b/packages/backend/src/services/moderation/subjects/types.ts
@@ -1,0 +1,106 @@
+/**
+ * The seam that makes this integration copyable.
+ *
+ * §5 opens by naming the mistake to avoid: designing moderation around `post`,
+ * `comment`, `room` or `product`. CrowdSource's side of that is already solved —
+ * the Case Envelope knows nothing about any of them, and `@oxyhq/crowdsource`
+ * composes one from a description of the material. What is left for an
+ * application is a translation problem, and this file is the whole of it:
+ *
+ *     "given one of MY nouns and its id, describe the material"
+ *
+ * Everything downstream — digests, resource ids, relations, principal bindings,
+ * the binding proof, the policy version, privacy terms, the idempotency key, the
+ * envelope itself — is composed by the SDK from that description and is IDENTICAL
+ * for every application and every subject type. So adding a subject type is one
+ * file implementing {@link ModerationSubjectProvider} plus one line in the
+ * registry.
+ *
+ * Two rules keep it that way, and both are load-bearing rather than stylistic:
+ *
+ * 1. **A provider returns a DESCRIPTION, never an envelope.** The types below are
+ *    the SDK's own input types, re-exported unchanged. A provider that built an
+ *    envelope would have to invent resource ids and principal refs, and §7.3's
+ *    dedup key is computed over exactly those — two reporters describing one
+ *    account would open two cases, and "one penalty per incident" would fail in
+ *    production with nothing failing in a test.
+ * 2. **A provider is pure translation with reads.** It fetches its own object and
+ *    returns; it does not decide whether to deliver, what the allegation is, or
+ *    what happens to the report. Those belong to callers that are shared.
+ *
+ * ## In Allo there is a third rule, and it outranks both
+ *
+ * **A provider may only describe material the server can legitimately read.** Allo
+ * is end-to-end encrypted; the server holds ciphertext and public keys. A provider
+ * is the ONLY place where a decision to disclose could be made, so it is the place
+ * the constraint has to be stated. A provider that reached for message plaintext
+ * would not be a feature — it would be the point at which the encryption promise
+ * quietly stopped being true.
+ */
+
+import type { ContextInput, ReportSubjectInput, ResourceInput } from "@oxyhq/crowdsource";
+
+/**
+ * The SDK's resource description, unchanged.
+ *
+ * Re-exported as a type alias so a provider imports the vocabulary from this seam
+ * rather than from several places — but it IS the SDK's type, not a local
+ * restatement of it. A resource type added to the contract becomes available to
+ * every provider the moment the dependency is bumped.
+ */
+export type ModerationResource = ResourceInput;
+export type ModerationContextResource = ContextInput;
+
+/**
+ * One reported object, described.
+ *
+ * `content` is required because a report with no material is a question a jury
+ * cannot answer. An application that cannot produce the material for one of its
+ * nouns should not register a provider for it — see the registry, where this is
+ * the governing fact rather than an edge case.
+ */
+export interface ModerationSubjectSnapshot {
+  /** Identity, type and author of the reported object (§5.1 `subject`). */
+  readonly subject: ReportSubjectInput;
+  /** The reported material itself. A string is shorthand for plain text. */
+  readonly content: string | ModerationResource;
+  /** Media carried BY the subject. */
+  readonly attachments?: readonly ModerationResource[];
+  /**
+   * Surrounding material a jury needs to judge fairly. Context, not extra
+   * exposure: §9.1 keeps a reviewer's view to the minimum that makes the question
+   * answerable.
+   */
+  readonly context?: readonly ModerationContextResource[];
+  /**
+   * SHA-256 of the exact representation being reviewed, stored on the local
+   * report so a decision about an older version stays identifiable as such
+   * (§5.6). Computed by `EvidenceSnapshotService`, not by the provider — one
+   * definition of "the hash of this snapshot" for every subject type.
+   */
+  readonly snapshotHash?: string;
+}
+
+/**
+ * Translates one of the application's nouns into universal material.
+ *
+ * `subjectType` is declared on the provider rather than returned per snapshot
+ * because it is a property of the noun (§5.4): every Allo account report is an
+ * `identity.profile`. Keeping it here means the registry can answer "what does
+ * this application report?" without loading a single object.
+ */
+export interface ModerationSubjectProvider {
+  /** The application's own name for the noun, as it arrives on a report. */
+  readonly reportedType: string;
+  /** §5.4's namespaced subject type, or `custom.<organization>.<object_type>`. */
+  readonly subjectType: string;
+  /**
+   * Describes the object, or returns `null` when it no longer exists.
+   *
+   * `null` is not a failure. An account deleted between the report and its
+   * delivery is ordinary, and it is the caller's job to decide what that means — a
+   * provider that threw would make deletion look like an outage and be retried
+   * for days.
+   */
+  snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null>;
+}

--- a/packages/backend/src/services/moderation/subjects/userSubject.ts
+++ b/packages/backend/src/services/moderation/subjects/userSubject.ts
@@ -1,0 +1,107 @@
+import { oxyClient } from "@oxyhq/core";
+import type { User } from "@oxyhq/core";
+import { isOxyUserNotFound } from "../../../utils/oxyUserDisplay";
+import type { ModerationSubjectProvider, ModerationSubjectSnapshot } from "./types";
+
+/**
+ * A reported account, as universal material (§5.3 `profile`).
+ *
+ * This is the ONLY subject Allo can send for review, and everything about it is
+ * shaped by that. Oxy owns identity, so the material comes from Oxy and is passed
+ * through unchanged. Nothing here reads a conversation, a message, a participant
+ * list or a ciphertext — a jury sees the account's own public self-presentation
+ * and the reporter's allegation, and that is the entire disclosure.
+ *
+ * `name.displayName` is read directly and never recomposed from `first`/`last` or
+ * from the username: what a jury judges has to be what the account actually shows,
+ * and a name this code assembled would be evidence Allo invented. A profile with
+ * no display name is normal, and every field of §5.3's `profile` resource is
+ * optional for exactly that reason, so nothing here substitutes a handle for a
+ * missing name — the handle travels separately, as a claim.
+ */
+
+/** §5.3 `profile.claims`: bounded, flat, scalar. */
+const MAX_CLAIM_LENGTH = 200;
+
+function claim(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, MAX_CLAIM_LENGTH) : undefined;
+}
+
+/**
+ * The identity source, injectable so a test can describe an account without a
+ * network. Production passes the SDK singleton.
+ */
+export interface UserSubjectDependencies {
+  readonly getUserById: (userId: string, options?: { cache?: boolean }) => Promise<User>;
+}
+
+export function createUserSubjectProvider(
+  dependencies: UserSubjectDependencies = {
+    getUserById: (userId, options) => oxyClient.getUserById(userId, options),
+  },
+): ModerationSubjectProvider {
+  return {
+    reportedType: "user",
+    subjectType: "identity.profile",
+
+    async snapshot(reportedId: string): Promise<ModerationSubjectSnapshot | null> {
+      let user: User;
+      try {
+        /**
+         * `cache: false`: a jury must review the profile as it is NOW, and the
+         * SDK's five-minute GET cache would otherwise let a stale display name or
+         * bio be the thing that was reviewed. A moderation snapshot is a
+         * consistency-critical read.
+         */
+        user = await dependencies.getUserById(reportedId, { cache: false });
+      } catch (error) {
+        /**
+         * A deleted or unknown account is `null`, not a throw — the caller treats
+         * that as "there is nothing to review", whereas a thrown error is retried
+         * as an outage. Every OTHER failure (network, 5xx, auth) must keep
+         * throwing, so a transient Oxy problem is retried instead of being
+         * recorded as a report about an account that does not exist.
+         */
+        if (isOxyUserNotFound(error)) return null;
+        throw error;
+      }
+
+      const displayName = claim(user.name?.displayName);
+      const bio = claim(user.description ?? user.bio);
+      const username = claim(user.username);
+
+      /**
+       * Claims, not evidence. A username and a website are what the account
+       * asserts about itself; they matter for an impersonation allegation and are
+       * exactly the fields §5.3 means by `claims`.
+       */
+      const claims: Record<string, string> = {};
+      if (username !== undefined) claims.username = username;
+      const website = claim(user.website);
+      if (website !== undefined) claims.website = website;
+
+      return {
+        subject: {
+          externalId: reportedId,
+          type: "identity.profile",
+          /**
+           * No `permalink`. Allo has no public profile page — `app/(chat)/u` is an
+           * in-app route behind authentication, so any URL emitted here would be
+           * one a reviewer cannot open and Allo invented. `permalink` is optional
+           * precisely so nobody has to make one up.
+           */
+          author: { oxyUserId: reportedId },
+        },
+        content: {
+          type: "profile",
+          data: {
+            ...(displayName === undefined ? {} : { displayName }),
+            ...(bio === undefined ? {} : { bio }),
+            ...(Object.keys(claims).length > 0 ? { claims } : {}),
+          },
+        },
+      };
+    },
+  };
+}

--- a/packages/backend/vitest.config.mts
+++ b/packages/backend/vitest.config.mts
@@ -10,6 +10,14 @@ export default defineConfig({
     environment: "node",
     setupFiles: [path.resolve(backendRoot, "src/__tests__/setup.ts")],
     include: [path.resolve(backendRoot, "src/__tests__/**/*.test.ts")],
+    /**
+     * A real MongoDB replica set for the whole run. Booting one costs a few
+     * seconds once; not having one cost a bug that broke every report submission
+     * while 62 tests passed.
+     */
+    globalSetup: [path.resolve(backendRoot, "vitest.globalSetup.ts")],
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
   },
   resolve: {
     alias: {

--- a/packages/backend/vitest.config.mts
+++ b/packages/backend/vitest.config.mts
@@ -1,0 +1,19 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+const backendRoot = import.meta.dirname;
+
+export default defineConfig({
+  root: backendRoot,
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: [path.resolve(backendRoot, "src/__tests__/setup.ts")],
+    include: [path.resolve(backendRoot, "src/__tests__/**/*.test.ts")],
+  },
+  resolve: {
+    alias: {
+      "@allo/shared-types": path.resolve(backendRoot, "../shared-types/src"),
+    },
+  },
+});

--- a/packages/backend/vitest.globalSetup.ts
+++ b/packages/backend/vitest.globalSetup.ts
@@ -1,0 +1,30 @@
+import { MongoMemoryReplSet } from "mongodb-memory-server";
+
+/**
+ * One MongoDB replica set for the whole suite.
+ *
+ * A replica SET rather than a standalone, because the properties this
+ * integration rests on only exist there: multi-document transactions (a report
+ * and its outbox row commit together, or neither does) and the unique indexes
+ * that make a retry idempotent.
+ *
+ * This exists because a mocked model hid a 100%-reproducible bug. The outbox
+ * write named `createdAt`/`updatedAt` in `$setOnInsert` while the schema
+ * declared `{ timestamps: true }`; a mocked `updateOne` accepts any update
+ * document, so every test passed while the real write failed for every report
+ * ever submitted. A mock can be made to agree with any claim, which is exactly
+ * why the claims that matter must not be tested against one.
+ */
+let replicaSet: MongoMemoryReplSet | null = null;
+
+export async function setup(): Promise<void> {
+  replicaSet = await MongoMemoryReplSet.create({
+    replSet: { count: 1, storageEngine: "wiredTiger" },
+  });
+  process.env.ALLO_TEST_MONGODB_URI = replicaSet.getUri();
+}
+
+export async function teardown(): Promise<void> {
+  await replicaSet?.stop();
+  replicaSet = null;
+}


### PR DESCRIPTION
Integrates Allo with CrowdSource participatory moderation. The design question this had to answer first was **what can honestly be reviewed at all**, and the answer shapes everything else.

## Only `user` is reviewable, and that is a finding rather than a limitation

Allo is end-to-end encrypted with the Signal Protocol:

- `packages/backend/src/models/Device.ts` stores **only public key material** — `identityKeyPublic`, `signedPreKey.publicKey`, `preKeys[].publicKey`. No private key is ever sent to the server.
- The backend contains **zero decryption code**. Every `decrypt` occurrence is a comment saying the client does it (`routes/messages.ts:217,264`; `utils/signalProtocol.ts:4-5`).

So for an encrypted message the server cannot produce a snapshot, and §5.6's requirement to pin "the exact version reported" cannot be satisfied. **A design in which the server could do it is a design in which the encryption promise is already false.**

`conversation` is excluded for a different reason: exposure, not cryptography. Allo has no public groups — `Conversation.type` is only `direct` or `group`, every route in `routes/conversations.ts` is scoped to `participants.userId`, and there is no discovery surface. Group metadata is member-only, so sending it to a randomly drawn jury discloses private group content **and** the existence and membership of a private group. Two leaks, not one.

**Both are still ACCEPTED and stored**, with the reason recorded on the row. Refusing them would tell a user being harassed that their report is invalid, when what is true is that strangers cannot be shown the evidence.

Reporter-consent disclosure is described in `subjects/registry.ts` and deliberately **not** implemented — the other party never consented, §5.6 would pin a client-supplied blob the server cannot verify (the binding proof attests the reporter *sent* it, not that it was ever *said*), and closing that needs sender-attributable franking, a messaging-protocol change. A weaker version produces evidence that looks binding and is not.

## Live security issue found here, deliberately NOT fixed in this PR

While establishing the above I found a real defect in Allo's encryption path, unrelated to moderation:

- **The client silently falls back to plaintext** when the recipient has no registered device or no preKeys (`packages/frontend/stores/messagesStore.ts`, the `catch` around `encryptMessageForRecipient`).
- **`POST /api/messages` still accepts and stores `text`** (`routes/messages.ts`) despite the schema calling the field deprecated migration-only.

In a product whose entire promise is end-to-end encryption, a *silent* downgrade is the worst possible shape — the user is told nothing and the failure is invisible from both ends. **This PR does not touch it.** It needs its own change, its own tests and its own review; a moderation PR is the wrong place to alter the encryption path. It is being raised as separate work.

It is also exactly why `message` has no provider: a provider reading `Message.text` would technically work, its coverage would be **exactly inverted** (only ever showing a jury the messages that were *not* encrypted), and moderation depending on that field would give the deprecated plaintext path a permanent reason to stay alive. That is E2EE weakened by omission rather than by decision. The full argument is a doc comment on `subjects/registry.ts`.

## Invariants

- **Nothing enqueued that is not already in the outbox, in the same transaction.** `enqueueModerationOutboxEvent` requires a session *and* asserts it is in a transaction — a bare `startSession()` type-checks and commits on its own.
- **Webhook receiver ahead of `express.json`** (`server.ts`), asserting `typeof req.body === 'undefined'` inside the route so a future edit that moves it below the parser fails naming the cause instead of looking like a bad secret.
- **No `CROWDSOURCE_APP_ID`.** The applicationId comes off the service credential; a configurable one is the IDOR the tenancy model exists to prevent. A test asserts setting it changes nothing.
- **No plaintext, key or ciphertext in any envelope, log, metric or audit row.** Pinned as a property of the serialised snapshot.
- **Observe mode**, and Allo has no platform-level sanction primitive — `Block`/`Restrict` are per-user relations. The decision worker records the action it *would* take and never sets `enforcedAt`, in `automatic` mode too.

## A bug this PR shipped, and the blind spot that hid it

The first two commits contained a 100%-reproducible failure, inherited from the Mention template this was adapted from and caught by the `shared-package` agent: `enqueueModerationOutboxEvent` named `createdAt`/`updatedAt` in `$setOnInsert` while the schema declares `{ timestamps: true }`, so Mongo rejected the whole write (`Updating the path 'updatedAt' would create a conflict at 'updatedAt'`). Because that write is inside `createReport`'s transaction, the abort took the `Report` with it — **every `POST /api/reports` would have failed, from the first one.**

Reproduced against a real replica set on this repo's own mongoose (9.7.4) before changing anything: the bare write failed, the transaction aborted with **0 reports and 0 outbox rows**, and omitting both fields committed while `timestamps: true` still set them.

**62 tests passed against it**, because the intake tests mock the outbox model and a mocked `updateOne` accepts any update document. So the fix includes the harness that makes this class of bug impossible to miss again:

- `vitest.globalSetup.ts` boots a real `MongoMemoryReplSet` for the suite.
- `reportIntakeMongo.test.ts` asserts **persisted state**, not which functions were called.
- `src/__tests__/setup.ts` no longer mocks mongoose's connection.

## Verification

- **69 tests**, `tsc --noEmit` clean, `bun run build` green across all packages.
- **5 mutations, all killed.** Each verified *applied* (marker present, file actually changed) and *type-clean* **before** the test run, so every failure is behavioural rather than a compile error:

| Mutation | Killed by |
|---|---|
| drop the `inTransaction()` guard | 2 tests |
| drop the session from the outbox write | 2 tests, across both intake and outbox files |
| enqueue delivery with no subject provider | `stores a type with no provider and enqueues NOTHING` |
| remove `assertRawBody` from the route | `refuses, naming the cause, when a body parser ran first` |
| wire `message` up as deliverable | `delivers exactly one subject type: the account` |

The last one is the privacy control: whether a reported type leaves the deployment is invisible in a 201 by design, so `deliverableTypes()` is pinned to exactly `['user']` with a vacuity floor requiring every `ReportedType` to be accounted for. The real-Mongo test was verified non-vacuous the same way — re-introducing the timestamps bug produced 5 failures with the exact `MongoServerError`.

## CI

Allo had no workflow running tests or `tsc`, so everything above executed nowhere on a PR — including the `deliverableTypes()` test, which is the only thing that fails if someone wires `message` up. This PR adds a minimal one (`.github/workflows/ci.yml`): install, typecheck, backend tests. No coverage thresholds, no matrix.

Both steps were verified to actually FAIL before being trusted, because a gate that cannot distinguish success from failure is worse than no gate — wiring `message` up as deliverable exits 1 with two failures, and a deliberate type error exits 2 naming the file. First run on this PR: **green in 44s, all steps executed, 69 tests**, with the MongoDB binary cached for subsequent runs.

The typecheck is scoped to `packages/backend/tsconfig.json`, not the root — the root config is a composite project-reference config and reports hundreds of pre-existing TS6305 errors for the frontend on a clean checkout.

**`auto-project.yml` is untouched and still fails.** It has failed on every Allo PR since at least 2026-07-17 (`Could not resolve to a ProjectV2 with the number 14`), is an org project-board config issue, and is not related to this change — fixing it inside a moderation PR would be the wrong place.

## Not included

- **No frontend report UI.** Allo had no report surface at all, so this adds the backend one (`POST /api/reports`, `GET /api/reports/mine`). Where a "Report" affordance belongs in a chat app is a product decision.
- `@oxyhq/crowdsource-app` was unpublished when this was built, so it consumes `@oxyhq/crowdsource` / `-contracts` / `-express` at `0.3.0` directly (contracts declared explicitly — it is a peer, and bun installs a missing peer silently). The plumbing is kept in files that map 1:1 onto the package's surface, so migrating is an import change plus deletions, and is deliberately left to its own PR.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
