### PR TITLE
fix(media): resolve an attachment with a variant Oxy actually serves

### DIFF
--- a/packages/frontend/__tests__/mediaVariant.test.ts
+++ b/packages/frontend/__tests__/mediaVariant.test.ts
@@ -1,0 +1,75 @@
+import type { MediaItem } from '@/stores';
+import { mediaVariantForKind } from '@/utils/mediaVariant';
+
+/**
+ * The bug these tests guard: every message attachment resolved with
+ * `?variant=full`, a name Oxy has never served. Its taxonomy is MIME-specific
+ * and 404s hard with no fallback, so a wrong name is not a degraded image — it
+ * is no image, and it looks exactly like a file that does not exist.
+ *
+ * A test that only restated the lookup table would pass no matter which names
+ * were in it, so the assertions below are built around the two properties that
+ * can actually catch a regression: that no kind may resolve with a name known
+ * to 404 for every MIME, and that image and video may never share one.
+ *
+ * `ALL_KINDS` is annotated with `MediaItem['type'][]` rather than inferred, so
+ * a kind added to the union without being added here is a compile error — the
+ * vacuity floor, without which a shrinking list would keep passing.
+ */
+const ALL_KINDS: MediaItem['type'][] = ['image', 'video', 'gif'];
+
+/**
+ * Measured against cloud.oxy.so on 2026-08-02: these three 404 for an image
+ * file id AND for a video file id. `full` is the one that shipped.
+ */
+const NEVER_SERVED = ['full', 'large', 'original'];
+
+describe('mediaVariantForKind', () => {
+  it.each(ALL_KINDS)('never resolves %s with a variant Oxy serves for nothing', (kind) => {
+    expect(NEVER_SERVED).not.toContain(mediaVariantForKind(kind));
+  });
+
+  it('does not reuse one variant across image and video', () => {
+    // The reason a per-kind mapping exists at all: the sized names (`w1280`,
+    // `thumb`, …) 404 for a video, and `poster` 404s for an image.
+    expect(mediaVariantForKind('image')).not.toEqual(mediaVariantForKind('video'));
+  });
+
+  it('asks for a sized rendition for an image', () => {
+    expect(mediaVariantForKind('image')).toBe('w1280');
+  });
+
+  it('asks for the still frame for a video, the only name a video resolves with today', () => {
+    expect(mediaVariantForKind('video')).toBe('poster');
+  });
+
+  it('asks for the original for a gif, so animation survives', () => {
+    expect(mediaVariantForKind('gif')).toBeUndefined();
+  });
+});
+
+describe('the URL the SDK builds from it', () => {
+  /**
+   * `getFileDownloadUrl` appends `?variant=` only when a variant is passed, so
+   * the composition — not just the name — is what decides whether the request
+   * 404s. This mirrors the builder in @oxyhq/core 17.0.2 rather than importing
+   * the SDK, which would drag the whole client into a unit test.
+   */
+  const buildUrl = (fileId: string, variant?: string) =>
+    `https://cloud.oxy.so/${encodeURIComponent(fileId)}${variant ? `?variant=${encodeURIComponent(variant)}` : ''}`;
+
+  it.each([
+    ['image' as const, 'https://cloud.oxy.so/abc123?variant=w1280'],
+    ['video' as const, 'https://cloud.oxy.so/abc123?variant=poster'],
+    ['gif' as const, 'https://cloud.oxy.so/abc123'],
+  ])('builds the verified-200 URL for %s', (kind, expected) => {
+    expect(buildUrl('abc123', mediaVariantForKind(kind))).toBe(expected);
+  });
+
+  it('no longer builds the URL that shipped', () => {
+    // The control: this is what every attachment resolved to before the fix,
+    // and it returns 404 for both an image file and a video file.
+    const shipped = buildUrl('abc123', 'full');
+    expect(ALL_KINDS.map((kind) => buildUrl('abc123', mediaVariantForKind(kind)))).not.toContain(shipped);
+  });
+});

--- a/packages/frontend/components/conversation/ConversationView.tsx
+++ b/packages/frontend/components/conversation/ConversationView.tsx
@@ -79,7 +79,8 @@ import { MESSAGING_CONSTANTS } from '@/constants/messaging';
 import { groupMessagesByTime, formatMessageGroupsWithDays, FormattedMessageGroup } from '@/utils/messageGrouping';
 
 // Import Message type from store
-import type { Message } from '@/stores';
+import type { MediaItem, Message } from '@/stores';
+import { mediaVariantForKind } from '@/utils/mediaVariant';
 
 /**
  * ConversationView component props
@@ -644,14 +645,14 @@ export default function ConversationView({ conversationId: propConversationId }:
 
 
   /**
-   * Resolve a media download URL from a media ID via the Oxy SDK. Returns an
+   * Resolve a media download URL from a media ID via the Oxy SDK. The rendition
+   * variant depends on the item's kind — see `mediaVariantForKind`. Returns an
    * empty string on failure so the image renderer surfaces a real error state
    * instead of a masking placeholder.
    */
-  const getMediaUrl = useCallback((mediaId: string): string => {
+  const getMediaUrl = useCallback((mediaId: string, kind: MediaItem['type']): string => {
     try {
-      // Use 'full' for full resolution images in messages.
-      return oxyServices.getFileDownloadUrl(mediaId, 'full');
+      return oxyServices.getFileDownloadUrl(mediaId, mediaVariantForKind(kind));
     } catch (error) {
       console.error('Error getting media URL:', error);
       return '';

--- a/packages/frontend/components/messages/MediaCarousel.tsx
+++ b/packages/frontend/components/messages/MediaCarousel.tsx
@@ -8,7 +8,11 @@ import { MESSAGING_CONSTANTS } from '@/constants/messaging';
 export interface MediaCarouselProps {
   media: MediaItem[];
   isAiMessage?: boolean;
-  getMediaUrl: (mediaId: string) => string;
+  /**
+   * Resolve a media id to a URL. Takes the item's kind because the Oxy
+   * rendition variant is MIME-specific — see `mediaVariantForKind`.
+   */
+  getMediaUrl: (mediaId: string, kind: MediaItem['type']) => string;
   onMediaPress?: (mediaId: string, index: number) => void;
   onMediaLongPress?: (mediaId: string, index: number, event: GestureResponderEvent) => void;
 }
@@ -26,7 +30,7 @@ export interface MediaCarouselProps {
  * <MediaCarousel
  *   media={mediaItems}
  *   isAiMessage={false}
- *   getMediaUrl={(id) => `https://example.com/${id}`}
+ *   getMediaUrl={(id, kind) => `https://example.com/${id}?kind=${kind}`}
  *   onMediaPress={(id, index) => console.log('Pressed', id)}
  * />
  * ```
@@ -117,7 +121,7 @@ export const MediaCarousel = memo<MediaCarouselProps>(({
   }
 
   const renderMediaItem = (item: MediaItem, index: number) => {
-    const mediaUrl = getMediaUrl(item.id);
+    const mediaUrl = getMediaUrl(item.id, item.type);
     const isImage = item.type === 'image' || item.type === 'gif';
     const isVideo = item.type === 'video';
 

--- a/packages/frontend/components/messages/MessageBlock.tsx
+++ b/packages/frontend/components/messages/MessageBlock.tsx
@@ -16,7 +16,11 @@ export interface MessageBlockProps {
   isGroup?: boolean;
   getSenderName?: (senderId: string) => string | undefined;
   getSenderAvatar?: (senderId: string) => string | undefined;
-  getMediaUrl: (mediaId: string) => string;
+  /**
+   * Resolve a media id to a URL. Takes the item's kind because the Oxy
+   * rendition variant is MIME-specific — see `mediaVariantForKind`.
+   */
+  getMediaUrl: (mediaId: string, kind: MediaItem['type']) => string;
   visibleTimestampId?: string | null;
   onMessagePress: (messageId: string) => void;
   onMessageLongPress?: (message: Message, position: { x: number; y: number; width?: number; height?: number }) => void;
@@ -44,7 +48,7 @@ export interface MessageBlockProps {
  *   group={messageGroup}
  *   isGroup={true}
  *   getSenderName={(id) => 'John'}
- *   getMediaUrl={(id) => `https://example.com/${id}`}
+ *   getMediaUrl={(id, kind) => `https://example.com/${id}?kind=${kind}`}
  *   onMessagePress={(id) => console.log('Pressed', id)}
  * />
  * ```

--- a/packages/frontend/utils/mediaVariant.ts
+++ b/packages/frontend/utils/mediaVariant.ts
@@ -1,0 +1,43 @@
+import type { MediaItem } from '@/stores';
+
+/**
+ * Oxy rendition variants are MIME-specific and 404 hard — there is no fallback,
+ * and no single name serves both an image and a video. Measured against
+ * `cloud.oxy.so` on 2026-08-02, one real image id and one real video id:
+ *
+ * | `?variant=`                 | image file | video file |
+ * | --------------------------- | ---------- | ---------- |
+ * | `thumb`, `w96`…`w2048`      | 302        | 404        |
+ * | `poster`, `hls_master`      | 404        | 302        |
+ * | omitted (the original)      | 302        | 302        |
+ * | `full`, `large`, `original` | 404        | 404        |
+ *
+ * So the variant an attachment resolves with is a function of that item's kind,
+ * and asking for the wrong one is indistinguishable from the file not existing:
+ * the URL is well-formed, the renderer just gets a 404 body. `undefined` means
+ * "send no `?variant=`", which serves the bytes as uploaded.
+ *
+ * Keyed by `MediaItem['type']` rather than switched on, so adding a media kind
+ * is a compile error here instead of a silent 404 inside a chat bubble.
+ */
+const VARIANT_BY_MEDIA_KIND: Record<MediaItem['type'], string | undefined> = {
+  // A bubble renders media at MESSAGING_CONSTANTS.MEDIA_MAX_WIDTH (250pt) and an
+  // AI message stretches to the window width, so 1280px covers the widest
+  // surface at 3x without paying for a rendition nothing can display.
+  image: 'w1280',
+  // The carousel renders a video as a still frame, and `poster` is the only name
+  // that resolves for a video today. Sized names for video are landing upstream;
+  // do not switch to one before it is live.
+  video: 'poster',
+  // The original, so animation survives. A resized rendition is not guaranteed
+  // to stay animated, and at 250pt a downscale buys nothing worth that risk.
+  gif: undefined,
+};
+
+/**
+ * The Oxy rendition variant to request for a message attachment of `kind`, for
+ * passing straight to `oxyServices.getFileDownloadUrl`.
+ */
+export function mediaVariantForKind(kind: MediaItem['type']): string | undefined {
+  return VARIANT_BY_MEDIA_KIND[kind];
+}


### PR DESCRIPTION
## Severity first: the bug is real, but nobody is affected today

Every message attachment resolved with `?variant=full`, a rendition name Oxy has **never** served. This would have broken every attachment in the app — but **no user is affected right now, because nothing produces `Message.media`**:

- Neither branch of the server→client mapping in `stores/messagesStore.ts` (plaintext or decrypted) copies `media` off the `MessageDto`, even though the DTO, the backend model and `POST /messages` all carry it.
- `sendMessage(conversationId, text, senderId, recipientUserId, fontSize)` takes no media argument.
- Every picker in `AttachmentMenu` is a stub — `onSelectPhoto` / `Camera` / `Document` / `Location` / `Contact` / `Poll` are all `// TODO: Implement`.

So `MediaCarousel` never renders and `getMediaUrl` is never called with a real id. This was **armed to fire the moment someone wires the photo picker**, not firing now. Please don't read this PR as a live outage being resolved.

## Why one variant name cannot work

Oxy's variant taxonomy is MIME-specific and 404s hard with no fallback. A wrong name is not a degraded image — it is no image, and it looks exactly like a file that does not exist (well-formed URL, 404 body, and `expo-image` here has no `onError`/`placeholder`, so it renders as an empty 250×200 box).

Measured against `cloud.oxy.so` on **2026-08-02**, one real public image id and one real video id:

| `?variant=` | image file | video file |
|---|---|---|
| `thumb`, `w96`…`w2048` | 302 | 404 |
| `poster`, `hls_master` | 404 | 302 |
| omitted (the original) | 302 | 302 |
| **`full`**, `large`, `original` | **404** | **404** |

Followed to the final response, so a 302 pointing at a dead object cannot pass as success. **The `full` rows are the control — the passing rows alone would prove nothing:**

```
IMAGE w1280 (followed)       final=200 type=image/webp                    bytes=36102
IMAGE full  (CONTROL)        final=404 type=application/json; charset=utf-8 bytes=52
VIDEO poster (followed)      final=200 type=image/jpeg                    bytes=242919
VIDEO full  (CONTROL)        final=404 type=application/json; charset=utf-8 bytes=52
IMAGE no-variant (gif path)  final=200 type=image/jpeg                    bytes=53154
```

## The fix

The variant is a function of the item's kind, which is already on the item at the render site — Allo never has to guess it from a file extension. New `packages/frontend/utils/mediaVariant.ts`:

```ts
const VARIANT_BY_MEDIA_KIND: Record<MediaItem['type'], string | undefined> = {
  image: 'w1280',
  video: 'poster',
  gif: undefined,
};
```

- **`image: 'w1280'`** — a bubble renders at `MESSAGING_CONSTANTS.MEDIA_MAX_WIDTH` (250pt) and an AI message stretches to the window width, so 1280 covers the widest surface at 3x without paying for a rendition nothing can display.
- **`video: 'poster'`** — the carousel renders a video as a still frame, and `poster` is the only name a video resolves with today. Sized names for video are landing upstream; don't switch before they're live.
- **`gif: undefined`** (no `?variant=`, the bytes as uploaded) — so animation survives. A resized rendition is not guaranteed to stay animated, and at 250pt a downscale buys nothing worth that risk.

Keyed by `MediaItem['type']` rather than switched on, so adding a media kind is a compile error rather than a silent 404 in a chat bubble.

`getMediaUrl` becomes `(mediaId, kind)`, resolved in the one place that calls the SDK (`ConversationView`); `MediaCarousel` and `MessageBlock` carry the widened prop type. Resolution stays at the canonical `oxyServices.getFileDownloadUrl` chokepoint — no per-app URL helper, no hardcoded `cloud.oxy.so`.

## Verification

**Unit tests** — mutation-tested, so they are known to be able to fail:

| mutant | result |
|---|---|
| `image -> 'full'` (reintroduce the shipped bug) | **4 failed**, 162 passed, 166 total |
| `image -> 'poster'` (a real name, wrong mime) | **3 failed**, 163 passed, 166 total |
| restored | 166 passed, 166 total |

**Typecheck controls** — both fire, so the gate is not vacuous:

```
drop 'gif' from the record:  error TS2741: Property 'gif' is missing in type '{ image: string; video: string; }'
call getMediaUrl(item.id):   error TS2554: Expected 2 arguments, but got 1
```

**Full gates:**

```
typecheck   backend + frontend, exit 0, no output
tests       frontend 15 suites / 166 tests passed
            backend  14 files  / 220 tests passed
            shared-types exit 0
```

**Lint is red repo-wide on `main` and this PR does not change that.** `origin/main` reports **197 problems (97 errors, 100 warnings)**. I measured the baseline by restoring the three modified files to `origin/main` content **in place** and re-running: byte-identical, **197 problems (97 errors, 100 warnings)**. The two new files produce no lint output at all, and the findings on the files touched here are at lines 140, 1039, 1, 11 and 175 — none of which this PR edits. **A red lint check on this PR is pre-existing, not introduced here.**

No dependency change: `package.json` and `bun.lock` are untouched.

## Follow-up, tracked separately

`getFileDownloadUrl` is synchronous and builds only the **public** CDN URL, so it 404s for a private asset whatever the variant — and attachments in an E2E messaging app should be private. Whoever wires the photo picker has to decide the visibility model at the same time and will likely need `getFileDownloadUrlAsync`, which makes `getMediaUrl` async through three prop contracts. Not built here: there is no upload path to build it against, and guessing its visibility model now would probably be wrong. Filed as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)