### PR TITLE
Revert: el bloque concurrency impedía todo despliegue

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -10,19 +10,26 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-# Un solo despliegue a la vez por rama. Sin esto, dos merges seguidos lanzan dos
-# `update-service --force-new-deployment` sobre el MISMO servicio ECS: cada uno
-# inicia su propio rollout, se pisan, y ninguno se estabiliza dentro de los diez
-# minutos del waiter. Pasó el 2026-08-02 con dos merges separados por 79
-# segundos — los dos despliegues fallaron y el servicio se quedó sirviendo la
-# tarea anterior, con la build en verde y producción desactualizada.
+# NOTA: aquí hubo un bloque `concurrency` y hubo que quitarlo — ver más abajo.
 #
-# `cancel-in-progress: false` es deliberado: encolar, no cancelar. Abortar un
-# despliegue a mitad de rollout deja el servicio en un estado peor que
-# esperar a que termine.
-concurrency:
-  group: deploy-aws-${{ github.ref }}
-  cancel-in-progress: false
+# El problema que intentaba resolver es real: el 2026-08-02 dos merges separados
+# por 79 segundos lanzaron dos `update-service --force-new-deployment` sobre el
+# mismo servicio ECS, se pisaron, y ninguno de los dos waiters vio estabilidad en
+# sus diez minutos. Los dos despliegues fallaron con la build en verde y
+# producción sirviendo la tarea anterior.
+#
+# Pero añadir
+#
+#     concurrency:
+#       group: deploy-aws-${{ github.ref }}
+#       cancel-in-progress: false
+#
+# a nivel de workflow dejó TODOS los runs en `action_required` con cero jobs —
+# nunca arrancaban—, tanto por `push` como por `workflow_dispatch`. Comprobado
+# ejecutando el mismo workflow desde una rama sin ese bloque: arranca. Con él, no.
+#
+# Quien lo vuelva a intentar: verifíquelo en una rama ANTES de fusionarlo, porque
+# el síntoma es que deja de desplegarse sin que nada aparezca en rojo.
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Qué pasó

Añadí un bloque `concurrency` hace una hora (#43) para evitar que dos merges seguidos lanzaran despliegues que se pisan. **El efecto real fue peor que el problema**: todos los runs de `Deploy to AWS` pasaron a `action_required` con **cero jobs**. No arrancaban, ni por `push` ni por `workflow_dispatch`.

## Confirmado por experimento

Ejecuté el mismo workflow desde una rama idéntica salvo por ese bloque:

| | Resultado |
|---|---|
| Con `concurrency` | `action_required`, cero jobs |
| Sin `concurrency` | `in_progress`, arranca normal |

## Por qué es urgente

Falla en la peor dirección. Un despliegue que revienta se ve. Uno que **nunca arranca** aparece como un run más en la lista, con CI en verde y los PRs marcados como fusionados, mientras producción se queda atrás.

Es exactamente el modo de fallo que el bloque pretendía eliminar, amplificado.

## Por qué revertir y no ajustar

No sé por qué GitHub responde así a un `concurrency` sintácticamente válido y colocado donde debe. Como no lo entiendo, no lo sustituyo por otra variante a ciegas.

Queda anotado en el fichero: el problema original descrito, y el aviso de verificarlo **en una rama** antes de volver a fusionarlo — porque el síntoma es que deja de desplegarse sin que nada aparezca en rojo.

## Mientras tanto

El problema de los despliegues concurrentes sigue abierto. Su mitigación es de proceso: no fusionar dos PRs seguidos sin dejar que el primero termine de desplegar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)