### PR TITLE
El esqueleto de carga reventaba la pila

### DIFF
--- a/packages/frontend/app/(chat)/index.tsx
+++ b/packages/frontend/app/(chat)/index.tsx
@@ -16,6 +16,9 @@ import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Animated, {
     Easing,
+    cancelAnimation,
+    withRepeat,
+    withSequence,
     FadeIn,
     FadeOut,
     LinearTransition,
@@ -388,18 +391,34 @@ function SwipeAction({
 function SkeletonRow({ index, theme }: { index: number; theme: ReturnType<typeof useTheme> }) {
     const opacity = useSharedValue(0.3);
 
+    // El pulso se declara como una secuencia que se repite, no como una animación
+    // que se relanza a sí misma desde su propio callback.
+    //
+    // La versión anterior hacía justo eso —`withTiming(1, …, () => { opacity.value
+    // = withTiming(0.3, …) })`— más un `setInterval` de 1600 ms que volvía a
+    // lanzarla sin esperar a que la anterior acabase. En web el setter de un
+    // shared value es un setter de JavaScript corriente, así que un callback que
+    // escribe el mismo valor que lo disparó es recursión directa:
+    //
+    //     RangeError: Maximum call stack size exceeded
+    //         at Object.get [as valueSetter]
+    //
+    // Se veía sólo cuando la lista tardaba en cargar, que es cuando este
+    // esqueleto se monta — es decir, precisamente cuando la app ya iba mal.
+    //
+    // `withRepeat(withSequence(...), -1)` deja el bucle en el hilo de UI, sin
+    // callbacks que reentren y sin temporizador que solape.
     useEffect(() => {
-        opacity.value = withTiming(1, { duration: 800, easing: Easing.inOut(Easing.ease) }, () => {
-            opacity.value = withTiming(0.3, { duration: 800, easing: Easing.inOut(Easing.ease) });
-        });
-        const interval = setInterval(() => {
-            opacity.value = withTiming(1, { duration: 800, easing: Easing.inOut(Easing.ease) }, () => {
-                opacity.value = withTiming(0.3, { duration: 800, easing: Easing.inOut(Easing.ease) });
-            });
-        }, 1600);
-        return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        opacity.value = withRepeat(
+            withSequence(
+                withTiming(1, { duration: 800, easing: Easing.inOut(Easing.ease) }),
+                withTiming(0.3, { duration: 800, easing: Easing.inOut(Easing.ease) }),
+            ),
+            -1,
+            false,
+        );
+        return () => cancelAnimation(opacity);
+    }, [opacity]);
 
     const animStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
     const bone = theme.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';


### PR DESCRIPTION
## La causa del `RangeError` de producción

`SkeletonRow`, el esqueleto de la lista de chats, animaba su opacidad así:

```ts
opacity.value = withTiming(1, …, () => {
    opacity.value = withTiming(0.3, …);   // el callback escribe el mismo valor
});
```

más un `setInterval` de 1600 ms que la relanzaba **sin esperar a que la anterior terminase**.

En web el setter de un shared value es un setter de JavaScript corriente, así que un callback que escribe el valor que lo disparó es recursión directa. De ahí la traza exacta que llegó:

```
RangeError: Maximum call stack size exceeded
    at Object.get [as valueSetter]
```

## Por qué apareció ahora

El esqueleto sólo se monta **mientras la lista carga**. Con las peticiones fallando por el CORS y el circuit breaker abierto, la app se quedó cargando y el esqueleto entró en bucle. El síntoma visible no era el fallo original sino su consecuencia.

Y localizarlo fue posible gracias a las fronteras de error acotadas de esta misma tarde: hasta entonces se llevaba por delante la aplicación entera y podía estar en cualquier sitio. Al quedar reducido a *"Chats temporarily unavailable"*, el fallo pasó a tener dirección.

## El arreglo

`withRepeat(withSequence(...), -1)` — el bucle vive en el hilo de UI, sin callbacks que reentren ni temporizador que solape, y se cancela al desmontar.

Comprobado que el patrón no queda en ningún otro sitio del frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)