### PR TITLE
fix(moderation): a repeated outbox enqueue must write nothing at all

### DIFF
--- a/packages/backend/src/__tests__/services/moderation/reportIntakeMongo.test.ts
+++ b/packages/backend/src/__tests__/services/moderation/reportIntakeMongo.test.ts
@@ -229,6 +229,57 @@ describe("report intake against a real replica set", () => {
     expect(stored?.attempts).toBe(3);
   });
 
+  it("a repeated enqueue writes NOTHING — not even updatedAt", async () => {
+    /**
+     * Stronger than "the fields I care about survived", and the difference is
+     * operational rather than tidy.
+     *
+     * Omitting `createdAt`/`updatedAt` from `$setOnInsert` fixes the update-
+     * conflict, but leaves Mongoose adding `updatedAt` to `$set` on every upsert
+     * — so a no-op enqueue still TOUCHES the row. A transaction retry, a
+     * duplicate concurrent submission or a reconciliation re-derivation would
+     * then take a write lock on a row the dispatcher may be claiming, and the
+     * intake transaction aborts. Measured: with Mongoose timestamping the no-op,
+     * that race aborts; with `timestamps: false`, it commits.
+     *
+     * `updatedAt` is the only field that would move, so it is the one to assert
+     * on. A `deepEqual` of the whole document would pass just as well against a
+     * write that happened to produce identical values.
+     */
+    const session = await mongoose.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await enqueueModerationOutboxEvent(
+          { eventId: "evt-noop", kind: "report.submit", payload: { reportId: "r1" } },
+          session,
+        );
+      });
+    } finally {
+      await session.endSession();
+    }
+
+    const before = await ModerationOutbox.findById("evt-noop").lean();
+    expect(before?.updatedAt).toBeInstanceOf(Date);
+    // A real interval, so an unchanged timestamp cannot be same-millisecond luck.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const second = await mongoose.startSession();
+    try {
+      await second.withTransaction(async () => {
+        await enqueueModerationOutboxEvent(
+          { eventId: "evt-noop", kind: "report.submit", payload: { reportId: "r1" } },
+          second,
+        );
+      });
+    } finally {
+      await second.endSession();
+    }
+
+    const after = await ModerationOutbox.findById("evt-noop").lean();
+    expect(after?.updatedAt?.getTime()).toBe(before?.updatedAt?.getTime());
+    expect(after?.createdAt?.getTime()).toBe(before?.createdAt?.getTime());
+  });
+
   it("refuses to enqueue outside a transaction, against a real session", async () => {
     /**
      * The guard tested with a genuine `startSession()` — the exact object that

--- a/packages/backend/src/services/moderation/ModerationOutboxService.ts
+++ b/packages/backend/src/services/moderation/ModerationOutboxService.ts
@@ -124,26 +124,44 @@ export async function enqueueModerationOutboxEvent(
         availableAt: now,
         expiresAt: new Date(now.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000),
         /**
-         * `createdAt` and `updatedAt` are deliberately ABSENT.
+         * Written HERE, with Mongoose's own timestamping switched off below.
          *
-         * The schema declares `{ timestamps: true }`, so Mongoose writes both
-         * paths itself on an upsert — `updatedAt` into `$set` and both into
-         * `$setOnInsert`. Naming them here too puts `updatedAt` in two operators
-         * of one update document, and Mongo rejects the WHOLE write:
-         * `Updating the path 'updatedAt' would create a conflict at 'updatedAt'`.
+         * Two things have to be true at once, and only this combination gets
+         * both.
          *
-         * The consequence is not a missing outbox row. This runs inside
-         * `createReport`'s transaction, so the abort takes the `Report` with it —
-         * `POST /reports` fails for EVERY report, from the first one. Verified
-         * against a real replica set on mongoose 9.7.4: report rows 0, outbox
-         * rows 0.
+         * **The write must not conflict.** The schema declares
+         * `{ timestamps: true }`, so on an upsert Mongoose writes `updatedAt`
+         * into `$set` and both paths into `$setOnInsert` itself. Naming them here
+         * as well puts `updatedAt` in two operators of one update document, and
+         * Mongo rejects the WHOLE write — `Updating the path 'updatedAt' would
+         * create a conflict at 'updatedAt'`. Inside `createReport`'s transaction
+         * that abort takes the `Report` with it, so `POST /reports` fails for
+         * every report, from the first one.
          *
-         * `claim`'s `sort: { createdAt: 1 }` still works, because `timestamps`
-         * sets `createdAt` on insert.
+         * **And a repeated enqueue must write NOTHING.** Simply omitting these
+         * two fields fixes the conflict but leaves Mongoose adding `updatedAt` to
+         * `$set` — so re-enqueueing an event that already exists still touches the
+         * row, even though `$setOnInsert` matches nothing. That is not cosmetic:
+         * a transaction retry, a duplicate concurrent submission or a
+         * reconciliation re-derivation would then take a write lock on a row the
+         * dispatcher may be claiming concurrently. Measured on mongoose 9.7.4
+         * against a real replica set: with Mongoose timestamping the no-op
+         * enqueue, an intake transaction racing a dispatcher claim ABORTS; with
+         * `timestamps: false`, it commits.
+         *
+         * So the fields are set explicitly on insert and Mongoose is told to keep
+         * out. `claim`'s `sort: { createdAt: 1 }` is satisfied by the value above.
          */
+        createdAt: now,
+        updatedAt: now,
       },
     },
-    { upsert: true, session },
+    /**
+     * `timestamps: false` applies to THIS call only; every other write in this
+     * file sets `updatedAt` inside its own `$set`, where Mongoose merging into
+     * the same operator is harmless.
+     */
+    { upsert: true, session, timestamps: false },
   );
   return input.eventId;
 }


### PR DESCRIPTION
Second-order follow-up to the `$setOnInsert` timestamps fix in #33. Reported by the `shared-package` agent, who hit the same thing in `@oxyhq/crowdsource-app` (CrowdSource PR #34).

## The first fix was correct and incomplete

#33 removed `createdAt`/`updatedAt` from `$setOnInsert` and let the schema's `{ timestamps: true }` supply them. That resolves the conflict that was failing **every** `POST /reports` — but it leaves Mongoose adding `updatedAt` to `$set` on every upsert, so re-enqueueing an event that already exists still **touches the row**, even though `$setOnInsert` matches nothing.

## Why that is not cosmetic

A transaction retry, two concurrent duplicate submissions, and a reconciliation re-derivation all re-enqueue an existing id. The extra write takes a lock on a row the dispatcher may be claiming at that moment.

Measured on mongoose 9.7.4 against a real replica set — an intake transaction racing a dispatcher claim on the same row:

| variant | outcome |
|---|---|
| Mongoose timestamps the no-op enqueue | transaction **ABORTS** |
| `timestamps: false`, explicit fields on insert | **commits** |

So the fields are set explicitly on insert and Mongoose is told to keep out of *this one call*. Every other write in the file sets `updatedAt` inside its own `$set`, where Mongoose merging into the same operator is harmless — which is why this is `timestamps: false` on the call rather than on the schema.

## The existing test could not see it

`re-enqueueing the same event is idempotent` asserts `status` and `attempts` survive. **Both variants satisfy that** — the properties it checks are exactly the ones the extra write does not disturb.

The new test asserts the stronger property: `updatedAt` does not move. With a real 25ms interval between the two enqueues, so an unchanged timestamp cannot be same-millisecond luck.

## Verification

- **72 tests**, `tsc --noEmit` clean.
- Mutation: reverting to the previous variant is type-clean and fails the new test with a 27ms delta (`expected …736 to be …709`) — **and nothing else**, which is what makes it specific rather than incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)