### PR TITLE
Un despliegue a AWS a la vez

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -10,6 +10,20 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+# Un solo despliegue a la vez por rama. Sin esto, dos merges seguidos lanzan dos
+# `update-service --force-new-deployment` sobre el MISMO servicio ECS: cada uno
+# inicia su propio rollout, se pisan, y ninguno se estabiliza dentro de los diez
+# minutos del waiter. Pasó el 2026-08-02 con dos merges separados por 79
+# segundos — los dos despliegues fallaron y el servicio se quedó sirviendo la
+# tarea anterior, con la build en verde y producción desactualizada.
+#
+# `cancel-in-progress: false` es deliberado: encolar, no cancelar. Abortar un
+# despliegue a mitad de rollout deja el servicio en un estado peor que
+# esperar a que termine.
+concurrency:
+  group: deploy-aws-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
## Qué pasó

Dos PRs fusionados con **79 segundos de diferencia**. Cada push disparó su `Deploy to AWS`, los dos llegaron a `aws ecs update-service --force-new-deployment` sobre el mismo servicio, y **los dos fallaron**:

```
Waiter ServicesStable failed: Max attempts exceeded
```

Cada `force-new-deployment` inicia su propio rollout. Con dos solapados el servicio no se queda quieto, así que ningún waiter ve estabilidad en sus diez minutos. Los despliegues anteriores del día, de uno en uno, pasaron sin problema.

| Run | Hora | Resultado |
|---|---|---|
| 30726376138 | 01:03:56 | failure |
| 30726335823 | 01:02:37 | failure |
| 30725189203 | 00:25:38 | success |
| 30722411530 | 22:58:58 | success |

## Por qué importa más de lo que parece

**La forma en que falla es peor que el fallo.** La imagen se construyó bien, se subió a ECR, CI estaba en verde y los dos PRs quedaron marcados como fusionados. Producción siguió sirviendo la tarea anterior.

El síntoma que llegó al usuario fue un error de CORS desde `allo.you` — arreglado en el código, pero nunca desplegado. Nada en el estado de los PRs sugería mirar el despliegue.

## La decisión

`cancel-in-progress: false` es deliberado: **encolar, no cancelar**. Abortar un rollout a mitad deja el servicio en peor estado que esperar a que acabe.

El grupo lleva `github.ref` para que un despliegue de otra rama no bloquee al de main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)