### PR TITLE
El socket apuntaba a wss://https, y un panel tumbaba la app

### DIFF
--- a/packages/frontend/app/(chat)/_layout.tsx
+++ b/packages/frontend/app/(chat)/_layout.tsx
@@ -13,6 +13,7 @@ import { useOxy } from '@oxyhq/services';
 import { getContactInfo, getGroupInfo } from '@/utils/conversationUtils';
 import { BREAKPOINTS } from '@/constants/responsive';
 import { useRealtimeMessaging } from '@/hooks/useRealtimeMessaging';
+import { FeatureErrorBoundary } from '@/components/ErrorBoundary';
 
 const ConversationViewWrapper = ({ conversationId }: { conversationId: string }) => {
   try {
@@ -114,11 +115,18 @@ export default function ChatLayout() {
     return (
       <ThemedView style={styles.container}>
         <View style={styles.leftPane}>
-          {isSettingsRoute && ChatSettings ? (
-            <ChatSettings />
-          ) : (
-            <ConversationsList />
-          )}
+          {/* Cada panel lleva su propia frontera de error. Sin esto, un fallo de
+              render en cualquiera de ellos sube hasta la frontera raíz y
+              sustituye la aplicación entera por una pantalla de disculpa —
+              incluida la lista de conversaciones, que probablemente estaba
+              perfectamente. */}
+          <FeatureErrorBoundary featureName="Chats">
+            {isSettingsRoute && ChatSettings ? (
+              <ChatSettings />
+            ) : (
+              <ConversationsList />
+            )}
+          </FeatureErrorBoundary>
         </View>
 
         <View style={[

--- a/packages/frontend/components/ErrorBoundary.tsx
+++ b/packages/frontend/components/ErrorBoundary.tsx
@@ -136,8 +136,15 @@ class ErrorBoundaryBase extends Component<Props, State> {
 const ErrorBoundary: React.ComponentType<Omit<Props, 't'>> = withTranslation()(ErrorBoundaryBase);
 
 /**
- * Smaller error boundary for specific features
- * Falls back to a minimal error state instead of full screen
+ * Error boundary scoped to one part of the screen.
+ *
+ * Use this, not the default export, anywhere a failure should stay local. The
+ * top-level boundary replaces the whole interface with a full-screen apology,
+ * which is the right last resort and the wrong first one: a component that
+ * throws while rendering one panel should not take the navigation, the
+ * conversation list and every other panel down with it.
+ *
+ * `featureName` is what the user reads, so name the surface and not the module.
  */
 export function FeatureErrorBoundary({
     children,
@@ -146,9 +153,15 @@ export function FeatureErrorBoundary({
     children: ReactNode;
     featureName: string;
 }): React.JSX.Element {
-    const Wrapper = ({ children: wrappedChildren }: { children: ReactNode }) => (
+    // Rendered directly rather than through a `Wrapper` component defined in
+    // this function body. A component type created during render is a NEW type
+    // on every render, so React unmounts and remounts the entire subtree each
+    // time — which for a conversation panel means losing scroll position, focus
+    // and any in-flight state, continuously. That is why this helper was safe to
+    // export and unsafe to use, and why nothing used it.
+    return (
         <ErrorBoundaryBase
-            t={(key: string) => key}
+            t={identityTranslate}
             fallback={
                 <View style={styles.featureError}>
                     <Text style={styles.featureErrorText}>
@@ -163,11 +176,14 @@ export function FeatureErrorBoundary({
                 console.error(`[${featureName}] Error:`, error);
             }}
         >
-            {wrappedChildren}
+            {children}
         </ErrorBoundaryBase>
     );
+}
 
-    return <Wrapper>{children}</Wrapper>;
+/** Stable identity so the prop does not change on every render. */
+function identityTranslate(key: string): string {
+    return key;
 }
 
 const styles = StyleSheet.create({

--- a/packages/frontend/hooks/useRealtimeMessaging.ts
+++ b/packages/frontend/hooks/useRealtimeMessaging.ts
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useRef } from 'react';
 import { useOxy } from '@oxyhq/services';
 import { oxyClient } from '@oxyhq/core';
 import { io, Socket } from 'socket.io-client';
-import { API_URL } from '@/config';
+import { SOCKET_URL } from '@/config';
 import { useMessagesStore } from '@/stores/messagesStore';
 import { useConversationsStore } from '@/stores/conversationsStore';
 import { useDeviceKeysStore } from '@/stores/deviceKeysStore';
@@ -358,11 +358,21 @@ export const useRealtimeMessaging = (conversationId?: string) => {
     }
 
     try {
-      // Get socket URL - remove /api suffix if present, use HTTP/WS protocol
-      let socketUrl = API_URL || process.env.EXPO_PUBLIC_API_URL || 'http://localhost:4140';
-      socketUrl = socketUrl.replace('/api', '').replace('https://', 'wss://').replace('http://', 'ws://');
-
-      messagingSocket = io(`${socketUrl}/messaging`, {
+      // `SOCKET_URL` comes from config already built for this purpose. It used
+      // to be derived here from `API_URL` with
+      //
+      //     API_URL.replace('/api', '').replace('https://', 'wss://')
+      //
+      // which is silently wrong for every host that starts with `api.`:
+      // `replace` takes the FIRST match, and in `https://api.allo.you/api` that
+      // is the `/api` inside `//api...`, not the path suffix. The result was
+      // `https:/.allo.you/api`, which socket.io then parsed with `https` as the
+      // hostname — hence `wss://https/socket.io/` in production.
+      //
+      // It worked in development only because `http://localhost:4140/api` has
+      // no earlier `/api` to hit, so the bug was invisible exactly where anyone
+      // would have caught it.
+      messagingSocket = io(`${SOCKET_URL}/messaging`, {
         // Provide auth as a callback so every (re)connection attempt re-reads a
         // fresh access token from the Oxy SDK (minted from the device secret),
         // never one captured at first connect. The backend's `oxy.authSocket()`


### PR DESCRIPTION
## El socket nunca ha funcionado en producción

`useRealtimeMessaging` derivaba la URL del socket con:

```ts
API_URL.replace('/api', '').replace('https://', 'wss://')
```

`replace` con una cadena sustituye la **primera** aparición. En `https://api.allo.oxy.so/api` la primera `/api` no es el sufijo de ruta — es la que está dentro de `//api...`, porque el host empieza por `api.`.

| Entrada | Salida |
|---|---|
| `https://api.allo.oxy.so/api` | `https:/.allo.oxy.so/api` ❌ |
| `https://api.allo.you/api` | `https:/.allo.you/api` ❌ |
| `http://localhost:4140/api` | `ws://localhost:4140` ✓ |

La última línea explica por qué ha durado tanto: **en desarrollo funciona**, porque no hay una `/api` anterior que capturar. El fallo era invisible exactamente donde alguien lo habría visto.

`config.ts` ya exportaba `SOCKET_URL` construida para esto.

## Un panel no debe tumbar la aplicación

Sólo había una frontera de error, en la raíz. Cualquier excepción sustituía la interfaz entera por "Oops! Something went wrong" — incluida la lista de conversaciones, que normalmente estaba bien.

Existía un `FeatureErrorBoundary` acotado y **no lo usaba nadie**, con motivo: definía su componente `Wrapper` dentro del cuerpo de la función, creando un tipo nuevo en cada render. React responde desmontando y remontando el subárbol entero, continuamente — en un panel de conversación eso es perder scroll, foco y estado en vuelo. Era seguro de exportar e inseguro de usar.

## Lo que NO arregla

El `RangeError: Maximum call stack size exceeded` que aparece en los mismos logs. Es una recursión entre un setter y su callback; no he podido reproducirla ni localizar su origen sin la app corriendo. Descartados `AnimatedNumber` (no lo monta nadie) y la ruta del socket (es asíncrona, no pasa por el render).

Lo que sí cambia es su **consecuencia**: con las fronteras acotadas deja de llevarse la aplicación entera.

Para localizarlo hace falta el `componentStack` del error, que el ErrorBoundary ya registra — con eso se sabe qué subárbol lo lanza.

## Plan de pruebas

- Transformación de URL reproducida en las tres URLs reales antes y después.
- Typecheck de frontend en verde reproduciendo condiciones de CI.
- 89 tests en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)