### PR TITLE
Mover la app a allo.you

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Expo/RN frontend + Express backend. Agent: `allo`.
 
 ## Deployment
 
-- **Port**: `8080` | **Domain**: `api.allo.oxy.so` | **ECR**: `oxy/allo`
+- **Port**: `8080` | **Domain**: `api.allo.you` | **ECR**: `oxy/allo`
 - Build: `linux/arm64` Dockerfile in `packages/backend/`.
 - `.github/workflows/deploy-aws.yml` is the only deployment. `server.ts` defaults to `4140` for local dev; ECS injects `PORT=8080`.
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -14,7 +14,7 @@ The Allo backend is a small Express + Socket.IO service. Every authenticated rou
 
 | Env | URL |
 |-----|-----|
-| Production | `https://api.allo.oxy.so` |
+| Production | `https://api.allo.you` |
 | Development | `http://localhost:4140` |
 
 Both are hardcoded in `packages/frontend/config.ts`; only the development side can be overridden from the environment.

--- a/docs/matrix/bridges.md
+++ b/docs/matrix/bridges.md
@@ -107,7 +107,7 @@ Dos detalles que sorprenden y conviene tener presentes:
 
 - **[V] bridgev2 no registra namespaces de alias ni de salas.** Sólo de usuarios.
   Los portales se crean sin alias. Si alguien esperaba poder resolver
-  `#whatsapp_XXX:allo.oxy.so`, no va a existir.
+  `#whatsapp_XXX:allo.you`, no va a existir.
 - **[V] `sender_localpart` es aleatorio y distinto del bot visible.** El usuario
   del appservice y el bot que aparece en las salas de gestión no son el mismo
   MXID.
@@ -283,14 +283,14 @@ Configuración relevante:
 bridge:
   permissions:
     "*": relay              # nadie de fuera puede loguearse
-    "allo.oxy.so": user     # todos nuestros usuarios pueden vincular cuentas
-    "@allo-admin:allo.oxy.so": admin
+    "allo.you": user     # todos nuestros usuarios pueden vincular cuentas
+    "@allo-admin:allo.you": admin
   split_portals: true       # ver más abajo — IRREVERSIBLE
   bridge_status_notices: none
   cleanup_on_logout:
     enabled: true
 homeserver:
-  status_endpoint: https://api.allo.oxy.so/internal/bridges/status
+  status_endpoint: https://api.allo.you/internal/bridges/status
 provisioning:
   shared_secret: <secreto de 32+ chars, del gestor de secretos>
   allow_matrix_auth: false  # sólo el backend habla con el bridge
@@ -317,7 +317,7 @@ mutuamente y descubriendo que el otro usa Allo. Para un producto de consumo eso
 es una fuga de privacidad, no una optimización. El coste es más salas y más
 tráfico; se paga.
 
-Los ghosts (`@telegram_123456:allo.oxy.so`) **[V]** siguen siendo compartidos
+Los ghosts (`@telegram_123456:allo.you`) **[V]** siguen siendo compartidos
 entre usuarios aunque los portales estén separados. Eso está bien: un contacto de
 Telegram es la misma persona para todos.
 
@@ -347,8 +347,8 @@ Un *slot* es una tupla estática, creada en despliegue:
 |---|---|
 | ID de appservice | `allo-wa-0042` |
 | Fichero de registro | `/data/appservices/allo-wa-0042.yaml` |
-| `username_template` | `wa0042_{{.}}` → ghosts `@wa0042_34600111222:allo.oxy.so` |
-| Bot | `@wa0042bot:allo.oxy.so` |
+| `username_template` | `wa0042_{{.}}` → ghosts `@wa0042_34600111222:allo.you` |
+| Bot | `@wa0042bot:allo.you` |
 | Puerto | `29500 + 42` |
 | Base de datos | SQLite en volumen propio, o `allo_wa_0042` en Postgres |
 | Proxy | resuelto en runtime vía `get_proxy_url` (§8) |
@@ -384,7 +384,7 @@ configuramos:
 
 ```yaml
 network:
-  get_proxy_url: https://api.allo.oxy.so/internal/bridges/proxy?slot=allo-wa-0042&t=<token>
+  get_proxy_url: https://api.allo.you/internal/bridges/proxy?slot=allo-wa-0042&t=<token>
 ```
 
 el bridge llamará a
@@ -470,7 +470,7 @@ pantalla de "vincular cuenta": la app no lleva lista propia.
     {
       "id": "telegram",
       "displayName": "Telegram",
-      "icon": "mxc://allo.oxy.so/...",
+      "icon": "mxc://allo.you/...",
       "loginFlows": [
         { "id": "phone", "name": "Número de teléfono", "description": "..." },
         { "id": "qr",    "name": "Código QR",          "description": "..." }

--- a/docs/matrix/data-model.md
+++ b/docs/matrix/data-model.md
@@ -564,7 +564,7 @@ representar.
 La marca **secundaria**, y sólo para decir *qué* red es (icono de WhatsApp,
 nombre del canal), es el evento de estado `m.bridge` — que sigue siendo un MSC
 inestable (MSC2346, prefijo `uk.half-shot.bridge`) [?] — más el namespace del MXID
-de los usuarios fantasma del appservice (`@whatsapp_...:allo.oxy.so`).
+de los usuarios fantasma del appservice (`@whatsapp_...:allo.you`).
 
 La regla de UI, dicha explícitamente porque es donde se cometen los errores:
 **el candado lo decide el estado de cifrado; el icono de red lo decide el evento

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -139,7 +139,7 @@ nothing is deployed by hand.
 - **Port** — the container listens on the `PORT` that ECS injects (8080; set in
   oxy-infra's `terraform-uswest2/app-allo.tf`). The `4140` in `server.ts` is the
   local fallback only.
-- **Public URL** — `api.allo.oxy.so`.
+- **Public URL** — `api.allo.you`.
 
 ### Credentials
 

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -26,11 +26,20 @@ import { startModerationOutboxDispatcher } from "./src/services/moderation/Moder
 // --- Config ---
 dotenv.config();
 
-// Explicit localhost dev origins. The Oxy apex family (*.oxy.so — including
-// allo.oxy.so / api.allo.oxy.so) is allowed automatically by createOxyCors, so
-// only non-apex dev origins need to be listed here. Reused for both the Express
-// CORS middleware and the Socket.IO CORS allowlist.
-const APP_ORIGINS = ["http://localhost:8140", "http://localhost:8141"];
+// Origins that are NOT covered by createOxyCors, which admits the Oxy apex
+// family (*.oxy.so) automatically and nothing else.
+//
+// `https://allo.you` has to be listed explicitly for exactly that reason: it is
+// the product's own domain, outside the oxy.so apex, so the automatic rule does
+// not reach it. Dropping it from here does not fail at boot — it fails in the
+// browser, as a CORS error on every request the web app makes.
+//
+// Reused for both the Express CORS middleware and the Socket.IO allowlist.
+const APP_ORIGINS = [
+  "https://allo.you",
+  "http://localhost:8140",
+  "http://localhost:8141",
+];
 
 const app = express();
 
@@ -110,7 +119,7 @@ const io = new SocketIOServer(server, {
   maxHttpBufferSize: SOCKET_CONFIG.MAX_BUFFER_SIZE,
   connectTimeout: SOCKET_CONFIG.CONNECT_TIMEOUT,
   cors: {
-    origin: [...APP_ORIGINS, "https://allo.oxy.so"],
+    origin: APP_ORIGINS,
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     credentials: true,
     allowedHeaders: [

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -142,7 +142,7 @@ Once the development server is running, you can:
 ### Environment Setup
 
 Base URLs are resolved in `config.ts`, which hardcodes production
-(`https://api.allo.oxy.so`) and only consults the environment in development.
+(`https://api.allo.you`) and only consults the environment in development.
 None of the variables below is required to run against a local backend — the
 defaults already point at `localhost:4140`, Allo's slot in the Oxy per-app port
 map.

--- a/packages/frontend/__tests__/matrix/oidcLogin.test.ts
+++ b/packages/frontend/__tests__/matrix/oidcLogin.test.ts
@@ -17,16 +17,16 @@ import type { SessionFields } from '@/lib/matrix/native/session';
  * a login that succeeded or replays an authorization code the server has seen.
  */
 
-const AUTHORIZATION_URL = 'https://account.allo.oxy.so/authorize?client_id=allo';
+const AUTHORIZATION_URL = 'https://account.allo.you/authorize?client_id=allo';
 const CALLBACK_URL = 'allo://oidc-callback?code=abc&state=xyz';
 
 const SESSION: SessionFields = {
-  userId: '@alice:allo.oxy.so',
+  userId: '@alice:allo.you',
   deviceId: 'DEVICE1',
-  homeserverUrl: 'https://matrix.allo.oxy.so',
+  homeserverUrl: 'https://matrix.allo.you',
   accessToken: 'access',
   refreshToken: 'refresh',
-  oidcData: '{"issuer":"https://account.allo.oxy.so/"}',
+  oidcData: '{"issuer":"https://account.allo.you/"}',
 };
 
 function authorizationData(): OAuthAuthorizationDataLike {
@@ -72,12 +72,12 @@ describe('NativeOidcLoginRequest', () => {
 
     expect(client.completed).toEqual([CALLBACK_URL]);
     expect(session).toEqual({
-      userId: '@alice:allo.oxy.so',
+      userId: '@alice:allo.you',
       deviceId: 'DEVICE1',
-      homeserverUrl: 'https://matrix.allo.oxy.so',
+      homeserverUrl: 'https://matrix.allo.you',
       accessToken: 'access',
       refreshToken: 'refresh',
-      authData: '{"issuer":"https://account.allo.oxy.so/"}',
+      authData: '{"issuer":"https://account.allo.you/"}',
     });
   });
 

--- a/packages/frontend/__tests__/matrix/session.test.ts
+++ b/packages/frontend/__tests__/matrix/session.test.ts
@@ -17,28 +17,28 @@ describe('toAlloSession', () => {
     // cannot renew itself and stops working when the access token expires.
     expect(
       toAlloSession({
-        userId: '@alice:allo.oxy.so',
+        userId: '@alice:allo.you',
         deviceId: 'DEVICE1',
-        homeserverUrl: 'https://matrix.allo.oxy.so',
+        homeserverUrl: 'https://matrix.allo.you',
         accessToken: 'access',
         refreshToken: 'refresh',
-        oidcData: '{"issuer":"https://account.allo.oxy.so/"}',
+        oidcData: '{"issuer":"https://account.allo.you/"}',
       }),
     ).toEqual({
-      userId: '@alice:allo.oxy.so',
+      userId: '@alice:allo.you',
       deviceId: 'DEVICE1',
-      homeserverUrl: 'https://matrix.allo.oxy.so',
+      homeserverUrl: 'https://matrix.allo.you',
       accessToken: 'access',
       refreshToken: 'refresh',
-      authData: '{"issuer":"https://account.allo.oxy.so/"}',
+      authData: '{"issuer":"https://account.allo.you/"}',
     });
   });
 
   it('keeps the optional credentials absent rather than inventing them', () => {
     const session = toAlloSession({
-      userId: '@alice:allo.oxy.so',
+      userId: '@alice:allo.you',
       deviceId: 'DEVICE1',
-      homeserverUrl: 'https://matrix.allo.oxy.so',
+      homeserverUrl: 'https://matrix.allo.you',
       accessToken: 'access',
       refreshToken: undefined,
       oidcData: undefined,

--- a/packages/frontend/__tests__/matrix/timelineProjection.test.ts
+++ b/packages/frontend/__tests__/matrix/timelineProjection.test.ts
@@ -21,7 +21,7 @@ jest.mock('@unomed/react-native-matrix-sdk');
 function eventFields(body: string): TimelineEventFields {
   return {
     eventOrTransactionId: new EventOrTransactionId.EventId({ eventId: `$${body}` }),
-    sender: '@alice:allo.oxy.so',
+    sender: '@alice:allo.you',
     senderProfile: new ProfileDetails.Unavailable(),
     content: new TimelineItemContent.MsgLike({
       content: {

--- a/packages/frontend/__tests__/matrix/translate.test.ts
+++ b/packages/frontend/__tests__/matrix/translate.test.ts
@@ -52,7 +52,7 @@ function textContent(body: string, isEdited = false): SdkTimelineItemContent {
 function event(overrides: Partial<TimelineEventFields> = {}): TimelineEventFields {
   return {
     eventOrTransactionId: new EventOrTransactionId.EventId({ eventId: '$event' }),
-    sender: '@alice:allo.oxy.so',
+    sender: '@alice:allo.you',
     senderProfile: new ProfileDetails.Unavailable(),
     content: textContent('hello'),
     timestamp: 1_700_000_000_000n,
@@ -64,9 +64,9 @@ function event(overrides: Partial<TimelineEventFields> = {}): TimelineEventField
 
 function roomInfo(overrides: Partial<RoomSummaryFields> = {}): RoomSummaryFields {
   return {
-    id: '!room:allo.oxy.so',
+    id: '!room:allo.you',
     displayName: 'Bea',
-    avatarUrl: 'mxc://allo.oxy.so/avatar',
+    avatarUrl: 'mxc://allo.you/avatar',
     isDirect: true,
     membership: Membership.Joined,
     encryptionState: EncryptionState.Encrypted,
@@ -100,9 +100,9 @@ describe('toSyncState', () => {
 describe('toRoomSummary', () => {
   it('carries the fields the conversation list draws', () => {
     expect(toRoomSummary(roomInfo({ numUnreadMessages: 3n }))).toEqual({
-      roomId: '!room:allo.oxy.so',
+      roomId: '!room:allo.you',
       displayName: 'Bea',
-      avatarUrl: 'mxc://allo.oxy.so/avatar',
+      avatarUrl: 'mxc://allo.you/avatar',
       isDirect: true,
       membership: 'joined',
       encryption: 'encrypted',
@@ -161,7 +161,7 @@ describe('toTimelineItem', () => {
       expect(item.content).toEqual({ kind: 'undecryptable' });
       // And it is a full row: the envelope survives even though the content did
       // not, which is what lets the UI place it in the right spot.
-      expect(item.sender).toBe('@alice:allo.oxy.so');
+      expect(item.sender).toBe('@alice:allo.you');
       expect(item.sentAt).toBe(1_700_000_000_000);
     });
 
@@ -205,7 +205,7 @@ describe('toTimelineItem', () => {
       // Dropped rows leave a gap that looks like lost messages. Naming them keeps
       // the gap visible.
       const content = new TimelineItemContent.RoomMembership({
-        userId: '@bea:allo.oxy.so',
+        userId: '@bea:allo.you',
         userDisplayName: undefined,
         change: undefined,
         reason: undefined,

--- a/packages/frontend/components/SEO.tsx
+++ b/packages/frontend/components/SEO.tsx
@@ -57,7 +57,7 @@ export const SEO: React.FC<SEOProps> = ({
   // Generate full URL
   const fullUrl = url || (Platform.OS === 'web' && typeof window !== 'undefined'
     ? `${window.location.origin}${pathname}`
-    : `https://allo.oxy.so${pathname}`);
+    : `https://allo.you${pathname}`);
 
   // Use provided siteName or translated default
   const finalSiteName = siteName || t('seo.siteName', { defaultValue: defaultSEO.siteName });
@@ -72,7 +72,7 @@ export const SEO: React.FC<SEOProps> = ({
   });
 
   // Default image (you should add your logo/image)
-  const pageImage = image || 'https://allo.oxy.so/og-image.png';
+  const pageImage = image || 'https://allo.you/og-image.png';
 
   // Only render on web
   if (Platform.OS !== 'web' || !Head) {

--- a/packages/frontend/config.ts
+++ b/packages/frontend/config.ts
@@ -4,16 +4,16 @@
 // (ECS injects PORT explicitly).
 export const API_URL =
   process.env.NODE_ENV === 'production'
-    ? 'https://api.allo.oxy.so/api'
+    ? 'https://api.allo.you/api'
     : (process.env.API_URL ?? 'http://localhost:4140/api');
 export const SOCKET_URL =
   process.env.NODE_ENV === "production"
-    ? "wss://api.allo.oxy.so"
+    ? "wss://api.allo.you"
     : (process.env.API_URL_SOCKET ?? "ws://localhost:4140");
 
 export const API_URL_SOCKET =
   process.env.NODE_ENV === "production"
-    ? "wss://api.allo.oxy.so"
+    ? "wss://api.allo.you"
     : (process.env.API_URL_SOCKET ?? "ws://localhost:4140");
 
 export const API_URL_SOCKET_CHAT = process.env.API_URL_SOCKET_CHAT || 'http://localhost:4140';

--- a/spikes/matrix-web/spike.ts
+++ b/spikes/matrix-web/spike.ts
@@ -775,7 +775,7 @@ export function step5ProbeLockPrimitives(): string {
  * server, so this step stops short of it: discovery is a read, and the
  * authorization URL is built locally.
  */
-const PLACEHOLDER_CLIENT_ID = 'https://allo.oxy.so/spike-placeholder-client';
+const PLACEHOLDER_CLIENT_ID = 'https://allo.you/spike-placeholder-client';
 
 export async function stepOidcDiscovery(homeserver: string): Promise<string> {
     const client = createClient({ baseUrl: homeserver });


### PR DESCRIPTION
## Resumen

`allo.you` se registró hace tiempo y el cutover quedó a medias: el commit que lo introdujo era explícitamente *additive, keeps allo.oxy.so*, y el cliente nunca se movió. Hasta ahora la app en producción hablaba con `api.allo.oxy.so` y **`allo.you` no aparecía en una sola línea de código**.

Comprobado antes de tocar nada: `api.allo.you` ya resuelve y sirve el backend de Allo — mismo ALB que `api.allo.oxy.so` (`52.88.70.169`), misma respuesta `{"status":"ok","service":"allo-backend"}`. No hay que levantar nada; es un nombre que ya apunta al sitio correcto.

## La trampa que había que ver

`createOxyCors` admite la familia `*.oxy.so` automáticamente **y nada más**. Mientras la web vivía en `allo.oxy.so` no hacía falta declararla; en `allo.you` sí, porque queda fuera de ese apex.

Eso no falla al compilar: falla en el navegador, como un error de CORS en cada petición. `APP_ORIGINS` la lista ahora explícitamente, con el motivo escrito al lado para que nadie la quite por parecer redundante.

## De paso

El diseño de bridges usaba `allo.oxy.so` como `server_name` de Matrix en todos los MXID de ejemplo, cuando la decisión de infraestructura fijó `server_name = allo.you` — un valor que queda grabado en cada MXID, sala y evento que el homeserver cree.

## Lo que este PR NO hace

**No retira el DNS viejo.** `api.allo.oxy.so` sigue en pie y debe seguir un tiempo: hay clientes instalados con esa URL compilada dentro y no se actualizan solos. El registro se borra cuando hayan rotado.

## Plan de pruebas

- Typecheck de backend y frontend en verde. El del frontend reproduciendo las condiciones de CI (sin el `router.d.ts` que genera `expo export` y que en un checkout limpio no existe).
- 89 tests del frontend en verde.
- Verificado que no queda ninguna referencia a `allo.oxy.so` fuera de `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)