### PR TITLE
fix(chat): the unread badge counts the viewer's own mail

### DIFF
--- a/packages/frontend/__tests__/conversationsUnread.test.ts
+++ b/packages/frontend/__tests__/conversationsUnread.test.ts
@@ -1,0 +1,77 @@
+import { viewerUnreadCount } from '@/lib/unreadCount';
+
+/**
+ * `unreadCounts` is a per-participant map, not a conversation total. The backend
+ * increments an entry for every participant except the sender and zeroes only the
+ * entry of whoever reads, so a conversation in normal use carries a non-zero count
+ * for more than one person at once.
+ *
+ * That is the shape these tests are built around: a case where only the viewer has
+ * unread mail cannot tell "read the viewer's entry" apart from "add the entries up",
+ * because with every other entry at zero the sum IS the viewer's count. Every
+ * assertion below that guards the fix therefore puts a non-zero count on both sides.
+ */
+
+const VIEWER = 'oxy-viewer-1';
+const OTHER = 'oxy-other-2';
+const THIRD = 'oxy-third-3';
+
+describe('viewerUnreadCount', () => {
+  describe('reads the viewer’s own entry, not the conversation total', () => {
+    it('ignores the other participant’s unread mail in a direct chat', () => {
+      // The viewer has 2 unread; the other side has 5 unread of the viewer's own
+      // messages. Summing would report 7.
+      expect(viewerUnreadCount({ [VIEWER]: 2, [OTHER]: 5 }, VIEWER)).toBe(2);
+    });
+
+    it('ignores every other member’s unread mail in a group', () => {
+      expect(
+        viewerUnreadCount({ [VIEWER]: 1, [OTHER]: 9, [THIRD]: 4 }, VIEWER)
+      ).toBe(1);
+    });
+
+    it('reports zero for a viewer who is caught up while others are not', () => {
+      // The case that actually reaches a user as a phantom badge: nothing to read,
+      // but the other side has a backlog.
+      expect(viewerUnreadCount({ [VIEWER]: 0, [OTHER]: 6 }, VIEWER)).toBe(0);
+    });
+
+    it('reports zero for a viewer with no entry at all while others have one', () => {
+      // A participant who has never had a message counted for them has no key.
+      expect(viewerUnreadCount({ [OTHER]: 6 }, VIEWER)).toBe(0);
+    });
+
+    it('gives each viewer their own count from one shared map', () => {
+      const counts = { [VIEWER]: 2, [OTHER]: 5 };
+      expect(viewerUnreadCount(counts, VIEWER)).toBe(2);
+      expect(viewerUnreadCount(counts, OTHER)).toBe(5);
+    });
+  });
+
+  describe('accepts both wire shapes the backend is typed for', () => {
+    it('reads a Map, not just a plain object', () => {
+      const counts = new Map([
+        [VIEWER, 2],
+        [OTHER, 5],
+      ]);
+      expect(viewerUnreadCount(counts, VIEWER)).toBe(2);
+    });
+
+    it('reads a plain object, the shape that actually arrives over the wire', () => {
+      expect(viewerUnreadCount({ [VIEWER]: 2, [OTHER]: 5 }, VIEWER)).toBe(2);
+    });
+  });
+
+  describe('declines to guess when it cannot identify the viewer', () => {
+    it('is zero, not the total, before the session restores', () => {
+      // An Oxy session can take seconds to restore. Falling back to the sum here
+      // is what the badge used to do for everyone.
+      expect(viewerUnreadCount({ [VIEWER]: 2, [OTHER]: 5 }, undefined)).toBe(0);
+    });
+
+    it('is zero for a conversation with no counts recorded', () => {
+      expect(viewerUnreadCount(undefined, VIEWER)).toBe(0);
+      expect(viewerUnreadCount({}, VIEWER)).toBe(0);
+    });
+  });
+});

--- a/packages/frontend/app/(chat)/index.tsx
+++ b/packages/frontend/app/(chat)/index.tsx
@@ -464,13 +464,31 @@ export default function ConversationsList() {
     const leftSwipeAction = useConversationSwipePreferencesStore(state => state.leftSwipeAction);
     const rightSwipeAction = useConversationSwipePreferencesStore(state => state.rightSwipeAction);
 
+    // Get current user ID and oxy services
+    const { user, oxyServices } = useOxy();
+    const currentUserId = user?.id;
+
     // Offline-first: load cached conversations instantly, then fetch from API in parallel
-    // Cache shows data immediately; API fetch updates in the background
+    // Cache shows data immediately; API fetch updates in the background.
+    //
+    // The fetch waits for the viewer's id because every conversation's unread
+    // badge is that viewer's own entry in a per-participant map. Restoring an
+    // Oxy session can take seconds, so `currentUserId` is a dependency rather
+    // than a read taken once: fetching before it lands would paint a list of
+    // zeroes over the cache and never recover.
     useEffect(() => {
-        // Fire both immediately — cache resolves fast, API runs in background
         loadCachedConversations();
-        fetchConversations();
-    }, [loadCachedConversations, fetchConversations]);
+        if (currentUserId) {
+            fetchConversations(currentUserId);
+        }
+    }, [loadCachedConversations, fetchConversations, currentUserId]);
+
+    // Pull-to-refresh, for the same reason, is a no-op until the viewer is known.
+    const handleRefresh = useCallback(() => {
+        if (currentUserId) {
+            refreshConversations(currentUserId);
+        }
+    }, [refreshConversations, currentUserId]);
 
     // Search state
     const [searchQuery, setSearchQuery] = useState('');
@@ -506,10 +524,6 @@ export default function ConversationsList() {
         const chatMatch = pathname?.match(/\/(chat)\/([^/]+)$/);
         return cMatch?.[1] || chatMatch?.[2] || null;
     }, [pathname]);
-
-    // Get current user ID and oxy services
-    const { user, oxyServices } = useOxy();
-    const currentUserId = user?.id;
 
     // Multi-selection state
     const [selectedConversationIds, setSelectedConversationIds] = useState<Set<string>>(() => new Set());
@@ -1160,7 +1174,7 @@ export default function ConversationsList() {
                         refreshControl={
                             <RefreshControl
                                 refreshing={isRefreshing}
-                                onRefresh={refreshConversations}
+                                onRefresh={handleRefresh}
                                 tintColor={theme.colors.primary}
                                 colors={[theme.colors.primary]}
                             />

--- a/packages/frontend/lib/unreadCount.ts
+++ b/packages/frontend/lib/unreadCount.ts
@@ -1,0 +1,29 @@
+import type { ConversationDto } from '@allo/shared-types';
+
+/**
+ * A conversation's unread count for ONE viewer.
+ *
+ * `unreadCounts` is keyed by user id and carries an entry per participant: the
+ * backend increments every participant except the sender, and zeroes only the
+ * one who reads. So the map holds other people's unread mail alongside the
+ * viewer's, and any reduction over its values reports the whole conversation's
+ * backlog as if it were theirs — for a two-person chat, their unread plus the
+ * unread of everything they sent.
+ *
+ * A viewer we cannot name yet has no entry to read, so the count is 0 rather
+ * than a guess; the list refetches once the id arrives.
+ *
+ * The backend serializes the field as a JSON object but types it as
+ * `Map | Record` to match its lean/`toObject()` shapes, so both are handled.
+ */
+export function viewerUnreadCount(
+  unreadCounts: ConversationDto['unreadCounts'],
+  viewerId: string | undefined
+): number {
+  if (!unreadCounts || !viewerId) return 0;
+  const count =
+    unreadCounts instanceof Map
+      ? unreadCounts.get(viewerId)
+      : unreadCounts[viewerId];
+  return count || 0;
+}

--- a/packages/frontend/stores/conversationsStore.ts
+++ b/packages/frontend/stores/conversationsStore.ts
@@ -9,22 +9,7 @@ import {
   storeConversationsLocally,
   getMessagesLocally,
 } from '@/lib/offlineStorage';
-
-/**
- * Sum a conversation's per-user unread counts. The backend serializes
- * `unreadCounts` as a JSON object but types it as `Map | Record` to match its
- * lean/`toObject()` shapes, so both are handled.
- */
-function sumUnreadCounts(
-  unreadCounts: ConversationDto['unreadCounts']
-): number {
-  if (!unreadCounts) return 0;
-  const values =
-    unreadCounts instanceof Map
-      ? Array.from(unreadCounts.values())
-      : Object.values(unreadCounts);
-  return values.reduce((sum, count) => sum + (count || 0), 0);
-}
+import { viewerUnreadCount } from '@/lib/unreadCount';
 
 /**
  * Format last message with sender name for group conversations
@@ -154,8 +139,8 @@ interface ConversationsState {
 
   // Async actions
   loadCachedConversations: () => Promise<void>;
-  fetchConversations: () => Promise<void>;
-  refreshConversations: () => Promise<void>;
+  fetchConversations: (currentUserId: string) => Promise<void>;
+  refreshConversations: (currentUserId: string) => Promise<void>;
   markAsRead: (id: string) => void;
 
   // Selectors (computed values)
@@ -296,7 +281,7 @@ export const useConversationsStore = create<ConversationsState>()(
     },
 
     // Async actions
-    fetchConversations: async () => {
+    fetchConversations: async (currentUserId) => {
       // Only show loading skeleton if we have NO data at all (first launch, no cache)
       const hasData = get().conversations.length > 0 || get().hasFetchedOnce;
       set({ isLoading: !hasData, error: null });
@@ -427,7 +412,7 @@ export const useConversationsStore = create<ConversationsState>()(
             lastMessageText,
             lastMessageSenderId,
             { type: conv.type || 'direct', participants },
-            undefined // currentUserId not available here, but function handles it gracefully
+            currentUserId
           );
 
           return {
@@ -436,7 +421,7 @@ export const useConversationsStore = create<ConversationsState>()(
             name: conv.name || (conv.type === 'group' ? 'Group Chat' : 'Direct Chat'),
             lastMessage: formattedLastMessage,
             timestamp: conv.lastMessageAt ? new Date(conv.lastMessageAt).toISOString() : new Date().toISOString(),
-            unreadCount: sumUnreadCounts(conv.unreadCounts),
+            unreadCount: viewerUnreadCount(conv.unreadCounts, currentUserId),
             avatar: conv.avatar,
             theme: conv.theme, // Color theme ID
             participants,
@@ -463,10 +448,10 @@ export const useConversationsStore = create<ConversationsState>()(
       }
     },
 
-    refreshConversations: async () => {
+    refreshConversations: async (currentUserId) => {
       set({ isRefreshing: true, error: null });
       try {
-        await get().fetchConversations();
+        await get().fetchConversations(currentUserId);
         set({ isRefreshing: false });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Failed to refresh conversations';


### PR DESCRIPTION
## Summary
- `unreadCounts` is a per-participant map (`userId -> count`); the chat list was summing ALL entries into one badge, so a viewer saw their own unread count plus everyone else's.
- The list now reads the viewer's own entry via `viewerUnreadCount()`. This required threading the viewer id into `fetchConversations`/`refreshConversations`, and the list now waits for `currentUserId` before fetching.

## Test plan
- [x] `bun run test` (packages/frontend) — 23 passed, 2 suites (14 pre-existing signalProtocol + 9 new conversationsUnread)
- [x] `bunx tsc --noEmit -p packages/frontend/tsconfig.json` — only pre-existing expo-router typed-route errors remain, none in the changed files
- [x] `bunx eslint` on the changed files — 0 errors, 7 pre-existing warnings in `conversationsStore.ts`