### PR TITLE
Un mensaje que no se puede cifrar no se envía

### DIFF
--- a/packages/frontend/stores/messagesStore.ts
+++ b/packages/frontend/stores/messagesStore.ts
@@ -557,28 +557,28 @@ export const useMessagesStore = create<MessagesState>()(
           throw new Error(`Encryption not available.${errorDetails}`);
         }
 
-        // Encrypt message (or use plaintext fallback if recipient keys unavailable)
-        let ciphertext: string | undefined;
-        let isEncrypted = false;
+        // A message that cannot be encrypted is not sent.
+        //
+        // This used to fall back to plaintext when the recipient had no
+        // registered devices, which turns a lookup returning an empty list —
+        // a transient server error, a race on first launch, a tampered
+        // response — into a silent downgrade of the conversation. The user
+        // sees a message delivered normally and has no way to tell it went out
+        // in the clear.
+        //
+        // Failing here is visible and recoverable: the caller surfaces the
+        // error and the message stays in the composer. Sending in the clear is
+        // neither.
+        let ciphertext: string;
         try {
           const updatedDeviceKeysStore = useDeviceKeysStore.getState();
           ciphertext = await updatedDeviceKeysStore.encryptMessageForRecipient(text, recipientUserId);
-          isEncrypted = true;
         } catch (error) {
-          console.warn('[Messages] Encryption failed, using plaintext fallback:', error);
-          const errorMessage = error instanceof Error ? error.message : 'Unknown encryption error';
-          
-          // If recipient has no devices registered, allow plaintext as fallback
-          if (errorMessage.includes('No devices found') || errorMessage.includes('No preKeys')) {
-            console.warn('[Messages] Recipient has no registered devices. Sending as plaintext (less secure).');
-            // Continue without encryption - will send as plaintext
-            isEncrypted = false;
-            ciphertext = undefined;
-          } else {
-            // For other encryption errors, still throw
-            throw new Error('Failed to encrypt message. Please try again.');
-          }
+          console.error('[Messages] Refusing to send: encryption failed', error);
+          const detail = error instanceof Error ? error.message : 'unknown error';
+          throw new Error(`This message was not sent because it could not be encrypted (${detail}).`);
         }
+        const isEncrypted = true;
 
         // Create message object with pending status (will update when sent)
         const message: Message = {


### PR DESCRIPTION
## Visto en producción

El circuit breaker del cliente HTTP se abrió tras los errores de CORS acumulados antes de que un despliegue llegara. La búsqueda de claves del destinatario falló y la consola imprimió:

```
[Messages] Encryption failed, using plaintext fallback
```

Ese aviso era **engañoso** — se emite antes de decidir, y para `Circuit breaker is open` el código sí acababa lanzando. Pero destapó la caída real: cuando el error contenía `No devices found` o `No preKeys`, **el mensaje se enviaba en claro**.

## Por qué es grave

Una lista de dispositivos vacía no significa sólo "el destinatario aún no ha instalado la app". Significa también un error transitorio del servidor, una carrera en el primer arranque, o una respuesta manipulada.

En cualquiera de esos casos el usuario ve su mensaje entregado con normalidad y **no tiene forma de saber que salió sin cifrar**. `docs/encryption.mdx` ya lo listaba esta mañana entre las amenazas contra las que la app no protege.

## Qué cambia

No se envía. El error sube al llamador, el mensaje se queda en el compositor y el usuario puede reintentar. Fallar así es visible y recuperable; enviar en claro no es ninguna de las dos cosas.

El aviso engañoso también se va: pasa a `console.error` y dice lo que de verdad ocurre.

Esto alinea además el comportamiento con hacia dónde va la app: **en una sala cifrada de Matrix no existe una ruta de texto plano que tomar**, porque el SDK cifra o falla.

## Plan de pruebas

- Typecheck del frontend en verde reproduciendo condiciones de CI.
- 89 tests en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)