### PR TITLE
Corregir el diagnóstico del despliegue, que era falso

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -10,26 +10,32 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-# NOTA: aquí hubo un bloque `concurrency` y hubo que quitarlo — ver más abajo.
+# PENDIENTE: los despliegues desde `main` no arrancan.
 #
-# El problema que intentaba resolver es real: el 2026-08-02 dos merges separados
-# por 79 segundos lanzaron dos `update-service --force-new-deployment` sobre el
-# mismo servicio ECS, se pisaron, y ninguno de los dos waiters vio estabilidad en
-# sus diez minutos. Los dos despliegues fallaron con la build en verde y
-# producción sirviendo la tarea anterior.
+# Desde el 2026-08-02 ~01:25, cada run de este workflow disparado por `push` a
+# `main` termina en `action_required` con CERO jobs — nunca empieza. `CI` y
+# `Deploy Frontends` sí corren sobre los mismos commits, así que no es del repo
+# ni de la organización: es de este workflow, en esta rama.
 #
-# Pero añadir
+# Descartado que lo cause un bloque `concurrency` que se probó y se revirtió: el
+# run del propio commit de revert, sin ese bloque, quedó igualmente en
+# `action_required`. La API no da más: sin aprobaciones pendientes, Actions
+# habilitado, workflow activo, actor el propietario.
 #
-#     concurrency:
-#       group: deploy-aws-${{ github.ref }}
-#       cancel-in-progress: false
+# Lo que queda por mirar, y necesita la interfaz web porque la API no lo expone:
+# el motivo que GitHub muestra en la propia página del run. Suele ser una regla
+# de aprobación o un límite de gasto de Actions.
 #
-# a nivel de workflow dejó TODOS los runs en `action_required` con cero jobs —
-# nunca arrancaban—, tanto por `push` como por `workflow_dispatch`. Comprobado
-# ejecutando el mismo workflow desde una rama sin ese bloque: arranca. Con él, no.
+# Ojo al modo de fallo mientras tanto: un despliegue que no arranca no aparece en
+# rojo en ningún sitio. CI queda en verde, el PR queda fusionado, y producción se
+# queda atrás en silencio. Antes de dar por desplegado un cambio de backend,
+# compruébelo contra el servicio, no contra el estado del PR.
 #
-# Quien lo vuelva a intentar: verifíquelo en una rama ANTES de fusionarlo, porque
-# el síntoma es que deja de desplegarse sin que nada aparezca en rojo.
+# El problema que motivó aquel `concurrency` sigue abierto: el 2026-08-02 dos
+# merges separados por 79 segundos lanzaron dos `update-service
+# --force-new-deployment` sobre el mismo servicio y ninguno se estabilizó. Su
+# mitigación hoy es de proceso: no fusionar dos PRs seguidos sin dejar que el
+# primero termine de desplegar.
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Qué corrige

El commit del revert (#45) afirmaba que el bloque `concurrency` era lo que dejaba los despliegues en `action_required`. **No lo era.**

La prueba con la que lo "confirmé" estaba viciada dos veces:
1. El run de la rama de comparación acabó en **`failure`**, no en éxito — falla en `Configure AWS credentials (OIDC)` porque la política de confianza está acotada a `main`.
2. Yo lo di por bueno leyendo `in_progress` a los quince segundos.

La evidencia que lo desmiente es el propio commit de revert: **su despliegue, ya sin el bloque, quedó igualmente en `action_required`**.

## Qué se sabe de verdad

- Desde ~01:25 del 2026-08-02, cada run de `Deploy to AWS` por `push` a `main` termina en `action_required` con **cero jobs**.
- `CI` y `Deploy Frontends` corren bien sobre los mismos commits → no es del repo ni de la organización.
- La API no da el motivo: sin aprobaciones pendientes, Actions habilitado, workflow activo, actor el propietario.
- Falta mirar la página del run en la interfaz web, que es donde GitHub muestra la razón.

## Lo peligroso

Un despliegue que **no arranca** no aparece en rojo en ningún sitio: CI en verde, PR fusionado, producción atrás en silencio. Queda anotado en el fichero.

Producción ahora mismo está correcta y verificada — el último cambio de backend (CORS) se desplegó antes de que esto empezara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)