### PR TITLE
test(moderation): pin the webhook raw-body guard against the silent-success config

### DIFF
--- a/packages/backend/src/__tests__/routes/crowdSourceWebhookMount.test.ts
+++ b/packages/backend/src/__tests__/routes/crowdSourceWebhookMount.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "crypto";
 import express from "express";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,12 +35,72 @@ import { createCrowdSourceWebhookRoutes } from "../../routes/crowdSourceWebhook"
 
 const SECRET = "a-test-webhook-secret-long-enough";
 
-function appWith(options: { parseJsonFirst: boolean }): express.Express {
+/**
+ * How the parser is configured, which turns out to decide the failure mode.
+ *
+ * - `none` — the webhook router is mounted first. Correct.
+ * - `plain` — `express.json()` ahead of it, exactly as `server.ts` configures it
+ *   today. `req.rawBody` is never set, so the SDK finds a parsed `req.body` and
+ *   REFUSES. Loud.
+ * - `verify-buffer` — `express.json({ verify })` ahead of it, keeping the raw
+ *   bytes as a Buffer on `req.rawBody`. The SDK's `readRawBody` PREFERS that
+ *   Buffer over reading the stream, so it verifies happily and the late mount
+ *   SUCCEEDS. Silent. Allo does not configure this today, and nothing stops
+ *   someone adding it — Alia has exactly this shape.
+ */
+type ParserMode = "none" | "plain" | "verify-buffer";
+
+function appWith(mode: ParserMode): express.Express {
   const app = express();
-  if (options.parseJsonFirst) app.use(express.json());
+  if (mode === "plain") {
+    app.use(express.json());
+  } else if (mode === "verify-buffer") {
+    app.use(
+      express.json({
+        verify: (req, _res, buf) => {
+          Reflect.set(req, "rawBody", buf);
+        },
+      }),
+    );
+  }
   app.use("/webhooks", createCrowdSourceWebhookRoutes());
-  if (!options.parseJsonFirst) app.use(express.json());
+  if (mode === "none") app.use(express.json());
   return app;
+}
+
+/**
+ * A correctly signed, schema-valid delivery, so a request can get all the way to
+ * a handler.
+ *
+ * The envelope is built out in full — `createdAt`, `organizationId` and
+ * `applicationId` are required by `WebhookEventEnvelopeSchema` — because a
+ * payload that merely LOOKS like an event is refused at the schema step with a
+ * 400, which would make the "late mount succeeds silently" test pass for the
+ * wrong reason. The vacuity guard below caught exactly that.
+ */
+function signedDelivery(secret: string) {
+  const body = {
+    id: "evt_signed_1",
+    type: "case.created",
+    createdAt: new Date().toISOString(),
+    organizationId: "org_1",
+    applicationId: "app_1",
+    data: { caseId: "case_1" },
+  };
+  const raw = JSON.stringify(body);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = createHmac("sha256", secret)
+    .update(`${timestamp}.${raw}`)
+    .digest("hex");
+  return {
+    raw,
+    headers: {
+      "content-type": "application/json",
+      "x-crowdsource-event-id": "evt_signed_1",
+      "x-crowdsource-timestamp": timestamp,
+      "x-crowdsource-signature": `v1=${signature}`,
+    },
+  };
 }
 
 describe("crowdsource webhook mount order", () => {
@@ -56,7 +117,7 @@ describe("crowdsource webhook mount order", () => {
   });
 
   it("refuses, naming the cause, when a body parser ran first", async () => {
-    const response = await request(appWith({ parseJsonFirst: true }))
+    const response = await request(appWith("plain"))
       .post("/webhooks/crowdsource")
       .set("content-type", "application/json")
       .send({ id: "evt_1", type: "case.decided" });
@@ -80,7 +141,7 @@ describe("crowdsource webhook mount order", () => {
      * and that is the point: it got far enough to be verified, which is exactly
      * what mounting ahead of the parser buys.
      */
-    const response = await request(appWith({ parseJsonFirst: false }))
+    const response = await request(appWith("none"))
       .post("/webhooks/crowdsource")
       .set("content-type", "application/json")
       .send({ id: "evt_1", type: "case.decided" });
@@ -100,11 +161,61 @@ describe("crowdsource webhook mount order", () => {
     delete process.env.CROWDSOURCE_WEBHOOK_SECRET;
     resetCrowdSourceConfigForTests();
 
-    const response = await request(appWith({ parseJsonFirst: false }))
+    const response = await request(appWith("none"))
       .post("/webhooks/crowdsource")
       .send({ id: "evt_1" });
 
     expect(response.status).toBe(404);
+  });
+
+  it("refuses a late mount even when the parser kept the raw bytes", async () => {
+    /**
+     * The case where the SDK's own protection DISAPPEARS, and therefore the case
+     * `assertRawBody` exists for.
+     *
+     * `readRawBody` in `@oxyhq/crowdsource-express` resolves the signed bytes in
+     * order: a Buffer on `req.rawBody` FIRST, then a Buffer `req.body`, then a
+     * throw if `req.body` is anything else, and only then the stream. With
+     * `express.json({ verify })` the first branch hits — so a router mounted
+     * AFTER the parser verifies successfully against parser-supplied bytes and
+     * records the decision. No error, no log line, nothing to notice.
+     *
+     * Allo's `server.ts` uses a plain `express.json()` today, so it lands in the
+     * throwing branch instead. That is a property of unrelated middleware, not of
+     * this integration, and it can change in a commit that never mentions
+     * moderation. Which is why the guard asserts `typeof req.body === 'undefined'`
+     * — that proves NO PARSER RAN, and holds in both configurations — rather than
+     * asserting that verification failed, which only holds in one.
+     *
+     * The delivery below is correctly signed, so without the guard this request
+     * would be accepted.
+     */
+    const { raw, headers } = signedDelivery(SECRET);
+
+    const response = await request(appWith("verify-buffer"))
+      .post("/webhooks/crowdsource")
+      .set(headers)
+      .send(raw);
+
+    expect(response.status).toBe(500);
+    expect(response.body).toMatchObject({ message: "Webhook receiver is misconfigured" });
+  });
+
+  it("accepts that same signed delivery when mounted correctly", async () => {
+    /**
+     * The vacuity guard for the test above, and the one that makes it mean
+     * anything: it proves the delivery really is well-formed and correctly
+     * signed. Without this, a typo in the signature would make the previous test
+     * pass no matter what `assertRawBody` did.
+     */
+    const { raw, headers } = signedDelivery(SECRET);
+
+    const response = await request(appWith("none"))
+      .post("/webhooks/crowdsource")
+      .set(headers)
+      .send(raw);
+
+    expect(response.status).toBeLessThan(300);
   });
 
   it("never authenticates by Oxy session — the HMAC is the authentication", async () => {
@@ -112,7 +223,7 @@ describe("crowdsource webhook mount order", () => {
      * An unsigned request carrying a bearer token must not be treated as
      * authorised. This is not a user endpoint, and a session must never satisfy it.
      */
-    const response = await request(appWith({ parseJsonFirst: false }))
+    const response = await request(appWith("none"))
       .post("/webhooks/crowdsource")
       .set("authorization", "Bearer a-perfectly-valid-looking-token")
       .set("content-type", "application/json")

--- a/packages/backend/src/routes/crowdSourceWebhook.ts
+++ b/packages/backend/src/routes/crowdSourceWebhook.ts
@@ -58,10 +58,32 @@ function stringField(source: unknown, key: string): string | undefined {
  *
  * `express.json()` sets `req.body` on every request it handles — to `{}` when
  * there is nothing to parse — so an undefined `req.body` is precisely the
- * assertion that no parser has touched this request. Mounted inside the route
- * rather than asserted in a test, because the thing being protected is the MOUNT
- * ORDER in `server.ts`, and a future edit that moves this router below
- * `express.json()` would break it in a way no unit test of this file could see.
+ * assertion that NO PARSER RAN. That is a deliberately different claim from "the
+ * signature failed to verify", and the difference is the whole reason this guard
+ * exists rather than relying on the SDK's own refusal.
+ *
+ * ## The SDK's protection is conditional on middleware this file does not own
+ *
+ * `readRawBody` in `@oxyhq/crowdsource-express` resolves the signed bytes in a
+ * fixed order: a Buffer on `req.rawBody` FIRST, then a Buffer `req.body`, then a
+ * throw if `req.body` is anything else, and only then the request stream. So the
+ * failure mode of a late mount is decided entirely by how `express.json()` was
+ * configured somewhere else in the app:
+ *
+ * - **Plain `express.json()`** — what `server.ts` uses today. `req.rawBody` is
+ *   never set and `req.body` is a parsed object, so the SDK throws. LOUD.
+ * - **`express.json({ verify })` keeping the raw bytes** — the SDK takes that
+ *   Buffer and verifies against parser-supplied bytes. The late mount SUCCEEDS,
+ *   answers 200, and records the decision. SILENT. (Measured, not assumed:
+ *   removing this guard and running the `verify-buffer` case in
+ *   `crowdSourceWebhookMount.test.ts` returns exactly 200. Alia's backend has
+ *   this configuration.)
+ *
+ * Allo is in the loud configuration today by accident of unrelated middleware,
+ * and a commit that never mentions moderation could move it to the silent one.
+ * Hence the assertion is on `req.body` being undefined — true in BOTH
+ * configurations — and hence it lives in the route rather than in a test, because
+ * what it protects is the mount order in `server.ts`.
  *
  * 500 rather than 4xx: this is Allo misassembled, not a bad request. Answering
  * non-2xx also keeps the delivery on CrowdSource's retry schedule, so decisions


### PR DESCRIPTION
Follow-up to #33, which was merged just before this landed. Finding originally from the Alia integration.

## "Mounted before `express.json`" cannot be checked by observing that webhooks work

`readRawBody` in `@oxyhq/crowdsource-express` resolves the signed bytes in a fixed order: a Buffer on `req.rawBody` **first**, then a Buffer `req.body`, then a throw if `req.body` is anything else, and only then the request stream.

So the failure mode of a late mount is decided entirely by middleware this integration does not own:

| Parser config | Late mount does | Visibility |
|---|---|---|
| plain `express.json()` — what `server.ts` uses today | SDK finds a parsed object and throws | loud |
| `express.json({ verify })` keeping the raw bytes | SDK takes that Buffer, verifies against **parser-supplied** bytes, accepts | **silent** |

**Measured, not assumed.** With `assertRawBody` removed, a correctly signed delivery to a router mounted *after* `express.json({ verify })` returns **200** — accepted, decision recorded, no error and no log line. Alia's backend has exactly that configuration. Allo is in the loud one today only by accident of unrelated middleware, and a commit that never mentions moderation could move it.

This is why the guard asserts `typeof req.body === 'undefined'` — that proves **no parser ran**, and holds in both configurations — rather than asserting that verification failed, which only holds in one. The reasoning is now a doc comment on `assertRawBody` so nobody later "simplifies" it to the narrower check.

## The vacuity guard earned its place immediately

Two tests are added, and the second is what makes the first mean anything: it sends the **same** signed delivery to a correctly-mounted app and requires a 2xx.

The first draft's envelope was missing `createdAt` / `organizationId` / `applicationId`, so it was refused at the schema step with a 400 — which means the silent-success test would have passed while proving nothing. The guard caught that on the first run.

## Verification

- **71 tests**, `tsc --noEmit` clean.
- Mutation: removing `assertRawBody` is type-clean and fails both mount tests, the verify-buffer one with `expected 200 to be 500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)