### PR TITLE
La UI, alimentada desde el puerto de Matrix

### DIFF
--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -1,0 +1,150 @@
+# La UI contra el puerto de Matrix
+
+Cómo se enciende el backend de Matrix en la app, qué llega hasta la pantalla y
+qué todavía no. Complementa `client-strategy.md` (qué SDK corre dónde) y
+`data-model.md` (dónde vive cada dato); esto es la capa de en medio: la que
+decide de dónde salen los datos que la UI ya sabía dibujar.
+
+---
+
+## 1. La bandera
+
+Una sola variable, leída en un solo sitio
+(`packages/frontend/lib/chat/backend.ts`):
+
+```
+EXPO_PUBLIC_CHAT_BACKEND=matrix
+```
+
+| Valor | Qué habla |
+|---|---|
+| sin definir, o vacío | `allo-api` — Express, Socket.IO y `signalProtocol.ts`. **El comportamiento de siempre.** |
+| `allo-api` | lo mismo, dicho en voz alta |
+| `matrix` | el homeserver, a través del puerto de `lib/matrix/` |
+| cualquier otra cosa | **lanza al importar** |
+
+Lo último no es rigidez: quien escribe `EXPO_PUBLIC_CHAT_BACKEND=true` y recibe
+en silencio el backend viejo no tiene forma de notarlo desde dentro de la app —
+todas las pantallas funcionan y es la app equivocada.
+
+Expo sustituye `process.env.EXPO_PUBLIC_*` por el literal en tiempo de
+compilación, así que el valor no cambia mientras la app corre y `CHAT_BACKEND`
+es una constante, no una función.
+
+**Con la bandera apagada no se ejecuta nada de Matrix.** El puerto se carga con
+un `import()` dinámico desde `matrixRuntime.ts`, y esa ruta sólo se recorre si la
+bandera está encendida. Importa más que el tamaño del bundle: el SDK nativo
+configura el log global de Rust en cuanto se evalúa su módulo, y el de web va a
+por IndexedDB.
+
+## 2. Las otras variables
+
+Sólo se leen cuando la bandera está en `matrix`
+(`packages/frontend/lib/chat/matrixConfig.ts`):
+
+| Variable | Para qué | Por defecto |
+|---|---|---|
+| `EXPO_PUBLIC_MATRIX_HOMESERVER` | el homeserver | **ninguno; lanza** |
+| `EXPO_PUBLIC_MATRIX_OIDC_CLIENT_ID` | client id acordado de antemano con MAS | registro dinámico |
+| `EXPO_PUBLIC_MATRIX_OIDC_REDIRECT_URI` | a dónde vuelve el navegador | `allo://matrix/oidc` en nativo, `/matrix-oidc-callback.html` en web |
+
+No hay homeserver por defecto a propósito: tendría que ser el de producción de
+Allo, que no existe, o el de otro, y una build que habla en silencio con un
+servidor que nadie eligió es peor que una que no arranca.
+
+Para desarrollo:
+
+```bash
+EXPO_PUBLIC_CHAT_BACKEND=matrix \
+EXPO_PUBLIC_MATRIX_HOMESERVER=https://matrix.org \
+bun run dev:frontend
+```
+
+## 3. Cómo está montado
+
+```
+lib/chat/
+  backend.ts          la bandera
+  matrixConfig.ts     homeserver, OIDC, almacén
+  matrixRuntime.ts    el cliente y su ciclo de vida, fuera de React
+  roomListSource.ts   la lista de salas como external store
+  timelineSource.ts   un timeline por sala, ídem, más paginar y enviar
+  matrixViewModel.ts  AlloRoomSummary → Conversation, AlloTimelineItem → Message
+hooks/
+  useMatrixRuntime.ts       useSyncExternalStore sobre el runtime
+  useMatrixConversations.ts → Conversation[] | undefined
+  useMatrixTimeline.ts      → { messages, loadOlder, send, … } | undefined
+components/matrix/
+  MatrixSignInGate.tsx      pinta a sus hijos salvo que falte sesión
+```
+
+**Ningún componente de presentación cambió.** `MessageBubble`, `MessageBlock`,
+`DaySeparator`, las filas de la lista, el layout de tres paneles y los temas por
+conversación siguen recibiendo `Conversation` y `Message`. Lo único que cambia es
+de dónde salen, y en cada punto de conexión la rama vieja es la expresión que ya
+estaba:
+
+```ts
+const conversations = roomConversations ?? storedConversations;
+const messages = matrixTimeline?.messages ?? storedMessages;
+```
+
+Los hooks devuelven `undefined` —no una lista vacía— cuando la bandera está
+apagada, que es lo que hace que el `??` sea suficiente.
+
+**Sin `useEffect` para nada de esto.** El cliente con su bucle de sync sí es
+sincronización con un sistema externo, que es el caso legítimo, pero pertenece a
+la *app* y no a la pantalla que se montó primero: un Effect lo ataría al ciclo de
+vida de un componente, y desmontar la lista pararía el sync. Vive en
+`matrixRuntime.ts` a nivel de módulo y React lo lee con `useSyncExternalStore`.
+Suscribirse es lo que lo arranca, así que ninguna pantalla tiene que acordarse de
+encenderlo.
+
+## 4. Qué llega a la pantalla hoy
+
+- Lista de conversaciones, en el orden que da el puerto (no se reordena aquí).
+- Timeline de una conversación, con paginación hacia atrás al llegar arriba.
+- Envío de texto.
+- Login OIDC en tres pasos, con `expo-web-browser`.
+- Estados propios para los eventos sin texto: no descifrable, redactado, y
+  «Allo no sabe dibujar esto todavía». Ninguno se pinta como una burbuja vacía.
+
+## 5. Qué no llega, y por qué
+
+Por orden de cuánto se nota:
+
+1. **La sesión no se persiste.** Cada arranque es un login nuevo y, por tanto, un
+   dispositivo Matrix nuevo. No es un olvido: `AlloSession` documenta que el SDK
+   rota los tokens sin avisar a la app y que una sesión guardada se queda rancia
+   y deja de restaurarse. Cerrar ese hueco es trabajo en el puerto. Por lo mismo
+   el almacén es `in-memory`: un almacén de cripto en disco sólo acumularía las
+   claves de dispositivos que nadie va a volver a usar.
+2. **La fila de la lista no tiene ni vista previa ni hora.** `AlloRoomSummary` no
+   lleva último evento ni marca de actividad. El orden no se pierde —lo da el
+   puerto— pero el texto y la hora se quedan vacíos, que es lo que el formateador
+   dibuja como nada. Inventar `Date.now()` pondría «ahora» al lado de cada
+   conversación de la app.
+3. **El tamaño de letra por mensaje no viaja.** `AlloTimelineHandle.sendText`
+   manda un cuerpo y nada más; `so.oxy.allo.font_size` (§4.2 de
+   `data-model.md`) necesita una llamada que el puerto no tiene.
+4. **Un envío fallido dibuja el reloj, no un error.** `MessageMetadata` sólo
+   conoce pendiente / enviado / entregado / leído. El reloj es cierto en móvil,
+   donde la cola del SDK sigue reintentando, y optimista en web, donde no.
+5. **Sin reacciones, sin edición, sin borrado, sin adjuntos, sin recibos de
+   lectura, sin indicador de escribiendo, sin crear conversaciones.** El puerto
+   no expone ninguna de esas operaciones todavía.
+6. **Sin cerrar sesión.** El único camino de vuelta es reiniciar la app.
+7. **Las invitaciones aparecen como filas normales.** El puerto las incluye
+   («todo lo que el usuario no ha abandonado»), y abrir una probablemente no dé
+   timeline. No se filtran aquí: la definición de qué es una conversación es del
+   puerto, no de este mapeo.
+
+## 6. Web
+
+El redirect de OIDC apunta a `public/matrix-oidc-callback.html`, un fichero
+estático que **no** es una ruta de la app. El export web responde `index.html` a
+las rutas desconocidas (`public/_redirects`), así que un redirect a una ruta de
+la app arrancaría una segunda copia de Allo dentro del popup — y dos copias son
+dos `MatrixClient` sobre un IndexedDB, que es la corrupción del almacén de cripto
+que avisa el SDK. Sigue en pie lo que dice `client.web.ts`: Allo en web es segura
+en una pestaña y no está probada en dos.

--- a/packages/frontend/__tests__/chat/backend.test.ts
+++ b/packages/frontend/__tests__/chat/backend.test.ts
@@ -1,0 +1,51 @@
+import { CHAT_BACKEND, CHAT_BACKEND_VARIABLE, parseChatBackend } from '@/lib/chat/backend';
+
+/**
+ * The flag that decides which messaging system a build talks to.
+ *
+ * The case worth being strict about is the third one: a value that is neither
+ * backend has to stop the build rather than pick one, because someone who
+ * mistypes it gets an app where every screen works and none of them talk to the
+ * system they meant.
+ */
+describe('parseChatBackend', () => {
+  it('leaves an unconfigured build on the Express API', () => {
+    expect(parseChatBackend(undefined)).toBe('allo-api');
+  });
+
+  it('treats an empty value as unconfigured', () => {
+    // Which is what a shell exports for a variable set to nothing, and what
+    // Expo substitutes for one that is declared and blank.
+    expect(parseChatBackend('')).toBe('allo-api');
+  });
+
+  it('selects Matrix when asked for it', () => {
+    expect(parseChatBackend('matrix')).toBe('matrix');
+  });
+
+  it('selects the Express API when asked for it by name', () => {
+    expect(parseChatBackend('allo-api')).toBe('allo-api');
+  });
+
+  it('refuses a value that is neither backend, and says what to write', () => {
+    expect(() => parseChatBackend('Matrix')).toThrow(CHAT_BACKEND_VARIABLE);
+    expect(() => parseChatBackend('Matrix')).toThrow(/allo-api, matrix/);
+  });
+
+  it('refuses a value that only looks like a switch', () => {
+    // `=true` is the shape people reach for first, and silently selecting the
+    // old backend for it is exactly the failure this refusal exists to prevent.
+    expect(() => parseChatBackend('true')).toThrow();
+    expect(() => parseChatBackend('1')).toThrow();
+  });
+});
+
+describe('CHAT_BACKEND', () => {
+  it('is the Express API in a build that has not asked for anything else', () => {
+    // The default the whole migration rests on: an ordinary build — this test
+    // run included — is the app as it was, and Matrix is what you opt into.
+    // Reading the constant and not the function is the point: this is the value
+    // every `CHAT_BACKEND === 'matrix'` in the app compares against.
+    expect(CHAT_BACKEND).toBe('allo-api');
+  });
+});

--- a/packages/frontend/__tests__/chat/matrixConfig.test.ts
+++ b/packages/frontend/__tests__/chat/matrixConfig.test.ts
@@ -1,0 +1,53 @@
+import {
+  HOMESERVER_VARIABLE,
+  readHomeserverUrl,
+  readOidcMetadata,
+  resolveRedirectUri,
+} from '@/lib/chat/matrixConfig';
+
+describe('readHomeserverUrl', () => {
+  it('returns the configured homeserver', () => {
+    expect(readHomeserverUrl('https://matrix.org')).toBe('https://matrix.org');
+  });
+
+  it('refuses to invent one, and names the variable to set', () => {
+    // A default would have to be somebody's homeserver. A build that quietly
+    // talks to a server nobody chose is worse than one that will not start.
+    expect(() => readHomeserverUrl(undefined)).toThrow(HOMESERVER_VARIABLE);
+    expect(() => readHomeserverUrl('')).toThrow(HOMESERVER_VARIABLE);
+  });
+});
+
+describe('resolveRedirectUri', () => {
+  it('uses the configured redirect URI unchanged', () => {
+    // It has to match what was registered with the authorization server exactly,
+    // so a deployment that sets one gets that one and no normalisation.
+    expect(resolveRedirectUri('https://allo.you/callback')).toBe('https://allo.you/callback');
+  });
+});
+
+describe('readOidcMetadata', () => {
+  it('registers dynamically when no client id is configured', () => {
+    const metadata = readOidcMetadata('https://matrix.org', undefined, 'allo://matrix/oidc');
+
+    expect(metadata.staticRegistrations).toBeUndefined();
+    expect(metadata.redirectUri).toBe('allo://matrix/oidc');
+  });
+
+  it('treats an empty client id as no client id', () => {
+    const metadata = readOidcMetadata('https://matrix.org', '', 'allo://matrix/oidc');
+
+    // An empty map would tell the port a registration exists and hand it "",
+    // which the authorization server rejects with an error about the client.
+    expect(metadata.staticRegistrations).toBeUndefined();
+  });
+
+  it('keys a configured client id by homeserver', () => {
+    const metadata = readOidcMetadata('https://allo.you', 'allo-web', 'allo://matrix/oidc');
+
+    // By homeserver and not by issuer: the issuer is only known once the client
+    // has asked the homeserver for its authorization metadata, and the port
+    // accepts either key.
+    expect(metadata.staticRegistrations?.get('https://allo.you')).toBe('allo-web');
+  });
+});

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -1,0 +1,421 @@
+import {
+  MatrixRuntime,
+  type AuthorizationOutcome,
+  type MatrixRuntimeDependencies,
+} from '@/lib/chat/matrixRuntime';
+import type {
+  AlloChatClient,
+  AlloChatClientConfig,
+  AlloEncryptionState,
+  AlloOidcLoginRequest,
+  AlloRoomListHandle,
+  AlloSession,
+  AlloSyncState,
+  AlloTimelineHandle,
+  AlloUnsubscribe,
+} from '@/lib/matrix/types';
+
+/**
+ * The client's lifecycle: building it, signing in through a browser, and what
+ * happens when any of that fails.
+ *
+ * Everything the runtime touches that is not its own logic is injected, so all
+ * of this runs without a homeserver, without a browser and without either Matrix
+ * SDK.
+ */
+
+const CONFIG: AlloChatClientConfig = {
+  homeserverUrl: 'https://matrix.example',
+  store: { kind: 'in-memory' },
+  oidc: {
+    clientName: 'Allo',
+    redirectUri: 'allo://matrix/oidc',
+    clientUri: 'https://allo.you',
+  },
+};
+
+const SESSION: AlloSession = {
+  userId: '@nate:matrix.example',
+  deviceId: 'DEVICE',
+  homeserverUrl: 'https://matrix.example',
+  accessToken: 'secret-access-token',
+  refreshToken: 'secret-refresh-token',
+  authData: undefined,
+};
+
+class FakeLoginRequest implements AlloOidcLoginRequest {
+  readonly authorizationUrl = 'https://auth.example/authorize?state=xyz';
+  completedWith: string | undefined;
+  aborts = 0;
+  completion: () => Promise<AlloSession> = async () => SESSION;
+
+  async complete(callbackUrl: string): Promise<AlloSession> {
+    this.completedWith = callbackUrl;
+    return this.completion();
+  }
+
+  async abort(): Promise<void> {
+    this.aborts += 1;
+  }
+}
+
+class FakeChatClient implements AlloChatClient {
+  readonly request = new FakeLoginRequest();
+  beginOidcLoginCalls = 0;
+  startSyncCalls = 0;
+  closes = 0;
+  beginOidcLoginFails: Error | undefined;
+  startSyncFails: Error | undefined;
+
+  #syncListeners = new Set<(state: AlloSyncState) => void>();
+  #syncState: AlloSyncState = 'idle';
+
+  async beginOidcLogin(): Promise<AlloOidcLoginRequest> {
+    this.beginOidcLoginCalls += 1;
+    if (this.beginOidcLoginFails !== undefined) {
+      throw this.beginOidcLoginFails;
+    }
+    return this.request;
+  }
+
+  async restoreSession(): Promise<void> {}
+
+  session(): AlloSession {
+    return SESSION;
+  }
+
+  async startSync(): Promise<void> {
+    this.startSyncCalls += 1;
+    if (this.startSyncFails !== undefined) {
+      throw this.startSyncFails;
+    }
+  }
+
+  async stopSync(): Promise<void> {}
+
+  observeSyncState(onChange: (state: AlloSyncState) => void): AlloUnsubscribe {
+    this.#syncListeners.add(onChange);
+    onChange(this.#syncState);
+    return () => {
+      this.#syncListeners.delete(onChange);
+    };
+  }
+
+  /** Drives the sync loop from a test. */
+  emitSyncState(state: AlloSyncState): void {
+    this.#syncState = state;
+    for (const listener of this.#syncListeners) {
+      listener(state);
+    }
+  }
+
+  async observeRooms(): Promise<AlloRoomListHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async roomEncryption(): Promise<AlloEncryptionState> {
+    return 'encrypted';
+  }
+
+  async openTimeline(): Promise<AlloTimelineHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async close(): Promise<void> {
+    this.closes += 1;
+  }
+}
+
+interface Harness {
+  readonly runtime: MatrixRuntime;
+  readonly client: FakeChatClient;
+  /** What the browser step was asked to open, in order. */
+  readonly opened: string[];
+  createClientCalls: number;
+}
+
+function harness(
+  overrides: Partial<MatrixRuntimeDependencies> & {
+    outcome?: () => Promise<AuthorizationOutcome>;
+    createClientFails?: () => Error | undefined;
+  } = {},
+): Harness {
+  const client = new FakeChatClient();
+  const opened: string[] = [];
+  const result: Harness = {
+    client,
+    opened,
+    createClientCalls: 0,
+    runtime: new MatrixRuntime({
+      config: () => CONFIG,
+      createClient: async () => {
+        result.createClientCalls += 1;
+        const failure = overrides.createClientFails?.();
+        if (failure !== undefined) {
+          throw failure;
+        }
+        return client;
+      },
+      authorize: async (url) => {
+        opened.push(url);
+        return (await overrides.outcome?.()) ?? { kind: 'returned', callbackUrl: 'allo://matrix/oidc?code=abc' };
+      },
+      ...overrides,
+    }),
+  };
+  return result;
+}
+
+/** Lets every already-queued promise settle. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('MatrixRuntime lifecycle', () => {
+  it('reports nothing until something subscribes', () => {
+    const { runtime, createClientCalls } = harness();
+
+    expect(runtime.getState().phase).toBe('idle');
+    expect(createClientCalls).toBe(0);
+  });
+
+  it('builds the client when the first subscriber arrives', async () => {
+    const context = harness();
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.createClientCalls).toBe(1);
+    expect(context.runtime.getState().phase).toBe('signed-out');
+  });
+
+  it('builds one client however many subscribers arrive', async () => {
+    // Every screen that reads the state subscribes. Building per subscriber
+    // would mean several clients on one crypto store, which is the corruption
+    // the port warns about.
+    const context = harness();
+
+    context.runtime.subscribe(() => {});
+    context.runtime.subscribe(() => {});
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.createClientCalls).toBe(1);
+  });
+
+  it('refuses to hand out a client before there is one', () => {
+    const { runtime } = harness();
+
+    expect(() => runtime.client('Observing the conversation list')).toThrow(
+      /Observing the conversation list/,
+    );
+  });
+
+  it('reports a build failure in the state instead of throwing at the subscriber', async () => {
+    const context = harness({
+      createClientFails: () => new Error('the homeserver does not serve sliding sync'),
+    });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.runtime.getState().phase).toBe('failed');
+    expect(context.runtime.getState().error).toContain('does not serve sliding sync');
+  });
+
+  it('rebuilds after a failure rather than repeating it forever', async () => {
+    let failures = 1;
+    const context = harness({
+      createClientFails: () => (failures-- > 0 ? new Error('no network') : undefined),
+    });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+    expect(context.runtime.getState().phase).toBe('failed');
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.createClientCalls).toBe(2);
+    expect(context.runtime.getState().phase).toBe('ready');
+  });
+});
+
+describe('MatrixRuntime sign-in', () => {
+  it('opens the authorization page, finishes it and starts sync', async () => {
+    const context = harness();
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.opened).toEqual(['https://auth.example/authorize?state=xyz']);
+    expect(context.client.request.completedWith).toBe('allo://matrix/oidc?code=abc');
+    expect(context.client.startSyncCalls).toBe(1);
+    expect(context.runtime.getState()).toMatchObject({
+      phase: 'ready',
+      userId: '@nate:matrix.example',
+    });
+  });
+
+  it('abandons the authorization when the user closes the browser', async () => {
+    // The authorization server holds state for an attempt until it is abandoned.
+    // A user who backs out has not failed at anything, so this goes back to
+    // signed out rather than to an error.
+    const context = harness({ outcome: async () => ({ kind: 'dismissed' }) });
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.client.request.aborts).toBe(1);
+    expect(context.runtime.getState().phase).toBe('signed-out');
+    expect(context.runtime.getState().error).toBeUndefined();
+  });
+
+  it('shares one authorization between simultaneous sign-ins', async () => {
+    // Two authorizations would each hold server-side state and only one could be
+    // completed; the other would leave the server holding an attempt forever.
+    let release = (): void => {};
+    const context = harness({
+      outcome: () =>
+        new Promise<AuthorizationOutcome>((resolve) => {
+          release = () => resolve({ kind: 'returned', callbackUrl: 'allo://matrix/oidc?code=abc' });
+        }),
+    });
+
+    const first = context.runtime.signIn();
+    const second = context.runtime.signIn();
+    await settle();
+    release();
+    await Promise.all([first, second]);
+
+    expect(context.client.beginOidcLoginCalls).toBe(1);
+    expect(context.opened).toHaveLength(1);
+  });
+
+  it('does nothing when a sign-in is asked for on a signed-in runtime', async () => {
+    const context = harness();
+
+    await context.runtime.signIn();
+    await context.runtime.signIn();
+
+    expect(context.client.beginOidcLoginCalls).toBe(1);
+  });
+
+  it('reports a completion the homeserver rejected', async () => {
+    const context = harness();
+    context.client.request.completion = async () => {
+      throw new Error('M_UNKNOWN_TOKEN');
+    };
+
+    await context.runtime.signIn();
+
+    expect(context.runtime.getState().phase).toBe('failed');
+    expect(context.runtime.getState().error).toContain('M_UNKNOWN_TOKEN');
+  });
+
+  it('never passes through ready when sync could not be started', async () => {
+    // Every phase, not just the last one. `ready` is what the room list and the
+    // timelines wait for, and they open against the port the moment they see it
+    // — so a runtime that says `ready` for even one notification before sync is
+    // up hands them a client that raises MatrixSyncNotStartedError. Asserting
+    // only the final state would not notice: the failure lands a moment later
+    // and the end state is the same either way.
+    const context = harness();
+    context.client.startSyncFails = new Error('sliding sync is not available');
+    const phases: string[] = [];
+    context.runtime.subscribe(() => {
+      phases.push(context.runtime.getState().phase);
+    });
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(phases).not.toContain('ready');
+    expect(context.runtime.getState().phase).toBe('failed');
+  });
+
+  it('starts sync before it reports itself ready', async () => {
+    const context = harness();
+    const phases: string[] = [];
+    context.runtime.subscribe(() => {
+      phases.push(context.runtime.getState().phase);
+    });
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.client.startSyncCalls).toBe(1);
+    expect(phases).toContain('ready');
+  });
+
+  it('never puts the callback URL in the state it publishes', async () => {
+    // The callback carries the authorization code. It is a credential, and the
+    // state is read by components and shown on screen.
+    const context = harness();
+
+    await context.runtime.signIn();
+
+    expect(JSON.stringify(context.runtime.getState())).not.toContain('code=abc');
+  });
+});
+
+describe('MatrixRuntime notifications', () => {
+  it('tells subscribers when the phase changes', async () => {
+    const context = harness();
+    let notifications = 0;
+    context.runtime.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+
+    expect(notifications).toBeGreaterThan(0);
+  });
+
+  it('stays quiet when the sync loop repeats a state it already reported', async () => {
+    // `useSyncExternalStore` re-renders on every notification whose snapshot is a
+    // new object. A sync heartbeat that republished `running` would re-render the
+    // whole conversation list for nothing.
+    const context = harness();
+    await context.runtime.signIn();
+    context.client.emitSyncState('running');
+
+    let notifications = 0;
+    context.runtime.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+    notifications = 0;
+
+    context.client.emitSyncState('running');
+    context.client.emitSyncState('running');
+
+    expect(notifications).toBe(0);
+
+    context.client.emitSyncState('offline');
+    expect(notifications).toBe(1);
+  });
+
+  it('answers with the same snapshot object while nothing changes', async () => {
+    const context = harness();
+    await context.runtime.signIn();
+
+    const first = context.runtime.getState();
+    context.client.emitSyncState(first.sync);
+
+    expect(context.runtime.getState()).toBe(first);
+  });
+
+  it('stops telling a subscriber that has unsubscribed', async () => {
+    const context = harness();
+    await context.runtime.signIn();
+
+    let notifications = 0;
+    const unsubscribe = context.runtime.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+    unsubscribe();
+
+    context.client.emitSyncState('offline');
+
+    expect(notifications).toBe(0);
+  });
+});

--- a/packages/frontend/__tests__/chat/matrixViewModel.test.ts
+++ b/packages/frontend/__tests__/chat/matrixViewModel.test.ts
@@ -1,0 +1,188 @@
+import { toConversation, toMessage, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
+import type { AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
+
+/**
+ * The translation from what the port reports to what Allo's chat components
+ * draw. Every gap between the two models shows up here, and this is where it is
+ * pinned down so it cannot be closed by inventing a value.
+ */
+
+const LABELS: UnreadableEventLabels = {
+  undecryptable: 'cannot be read on this device',
+  redacted: 'was deleted',
+  unsupported: (description) => `cannot show this yet (${description})`,
+};
+
+function room(overrides: Partial<AlloRoomSummary> = {}): AlloRoomSummary {
+  return {
+    roomId: '!room:allo.you',
+    displayName: 'Alice',
+    avatarUrl: undefined,
+    isDirect: true,
+    membership: 'joined',
+    encryption: 'encrypted',
+    unreadCount: 0,
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<AlloTimelineItem> = {}): AlloTimelineItem {
+  return {
+    key: 'row-1',
+    id: { kind: 'remote', eventId: '$one' },
+    sender: '@alice:allo.you',
+    senderDisplayName: 'Alice',
+    sentAt: 1_700_000_000_000,
+    isOwn: false,
+    sendState: 'sent',
+    content: { kind: 'text', body: 'hello', isEdited: false },
+    ...overrides,
+  };
+}
+
+describe('toConversation', () => {
+  it('carries the room across as a direct conversation', () => {
+    const conversation = toConversation(room({ unreadCount: 3, avatarUrl: 'mxc://a' }));
+
+    expect(conversation).toMatchObject({
+      id: '!room:allo.you',
+      type: 'direct',
+      name: 'Alice',
+      unreadCount: 3,
+      avatar: 'mxc://a',
+    });
+  });
+
+  it('calls a room that is not a direct message a group', () => {
+    expect(toConversation(room({ isDirect: false })).type).toBe('group');
+  });
+
+  it('falls back to the room id while the name has not synced', () => {
+    // A blank row is worse than an ugly one: the user can still tell two
+    // unnamed conversations apart by their ids, and cannot tell two blanks apart.
+    expect(toConversation(room({ displayName: undefined })).name).toBe('!room:allo.you');
+  });
+
+  it('leaves the last message empty rather than inventing one', () => {
+    // The port's room summary carries no latest event. Reading one would mean a
+    // timeline open per room in the list.
+    expect(toConversation(room()).lastMessage).toBe('');
+  });
+
+  it('leaves the timestamp empty rather than saying "now"', () => {
+    // This is the mistake this test exists to prevent. `AlloRoomSummary` has no
+    // activity time, and `new Date().toISOString()` would put the current time
+    // beside every conversation in the app — including one nobody has touched in
+    // a year. An empty string is what the formatter renders as nothing.
+    expect(toConversation(room()).timestamp).toBe('');
+  });
+
+  it('leaves the conversation theme unset', () => {
+    // Themes are to travel as an encrypted timeline event and nothing writes one
+    // yet, so a Matrix conversation uses the app's theme.
+    expect(toConversation(room()).theme).toBeUndefined();
+  });
+});
+
+describe('toMessage', () => {
+  it('carries a text message across', () => {
+    const message = toMessage(event(), '!room:allo.you', LABELS);
+
+    expect(message).toMatchObject({
+      id: 'row-1',
+      text: 'hello',
+      senderId: '@alice:allo.you',
+      senderName: 'Alice',
+      isSent: false,
+      conversationId: '!room:allo.you',
+    });
+    expect(message.timestamp.getTime()).toBe(1_700_000_000_000);
+  });
+
+  it('keys the row by the port key and not the event id', () => {
+    // The key is what survives a message the user just sent turning from a local
+    // echo into an event with an id. Keying by event id would remount the row at
+    // exactly the moment it must not move.
+    const message = toMessage(
+      event({ key: 'row-7', id: { kind: 'local', transactionId: 'txn-1' } }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.id).toBe('row-7');
+  });
+
+  it('says an undecryptable event arrived and cannot be read', () => {
+    // An event the SDK could not decrypt carries no body at all. Rendering it as
+    // an empty bubble makes "arrived but unreadable" look like "sent nothing",
+    // and a device set up today sees it for every message older than itself.
+    const message = toMessage(
+      event({ content: { kind: 'undecryptable' } }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.text).toBe('cannot be read on this device');
+    expect(message.text).not.toBe('');
+    expect(message.isEncrypted).toBe(true);
+  });
+
+  it('says a redacted event was deleted', () => {
+    const message = toMessage(
+      event({ content: { kind: 'redacted' } }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.text).toBe('was deleted');
+    // Not the same fact as an undecryptable one: there is nothing to read, not
+    // something unreadable.
+    expect(message.isEncrypted).toBe(false);
+  });
+
+  it('names the kind of event it cannot draw', () => {
+    const message = toMessage(
+      event({ content: { kind: 'unsupported', description: 'm.room.member' } }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.text).toBe('cannot show this yet (m.room.member)');
+  });
+
+  it('gives no send status to a message the viewer did not send', () => {
+    // The bubble draws a status only for the sender's own messages; reporting
+    // one for anyone else's would put a tick under a message the viewer received.
+    expect(toMessage(event({ isOwn: false }), '!room:allo.you', LABELS).readStatus).toBeUndefined();
+  });
+
+  it('shows a clock while a message the viewer sent is still on its way', () => {
+    const message = toMessage(
+      event({ isOwn: true, sendState: 'pending' }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.readStatus).toBe('pending');
+  });
+
+  it('shows a tick once the homeserver has the message', () => {
+    const message = toMessage(event({ isOwn: true, sendState: 'sent' }), '!room:allo.you', LABELS);
+
+    expect(message.readStatus).toBe('sent');
+  });
+
+  it('does not claim a failed send reached the homeserver', () => {
+    // The bubble has no failed state, so this settles for the clock. What it
+    // must never do is report `sent`, which draws the tick that tells the user
+    // the message arrived.
+    const message = toMessage(
+      event({ isOwn: true, sendState: 'failed' }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.readStatus).not.toBe('sent');
+    expect(message.readStatus).toBe('pending');
+  });
+});

--- a/packages/frontend/__tests__/chat/roomListSource.test.ts
+++ b/packages/frontend/__tests__/chat/roomListSource.test.ts
@@ -1,0 +1,349 @@
+import { RoomListSource } from '@/lib/chat/roomListSource';
+import {
+  IDLE_RUNTIME_STATE,
+  type MatrixRuntimeLike,
+  type MatrixRuntimeState,
+} from '@/lib/chat/matrixRuntime';
+import type {
+  AlloChatClient,
+  AlloEncryptionState,
+  AlloOidcLoginRequest,
+  AlloRoomListHandle,
+  AlloRoomSummary,
+  AlloSession,
+  AlloSyncState,
+  AlloTimelineHandle,
+  AlloUnsubscribe,
+} from '@/lib/matrix/types';
+
+/**
+ * The adapter between the port's room list and `useSyncExternalStore`.
+ *
+ * What it has to get right is the part the port leaves to its caller: the list
+ * can only be opened once sync is running, so opening waits for the runtime, and
+ * anything still resolving when the runtime goes away has to be given up rather
+ * than published.
+ */
+
+function summary(roomId: string): AlloRoomSummary {
+  return {
+    roomId,
+    displayName: roomId,
+    avatarUrl: undefined,
+    isDirect: true,
+    membership: 'joined',
+    encryption: 'encrypted',
+    unreadCount: 0,
+  };
+}
+
+class FakeRoomList implements AlloRoomListHandle {
+  closes = 0;
+  #rooms: readonly AlloRoomSummary[] = [];
+
+  constructor(private readonly onChange: (rooms: readonly AlloRoomSummary[]) => void) {}
+
+  rooms(): readonly AlloRoomSummary[] {
+    return this.#rooms;
+  }
+
+  /** What the port does when sync delivers a change. */
+  publish(rooms: readonly AlloRoomSummary[]): void {
+    this.#rooms = rooms;
+    this.onChange(rooms);
+  }
+
+  close(): void {
+    this.closes += 1;
+  }
+}
+
+/**
+ * A client that can hand out room lists and nothing else.
+ *
+ * Everything the source under test never calls throws rather than returning a
+ * plausible value, so a change that started calling one of them fails here
+ * instead of quietly working against a stub.
+ */
+class FakeChatClient implements AlloChatClient {
+  readonly lists: FakeRoomList[] = [];
+  observeRoomsCalls = 0;
+  /** When set, `observeRooms` waits for {@link release} before resolving. */
+  #pending: (() => void) | undefined;
+  #holdOpen = false;
+
+  holdOpen(): void {
+    this.#holdOpen = true;
+  }
+
+  release(): void {
+    const pending = this.#pending;
+    this.#pending = undefined;
+    pending?.();
+  }
+
+  async observeRooms(
+    onChange: (rooms: readonly AlloRoomSummary[]) => void,
+  ): Promise<AlloRoomListHandle> {
+    this.observeRoomsCalls += 1;
+    const list = new FakeRoomList(onChange);
+    this.lists.push(list);
+    if (this.#holdOpen) {
+      await new Promise<void>((resolve) => {
+        this.#pending = resolve;
+      });
+    }
+    return list;
+  }
+
+  async beginOidcLogin(): Promise<AlloOidcLoginRequest> {
+    throw new Error('not used by these tests');
+  }
+
+  async restoreSession(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  session(): AlloSession {
+    throw new Error('not used by these tests');
+  }
+
+  async startSync(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async stopSync(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  observeSyncState(_onChange: (state: AlloSyncState) => void): AlloUnsubscribe {
+    throw new Error('not used by these tests');
+  }
+
+  async roomEncryption(): Promise<AlloEncryptionState> {
+    throw new Error('not used by these tests');
+  }
+
+  async openTimeline(): Promise<AlloTimelineHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async close(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+}
+
+class FakeRuntime implements MatrixRuntimeLike {
+  readonly chatClient = new FakeChatClient();
+
+  #state: MatrixRuntimeState = IDLE_RUNTIME_STATE;
+  readonly #listeners = new Set<() => void>();
+
+  subscribe(listener: () => void): AlloUnsubscribe {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  getState(): MatrixRuntimeState {
+    return this.#state;
+  }
+
+  become(phase: MatrixRuntimeState['phase']): void {
+    this.#state = { ...this.#state, phase };
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  client(): AlloChatClient {
+    return this.chatClient;
+  }
+}
+
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('RoomListSource', () => {
+  it('answers with an empty list before anything is open', () => {
+    const source = new RoomListSource(new FakeRuntime());
+
+    expect(source.getSnapshot()).toEqual([]);
+  });
+
+  it('does not open a room list while there is no session', async () => {
+    // Opening one before sync runs is what the port raises
+    // MatrixSyncNotStartedError for, and it would arrive as a logged error on a
+    // screen that is only waiting for a sign-in.
+    const runtime = new FakeRuntime();
+    const source = new RoomListSource(runtime);
+
+    source.subscribe(() => {});
+    await settle();
+
+    expect(runtime.chatClient.observeRoomsCalls).toBe(0);
+  });
+
+  it('opens the room list of a runtime that was already ready', async () => {
+    // The runtime notifies on change. A source that only reacted to changes
+    // would never open against a runtime that became ready first.
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+
+    source.subscribe(() => {});
+    await settle();
+
+    expect(runtime.chatClient.observeRoomsCalls).toBe(1);
+  });
+
+  it('opens the room list when the runtime becomes ready', async () => {
+    const runtime = new FakeRuntime();
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.become('ready');
+    await settle();
+
+    expect(runtime.chatClient.observeRoomsCalls).toBe(1);
+  });
+
+  it('opens one room list however many subscribers arrive', async () => {
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+
+    source.subscribe(() => {});
+    source.subscribe(() => {});
+    await settle();
+
+    expect(runtime.chatClient.observeRoomsCalls).toBe(1);
+  });
+
+  it('publishes what the port reports, and tells its subscribers', async () => {
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    let notifications = 0;
+    source.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+    notifications = 0;
+
+    const rooms = [summary('!one:allo.you'), summary('!two:allo.you')];
+    runtime.chatClient.lists[0].publish(rooms);
+
+    expect(source.getSnapshot()).toBe(rooms);
+    expect(notifications).toBe(1);
+  });
+
+  it('keeps the list in the order the port gave it', async () => {
+    // The port hands back an ordered list — Rust's ordering on native, the web
+    // half's own sort on web. Re-sorting here would be a second, different
+    // opinion about which conversation belongs on top.
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.chatClient.lists[0].publish([summary('!z:allo.you'), summary('!a:allo.you')]);
+
+    expect(source.getSnapshot().map((room) => room.roomId)).toEqual([
+      '!z:allo.you',
+      '!a:allo.you',
+    ]);
+  });
+
+  it('answers with the same array while nothing changes', async () => {
+    // `useSyncExternalStore` throws if the snapshot keeps being a new object.
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+
+    expect(source.getSnapshot()).toBe(source.getSnapshot());
+  });
+
+  it('closes the room list and empties itself when the session goes away', async () => {
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+    runtime.chatClient.lists[0].publish([summary('!one:allo.you')]);
+
+    runtime.become('signed-out');
+
+    expect(runtime.chatClient.lists[0].closes).toBe(1);
+    // Not the stale list: it belongs to a session that no longer exists, and
+    // showing it would tell the user they are still signed in.
+    expect(source.getSnapshot()).toEqual([]);
+  });
+
+  it('closes a room list that arrives after the session went away', async () => {
+    // The race this exists for: `observeRooms` is asynchronous, so a sign-out
+    // between the call and its answer leaves a live subscription nobody owns.
+    const runtime = new FakeRuntime();
+    runtime.chatClient.holdOpen();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.become('signed-out');
+    runtime.chatClient.release();
+    await settle();
+
+    expect(runtime.chatClient.lists[0].closes).toBe(1);
+    expect(source.getSnapshot()).toEqual([]);
+  });
+
+  it('ignores a list published by a handle from a session that has ended', async () => {
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+    const stale = runtime.chatClient.lists[0];
+
+    runtime.become('signed-out');
+    stale.publish([summary('!ghost:allo.you')]);
+
+    expect(source.getSnapshot()).toEqual([]);
+  });
+
+  it('reopens the room list after signing in again', async () => {
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.become('signed-out');
+    runtime.become('ready');
+    await settle();
+
+    expect(runtime.chatClient.observeRoomsCalls).toBe(2);
+  });
+
+  it('stops telling a subscriber that has unsubscribed', async () => {
+    const runtime = new FakeRuntime();
+    runtime.become('ready');
+    const source = new RoomListSource(runtime);
+    let notifications = 0;
+    const unsubscribe = source.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+    unsubscribe();
+    notifications = 0;
+
+    runtime.chatClient.lists[0].publish([summary('!one:allo.you')]);
+
+    expect(notifications).toBe(0);
+  });
+});

--- a/packages/frontend/__tests__/chat/timelineSource.test.ts
+++ b/packages/frontend/__tests__/chat/timelineSource.test.ts
@@ -1,0 +1,445 @@
+import {
+  IDLE_RUNTIME_STATE,
+  type MatrixRuntimeLike,
+  type MatrixRuntimeState,
+} from '@/lib/chat/matrixRuntime';
+import { TimelineSource, timelineSource } from '@/lib/chat/timelineSource';
+import type {
+  AlloChatClient,
+  AlloEncryptionState,
+  AlloOidcLoginRequest,
+  AlloPaginationOutcome,
+  AlloRoomListHandle,
+  AlloSession,
+  AlloSyncState,
+  AlloTimelineHandle,
+  AlloTimelineItem,
+  AlloUnsubscribe,
+} from '@/lib/matrix/types';
+
+/**
+ * One conversation's timeline behind `useSyncExternalStore`, plus the two things
+ * only it can do: ask for older messages, and send.
+ *
+ * The pagination guards are the part with teeth. A list calls its "load more"
+ * handler as the user scrolls, which is to say often, and without the guards
+ * every frame near the top of the conversation would be another request to the
+ * homeserver.
+ */
+
+const ROOM = '!room:allo.you';
+
+function event(key: string): AlloTimelineItem {
+  return {
+    key,
+    id: { kind: 'remote', eventId: `$${key}` },
+    sender: '@alice:allo.you',
+    senderDisplayName: 'Alice',
+    sentAt: 1_700_000_000_000,
+    isOwn: false,
+    sendState: 'sent',
+    content: { kind: 'text', body: key, isEdited: false },
+  };
+}
+
+class FakeTimeline implements AlloTimelineHandle {
+  closes = 0;
+  paginateCalls: number[] = [];
+  sent: string[] = [];
+  outcome: AlloPaginationOutcome = 'more-available';
+  /** When set, `paginateBackwards` waits for {@link releasePagination}. */
+  #pendingPagination: (() => void) | undefined;
+  #holdPagination = false;
+  #items: readonly AlloTimelineItem[] = [];
+
+  constructor(private readonly onChange: (items: readonly AlloTimelineItem[]) => void) {}
+
+  items(): readonly AlloTimelineItem[] {
+    return this.#items;
+  }
+
+  publish(items: readonly AlloTimelineItem[]): void {
+    this.#items = items;
+    this.onChange(items);
+  }
+
+  holdPagination(): void {
+    this.#holdPagination = true;
+  }
+
+  releasePagination(): void {
+    const pending = this.#pendingPagination;
+    this.#pendingPagination = undefined;
+    pending?.();
+  }
+
+  async paginateBackwards(count: number): Promise<AlloPaginationOutcome> {
+    this.paginateCalls.push(count);
+    if (this.#holdPagination) {
+      await new Promise<void>((resolve) => {
+        this.#pendingPagination = resolve;
+      });
+    }
+    return this.outcome;
+  }
+
+  async sendText(body: string): Promise<void> {
+    this.sent.push(body);
+  }
+
+  close(): void {
+    this.closes += 1;
+  }
+}
+
+/** A client that can open timelines and nothing else. */
+class FakeChatClient implements AlloChatClient {
+  readonly timelines: FakeTimeline[] = [];
+  openTimelineCalls: string[] = [];
+  #pendingOpen: (() => void) | undefined;
+  #holdOpen = false;
+
+  holdOpen(): void {
+    this.#holdOpen = true;
+  }
+
+  releaseOpen(): void {
+    const pending = this.#pendingOpen;
+    this.#pendingOpen = undefined;
+    pending?.();
+  }
+
+  async openTimeline(
+    roomId: string,
+    onChange: (items: readonly AlloTimelineItem[]) => void,
+  ): Promise<AlloTimelineHandle> {
+    this.openTimelineCalls.push(roomId);
+    const timeline = new FakeTimeline(onChange);
+    this.timelines.push(timeline);
+    if (this.#holdOpen) {
+      await new Promise<void>((resolve) => {
+        this.#pendingOpen = resolve;
+      });
+    }
+    return timeline;
+  }
+
+  async beginOidcLogin(): Promise<AlloOidcLoginRequest> {
+    throw new Error('not used by these tests');
+  }
+
+  async restoreSession(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  session(): AlloSession {
+    throw new Error('not used by these tests');
+  }
+
+  async startSync(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async stopSync(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  observeSyncState(_onChange: (state: AlloSyncState) => void): AlloUnsubscribe {
+    throw new Error('not used by these tests');
+  }
+
+  async observeRooms(): Promise<AlloRoomListHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async roomEncryption(): Promise<AlloEncryptionState> {
+    throw new Error('not used by these tests');
+  }
+
+  async close(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+}
+
+class FakeRuntime implements MatrixRuntimeLike {
+  readonly chatClient = new FakeChatClient();
+
+  #state: MatrixRuntimeState = IDLE_RUNTIME_STATE;
+  readonly #listeners = new Set<() => void>();
+
+  subscribe(listener: () => void): AlloUnsubscribe {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  getState(): MatrixRuntimeState {
+    return this.#state;
+  }
+
+  become(phase: MatrixRuntimeState['phase']): void {
+    this.#state = { ...this.#state, phase };
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  client(): AlloChatClient {
+    return this.chatClient;
+  }
+}
+
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+function readyTimeline(): { runtime: FakeRuntime; source: TimelineSource } {
+  const runtime = new FakeRuntime();
+  runtime.become('ready');
+  return { runtime, source: new TimelineSource(runtime, ROOM, () => {}) };
+}
+
+describe('TimelineSource opening', () => {
+  it('opens nothing until something watches it', async () => {
+    const { runtime } = readyTimeline();
+    await settle();
+
+    expect(runtime.chatClient.openTimelineCalls).toEqual([]);
+  });
+
+  it('opens the room the moment it is watched', async () => {
+    const { runtime, source } = readyTimeline();
+
+    source.subscribe(() => {});
+    await settle();
+
+    expect(runtime.chatClient.openTimelineCalls).toEqual([ROOM]);
+  });
+
+  it('says it is opening before the timeline arrives', async () => {
+    const { runtime, source } = readyTimeline();
+    runtime.chatClient.holdOpen();
+
+    source.subscribe(() => {});
+    await settle();
+
+    // The difference between "this conversation is empty" and "Allo has not
+    // read it yet", which the screen draws differently.
+    expect(source.getSnapshot().isOpening).toBe(true);
+    expect(source.getSnapshot().items).toEqual([]);
+  });
+
+  it('stops saying it is opening once the timeline is there', async () => {
+    const { source } = readyTimeline();
+
+    source.subscribe(() => {});
+    await settle();
+
+    expect(source.getSnapshot().isOpening).toBe(false);
+  });
+
+  it('publishes the rows the port reports', async () => {
+    const { runtime, source } = readyTimeline();
+    let notifications = 0;
+    source.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+    notifications = 0;
+
+    const items = [event('one'), event('two')];
+    runtime.chatClient.timelines[0].publish(items);
+
+    expect(source.getSnapshot().items).toBe(items);
+    expect(notifications).toBe(1);
+  });
+
+  it('closes the timeline when the last watcher goes away', async () => {
+    // Unlike the conversation list, a timeline is per room: keeping every
+    // conversation the user has visited subscribed would keep a listener per
+    // room for the life of the app.
+    const { runtime, source } = readyTimeline();
+    const unsubscribe = source.subscribe(() => {});
+    await settle();
+
+    unsubscribe();
+
+    expect(runtime.chatClient.timelines[0].closes).toBe(1);
+  });
+
+  it('keeps the timeline open while another watcher remains', async () => {
+    const { runtime, source } = readyTimeline();
+    const first = source.subscribe(() => {});
+    source.subscribe(() => {});
+    await settle();
+
+    first();
+
+    expect(runtime.chatClient.timelines[0].closes).toBe(0);
+  });
+
+  it('closes the timeline when the session goes away', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.become('signed-out');
+
+    expect(runtime.chatClient.timelines[0].closes).toBe(1);
+    expect(source.getSnapshot().items).toEqual([]);
+  });
+
+  it('closes a timeline that arrives after the session went away', async () => {
+    const { runtime, source } = readyTimeline();
+    runtime.chatClient.holdOpen();
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.become('signed-out');
+    runtime.chatClient.releaseOpen();
+    await settle();
+
+    expect(runtime.chatClient.timelines[0].closes).toBe(1);
+  });
+});
+
+describe('TimelineSource pagination', () => {
+  it('asks the port for older messages', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    await source.paginateBackwards(30);
+
+    expect(runtime.chatClient.timelines[0].paginateCalls).toEqual([30]);
+  });
+
+  it('says so while a pagination is running', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+    runtime.chatClient.timelines[0].holdPagination();
+
+    const running = source.paginateBackwards(30);
+    await settle();
+    expect(source.getSnapshot().isPaginating).toBe(true);
+
+    runtime.chatClient.timelines[0].releasePagination();
+    await running;
+    expect(source.getSnapshot().isPaginating).toBe(false);
+  });
+
+  it('does not ask twice while one request is still in flight', async () => {
+    // A list fires "load more" as the user scrolls. Without this the top of a
+    // conversation would send a request per frame.
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+    runtime.chatClient.timelines[0].holdPagination();
+
+    const first = source.paginateBackwards(30);
+    await settle();
+    await source.paginateBackwards(30);
+
+    expect(runtime.chatClient.timelines[0].paginateCalls).toEqual([30]);
+
+    runtime.chatClient.timelines[0].releasePagination();
+    await first;
+  });
+
+  it('remembers that the conversation has no more history', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+    runtime.chatClient.timelines[0].outcome = 'reached-start';
+
+    await source.paginateBackwards(30);
+
+    expect(source.getSnapshot().reachedStart).toBe(true);
+  });
+
+  it('stops asking once the start of the conversation has been reached', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+    runtime.chatClient.timelines[0].outcome = 'reached-start';
+    await source.paginateBackwards(30);
+
+    await source.paginateBackwards(30);
+    await source.paginateBackwards(30);
+
+    expect(runtime.chatClient.timelines[0].paginateCalls).toEqual([30]);
+  });
+
+  it('stops saying it is paginating when the request fails', async () => {
+    // Otherwise one failure leaves the spinner up and the guard latched, and the
+    // conversation can never load its history again.
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+    const timeline = runtime.chatClient.timelines[0];
+    timeline.paginateBackwards = async () => {
+      throw new Error('the homeserver said no');
+    };
+
+    await expect(source.paginateBackwards(30)).rejects.toThrow('the homeserver said no');
+
+    expect(source.getSnapshot().isPaginating).toBe(false);
+  });
+
+  it('refuses to paginate a conversation nothing is watching', async () => {
+    const { source } = readyTimeline();
+
+    await expect(source.paginateBackwards(30)).rejects.toThrow(ROOM);
+  });
+});
+
+describe('TimelineSource sending', () => {
+  it('sends the body verbatim through the port', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    await source.sendText('*not* markdown');
+
+    expect(runtime.chatClient.timelines[0].sent).toEqual(['*not* markdown']);
+  });
+
+  it('adds nothing to the timeline of its own accord', async () => {
+    // The port puts the local echo in the timeline itself. An optimistic row
+    // added here would be a second copy of the same message.
+    const { source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    await source.sendText('hello');
+
+    expect(source.getSnapshot().items).toEqual([]);
+  });
+
+  it('refuses to send to a conversation nothing is watching', async () => {
+    const { source } = readyTimeline();
+
+    await expect(source.sendText('hello')).rejects.toThrow(ROOM);
+  });
+});
+
+describe('timelineSource registry', () => {
+  it('hands the same source to everything drawing one room', () => {
+    // Two panes of the three-panel layout can draw one conversation. Two sources
+    // would be two timelines open over one room.
+    expect(timelineSource(ROOM)).toBe(timelineSource(ROOM));
+  });
+
+  it('keeps separate rooms separate', () => {
+    expect(timelineSource(ROOM)).not.toBe(timelineSource('!other:allo.you'));
+  });
+
+  it('forgets a room once nothing is watching it', () => {
+    const source = timelineSource('!transient:allo.you');
+    const unsubscribe = source.subscribe(() => {});
+
+    unsubscribe();
+
+    expect(timelineSource('!transient:allo.you')).not.toBe(source);
+  });
+});

--- a/packages/frontend/app/(chat)/c/[id].tsx
+++ b/packages/frontend/app/(chat)/c/[id].tsx
@@ -6,6 +6,7 @@ import { useOxy } from "@oxyhq/services";
 import { useUserById, useUsersStore } from "@/stores/usersStore";
 import { api } from "@/utils/api";
 import { toast } from "@oxyhq/bloom/toast";
+import { CHAT_BACKEND } from "@/lib/chat/backend";
 
 /** Participant shape returned by the backend conversations API. */
 interface ApiConversationParticipant {
@@ -45,7 +46,7 @@ type CreateConversationPayload = ApiConversation & { data?: ApiConversation };
  * Offline-first: renders ConversationView immediately using an optimistic
  * conversation when needed, so the user never sees a loading spinner.
  */
-export default function UnifiedConversationRoute() {
+function AlloApiConversationRoute() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
   const { user: currentUser } = useOxy();
@@ -226,4 +227,30 @@ export default function UnifiedConversationRoute() {
     optimisticId;
 
   return <ConversationView conversationId={conversationId || undefined} />;
+}
+
+/**
+ * The same route, for a Matrix room.
+ *
+ * Everything the branch above does — resolving a user id, inventing an optimistic
+ * conversation, creating one over the API — exists because Allo's own backend
+ * makes a conversation out of a pair of user ids. On Matrix the id in the URL is
+ * a room id and rooms come from sync alone: there is nothing to create here, and
+ * a room that has not arrived yet is a room the timeline reports as empty rather
+ * than one this route should conjure.
+ */
+function MatrixConversationRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  return <ConversationView conversationId={id || undefined} />;
+}
+
+/**
+ * Picks the route body for this build's chat backend.
+ *
+ * A component boundary and not a branch inside one body, because the two have
+ * different hooks: React allows a component to be chosen conditionally, and does
+ * not allow its hooks to be.
+ */
+export default function UnifiedConversationRoute() {
+  return CHAT_BACKEND === 'matrix' ? <MatrixConversationRoute /> : <AlloApiConversationRoute />;
 }

--- a/packages/frontend/app/(chat)/index.tsx
+++ b/packages/frontend/app/(chat)/index.tsx
@@ -49,6 +49,10 @@ import {
 // Conversation peek preview
 import { ConversationPeekPreview } from '@/components/conversation/ConversationPeekPreview';
 
+// Matrix chat backend (behind EXPO_PUBLIC_CHAT_BACKEND)
+import { MatrixSignInGate } from '@/components/matrix/MatrixSignInGate';
+import { useMatrixConversations } from '@/hooks/useMatrixConversations';
+
 // Utils
 import { colors } from '@/styles/colors';
 import {
@@ -462,7 +466,12 @@ export default function ConversationsList() {
     const router = useRouter();
     const { width: windowWidth } = useWindowDimensions();
     // Get conversations from store
-    const conversations = useConversationsStore(state => state.conversations);
+    const storedConversations = useConversationsStore(state => state.conversations);
+    // ...or from the Matrix room list, which is `undefined` unless this build's
+    // chat backend is Matrix. The port's sync loop keeps it up to date, so there
+    // is nothing to fetch, nothing to cache and nothing to refresh.
+    const roomConversations = useMatrixConversations();
+    const conversations = roomConversations ?? storedConversations;
     const loadCachedConversations = useConversationsStore(state => state.loadCachedConversations);
     const fetchConversations = useConversationsStore(state => state.fetchConversations);
     const refreshConversations = useConversationsStore(state => state.refreshConversations);
@@ -488,18 +497,26 @@ export default function ConversationsList() {
     // than a read taken once: fetching before it lands would paint a list of
     // zeroes over the cache and never recover.
     useEffect(() => {
+        // The Matrix room list is fed by sync, not by a request. Calling the
+        // Express API here would fetch a list this screen is not drawing.
+        if (roomConversations !== undefined) {
+            return;
+        }
         loadCachedConversations();
         if (currentUserId) {
             fetchConversations(currentUserId);
         }
-    }, [loadCachedConversations, fetchConversations, currentUserId]);
+    }, [loadCachedConversations, fetchConversations, currentUserId, roomConversations]);
 
     // Pull-to-refresh, for the same reason, is a no-op until the viewer is known.
     const handleRefresh = useCallback(() => {
+        if (roomConversations !== undefined) {
+            return;
+        }
         if (currentUserId) {
             refreshConversations(currentUserId);
         }
-    }, [refreshConversations, currentUserId]);
+    }, [refreshConversations, currentUserId, roomConversations]);
 
     // Search state
     const [searchQuery, setSearchQuery] = useState('');
@@ -1171,35 +1188,39 @@ export default function ConversationsList() {
                     )}
                 </Animated.View>
 
-                {isLoading && !hasFetchedOnce && conversations.length === 0 ? (
-                    <ConversationsSkeleton theme={theme} />
-                ) : visibleConversations.length > 0 ? (
-                    <FlashList
-                        data={visibleConversations}
-                        renderItem={renderConversationItem}
-                        keyExtractor={keyExtractor}
-                        extraData={selectedConversationIds}
-                        ListHeaderComponent={SearchBarHeader}
+                {/* Renders its children unchanged unless this build's chat backend
+                    is Matrix and there is no session yet. */}
+                <MatrixSignInGate>
+                    {isLoading && !hasFetchedOnce && conversations.length === 0 ? (
+                        <ConversationsSkeleton theme={theme} />
+                    ) : visibleConversations.length > 0 ? (
+                        <FlashList
+                            data={visibleConversations}
+                            renderItem={renderConversationItem}
+                            keyExtractor={keyExtractor}
+                            extraData={selectedConversationIds}
+                            ListHeaderComponent={SearchBarHeader}
 
-                        keyboardShouldPersistTaps="handled"
-                        refreshControl={
-                            <RefreshControl
-                                refreshing={isRefreshing}
-                                onRefresh={handleRefresh}
-                                tintColor={theme.colors.primary}
-                                colors={[theme.colors.primary]}
-                            />
-                        }
-                    />
-                ) : (
-                    <>
-                        {SearchBarHeader}
-                        <EmptyState
-                            lottieSource={require('@/assets/lottie/welcome.json')}
-                            title={emptyStateCopy}
+                            keyboardShouldPersistTaps="handled"
+                            refreshControl={
+                                <RefreshControl
+                                    refreshing={isRefreshing}
+                                    onRefresh={handleRefresh}
+                                    tintColor={theme.colors.primary}
+                                    colors={[theme.colors.primary]}
+                                />
+                            }
                         />
-                    </>
-                )}
+                    ) : (
+                        <>
+                            {SearchBarHeader}
+                            <EmptyState
+                                lottieSource={require('@/assets/lottie/welcome.json')}
+                                title={emptyStateCopy}
+                            />
+                        </>
+                    )}
+                </MatrixSignInGate>
 
                 <Link
                     href="/(chat)/settings"

--- a/packages/frontend/components/conversation/ConversationView.tsx
+++ b/packages/frontend/components/conversation/ConversationView.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useEffect, useContext, useCallback, useState } from 'react';
 import {
+  ActivityIndicator,
   StyleSheet,
   View,
   TextInput,
@@ -71,6 +72,9 @@ import { useUsersStore } from '@/stores/usersStore';
 import { useRealtimeMessaging } from '@/hooks/useRealtimeMessaging';
 import { useTypingIndicator } from '@/hooks/useTypingIndicator';
 import { useSenderInfo } from '@/hooks/useSenderInfo';
+// Matrix chat backend (behind EXPO_PUBLIC_CHAT_BACKEND)
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+import { useMatrixTimeline } from '@/hooks/useMatrixTimeline';
 
 // Constants
 import { MESSAGING_CONSTANTS } from '@/constants/messaging';
@@ -98,6 +102,19 @@ const EMPTY_MESSAGES: Message[] = [];
 
 // Stable empty style for FlashList contentContainer
 const MESSAGE_LIST_CONTENT_STYLE = { paddingVertical: 8 };
+
+// Shown above the oldest loaded message while the homeserver is being asked for
+// more. Declared once, at module scope, so the list header is not a new element
+// type on every render.
+const olderMessagesStyles = StyleSheet.create({
+  spinner: { paddingVertical: 12 },
+});
+
+const OlderMessagesSpinner = (
+  <View style={olderMessagesStyles.spinner}>
+    <ActivityIndicator />
+  </View>
+);
 
 
 /**
@@ -168,9 +185,15 @@ export default function ConversationView({ conversationId: propConversationId }:
   const isLargeScreen = useOptimizedMediaQuery({ minWidth: 768 });
 
   // Get messages from store (direct access with stable empty array reference)
-  const messages = useMessagesStore(state =>
+  const storedMessages = useMessagesStore(state =>
     conversationId ? (state.messagesByConversation[conversationId] || EMPTY_MESSAGES) : EMPTY_MESSAGES
   );
+
+  // ...or from the Matrix port, which is `undefined` unless this build's chat
+  // backend is Matrix. The room's timeline is a live view over the sync loop, so
+  // there is no fetch: opening it is subscribing to it.
+  const matrixTimeline = useMatrixTimeline(conversationId);
+  const messages = matrixTimeline?.messages ?? storedMessages;
 
   // Group messages by time and format with day separators
   const messageGroups = useMemo(() => {
@@ -182,9 +205,10 @@ export default function ConversationView({ conversationId: propConversationId }:
   }, [messages]);
 
   // Get loading state
-  const isLoading = useMessagesStore(state =>
+  const storedIsLoading = useMessagesStore(state =>
     conversationId ? state.isLoading(conversationId) : false
   );
+  const isLoading = matrixTimeline?.isLoading ?? storedIsLoading;
 
   // Get UI state from store - access directly from state for reactivity
   const inputText = useChatUIStore(state =>
@@ -234,6 +258,11 @@ export default function ConversationView({ conversationId: propConversationId }:
 
     // Clear UI state when switching conversations
     clearConversationUI(conversationId);
+
+    // A Matrix timeline is not fetched: it is a live view the port opens over
+    // the sync loop, and asking the Express API for this room's messages would
+    // request a conversation that does not exist there.
+    if (CHAT_BACKEND === 'matrix') return;
 
     // Fetch messages (store will handle duplicate requests)
     if (currentUserId) {
@@ -487,6 +516,43 @@ export default function ConversationView({ conversationId: propConversationId }:
       setMessageTextSize(sizeToUse);
     }
 
+    // On Matrix a message is addressed to a room, not to a recipient: there is
+    // no device list to encrypt for by hand and no user id to look up, because
+    // the room's members and their devices are the homeserver's business and the
+    // SDK's. Everything below this branch exists to satisfy the Signal
+    // implementation, which needs to know who it is encrypting for.
+    //
+    // The per-message font size does not survive this path. `AlloTimelineHandle`
+    // sends a body and nothing else, and Allo's font size is meant to travel as
+    // `so.oxy.allo.font_size` inside the encrypted content
+    // (`docs/matrix/data-model.md` §4.2) — which the port has no call for yet.
+    // The gesture still adjusts the composer; it just does not reach the message.
+    if (matrixTimeline) {
+      try {
+        await matrixTimeline.send(text);
+      } catch (error) {
+        console.error('Error sending message:', error);
+        const errorMessage = error instanceof Error ? error.message : 'Failed to send message. Please try again.';
+        toast.error(errorMessage);
+        setInputText(conversationId, text);
+        return;
+      }
+
+      if (sizeToUse && sizeToUse !== originalSize) {
+        setMessageTextSize(originalSize);
+        setTempTextSize(originalSize);
+      }
+      setIsSizeAdjusting(false);
+
+      setTimeout(() => {
+        flatListRef.current?.scrollToEnd({ animated: true });
+      }, 100);
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 100);
+      return;
+    }
+
     // Get recipient user ID from conversation
     // For direct messages, get the other participant
     // For groups, we'll need to handle multiple recipients (for now, use first other participant)
@@ -560,7 +626,7 @@ export default function ConversationView({ conversationId: propConversationId }:
     setTimeout(() => {
       inputRef.current?.focus();
     }, 100);
-  }, [conversationId, inputText, sendMessage, setInputText, messageTextSize, setMessageTextSize, conversation, isGroup, currentUserId]);
+  }, [conversationId, inputText, sendMessage, setInputText, messageTextSize, setMessageTextSize, conversation, isGroup, currentUserId, matrixTimeline]);
 
   /**
    * Handle Enter key press to send message
@@ -1014,6 +1080,15 @@ export default function ConversationView({ conversationId: propConversationId }:
                 data={messageGroups}
                 renderItem={renderMessageGroup}
                 keyExtractor={getGroupKey}
+                // Older messages are asked for as the top of the list comes into
+                // view. The store-backed path has no such call — it fetches a
+                // conversation whole — so this stays undefined there and the list
+                // behaves exactly as it did.
+                onStartReached={matrixTimeline?.loadOlder}
+                onStartReachedThreshold={0.5}
+                ListHeaderComponent={
+                  matrixTimeline?.isPaginating ? OlderMessagesSpinner : undefined
+                }
               />
               {/* Typing Indicator */}
               {typingUserIds.length > 0 && (

--- a/packages/frontend/components/matrix/MatrixSignInGate.tsx
+++ b/packages/frontend/components/matrix/MatrixSignInGate.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo } from 'react';
+import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { ThemedText } from '@/components/ThemedText';
+import { useMatrixRuntime, signInToMatrix } from '@/hooks/useMatrixRuntime';
+import { useTheme } from '@/hooks/useTheme';
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+
+/**
+ * Stands between the chat UI and a Matrix client that is not ready yet.
+ *
+ * Allo's homeserver hands out sessions through Matrix Authentication Service with
+ * Oxy upstream, so there is no Matrix password and signing in means handing
+ * control to a browser and getting it back. That takes a screen of its own, and
+ * this is the smallest one that tells the truth about each state it can be in.
+ *
+ * With the chat backend set to `allo-api` this renders its children and nothing
+ * else — the component is not in the way of the app as it was.
+ */
+export function MatrixSignInGate({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const runtime = useMatrixRuntime();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 32,
+          backgroundColor: theme.colors.background,
+        },
+        title: {
+          fontSize: 17,
+          fontWeight: '600',
+          color: theme.colors.text,
+          textAlign: 'center',
+        },
+        detail: {
+          fontSize: 15,
+          lineHeight: 22,
+          color: theme.colors.textSecondary,
+          textAlign: 'center',
+          marginTop: 8,
+          maxWidth: 320,
+        },
+        button: {
+          marginTop: 24,
+          paddingHorizontal: 24,
+          paddingVertical: 12,
+          borderRadius: 24,
+          backgroundColor: theme.colors.primary,
+        },
+        buttonLabel: {
+          fontSize: 16,
+          fontWeight: '600',
+          color: theme.colors.background,
+        },
+        spinner: {
+          marginBottom: 16,
+        },
+      }),
+    [theme.colors],
+  );
+
+  if (CHAT_BACKEND !== 'matrix' || runtime.phase === 'ready') {
+    return <>{children}</>;
+  }
+
+  if (runtime.phase === 'idle' || runtime.phase === 'starting') {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator style={styles.spinner} color={theme.colors.primary} />
+        <ThemedText style={styles.title}>{t('Connecting…')}</ThemedText>
+      </View>
+    );
+  }
+
+  if (runtime.phase === 'authorizing') {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator style={styles.spinner} color={theme.colors.primary} />
+        <ThemedText style={styles.title}>{t('Finish signing in')}</ThemedText>
+        <ThemedText style={styles.detail}>
+          {t('Allo is waiting for the sign-in page in your browser.')}
+        </ThemedText>
+      </View>
+    );
+  }
+
+  const failed = runtime.phase === 'failed';
+  return (
+    <View style={styles.container}>
+      <ThemedText style={styles.title}>
+        {failed ? t('Allo could not sign you in') : t('Sign in to start chatting')}
+      </ThemedText>
+      <ThemedText style={styles.detail}>
+        {failed
+          ? (runtime.error ?? t('Something went wrong. Try again.'))
+          : t('Your conversations live on your Matrix homeserver. Sign in to load them.')}
+      </ThemedText>
+      <TouchableOpacity
+        accessibilityRole="button"
+        style={styles.button}
+        onPress={signInToMatrix}
+      >
+        <ThemedText style={styles.buttonLabel}>
+          {failed ? t('Try again') : t('Sign in')}
+        </ThemedText>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/packages/frontend/eslint.config.js
+++ b/packages/frontend/eslint.config.js
@@ -8,6 +8,30 @@ module.exports = defineConfig([
     ignores: ['dist/*'],
   },
   {
+    settings: {
+      // Metro picks a platform variant before the plain file — `foo.native.ts`
+      // on iOS and Android, `foo.web.ts` on web — and `tsconfig.json` tells
+      // TypeScript the same thing through `moduleSuffixes`. The import resolver
+      // knows about neither, so an import of a module that exists *only* as
+      // platform variants, as `lib/matrix/client` does, would be reported as
+      // unresolved by a rule that is otherwise worth keeping on.
+      'import/resolver': {
+        typescript: {
+          extensions: [
+            '.native.ts',
+            '.native.tsx',
+            '.ts',
+            '.tsx',
+            '.d.ts',
+            '.js',
+            '.jsx',
+            '.json',
+          ],
+        },
+      },
+    },
+  },
+  {
     // Build scripts run in Node before Metro ever sees the project, so they get
     // Node's module globals. The Expo config does not grant them, because
     // everything else here is bundled.

--- a/packages/frontend/hooks/useConversation.ts
+++ b/packages/frontend/hooks/useConversation.ts
@@ -1,16 +1,36 @@
+import { useMemo } from 'react';
+
 import { useConversationsStore } from '@/stores';
+import { useMatrixConversations } from '@/hooks/useMatrixConversations';
 
 /**
  * Hook to get conversation data by ID from the store
- * 
+ *
  * @example
  * ```tsx
  * const conversation = useConversation('conv-1');
  * ```
+ *
+ * With the Matrix chat backend the conversation comes from the room list rather
+ * than the store: a room is only ever known through sync, so there is nowhere
+ * else to look it up. The store branch below is untouched, and is what a build
+ * with `EXPO_PUBLIC_CHAT_BACKEND` unset still runs.
  */
 export function useConversation(conversationId?: string | null) {
-  return useConversationsStore(state => 
+  const stored = useConversationsStore(state =>
     conversationId ? state.getConversation(conversationId) : null
   );
-}
+  const rooms = useMatrixConversations();
 
+  return useMemo(() => {
+    if (rooms === undefined) {
+      return stored;
+    }
+    if (!conversationId) {
+      return null;
+    }
+    // Undefined while sync has not delivered the room — a deep link into a
+    // conversation the client has not seen yet is the ordinary way there.
+    return rooms.find((room) => room.id === conversationId);
+  }, [rooms, stored, conversationId]);
+}

--- a/packages/frontend/hooks/useMatrixConversations.ts
+++ b/packages/frontend/hooks/useMatrixConversations.ts
@@ -1,0 +1,38 @@
+import { useMemo, useSyncExternalStore } from 'react';
+
+import type { Conversation } from '@/app/(chat)/index';
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+import { toConversation } from '@/lib/chat/matrixViewModel';
+import { roomListSource } from '@/lib/chat/roomListSource';
+import type { AlloRoomSummary, AlloUnsubscribe } from '@/lib/matrix/types';
+
+/**
+ * The conversation list, from the Matrix port.
+ *
+ * Answers `undefined` — not an empty list — when this build talks to the Express
+ * API, so that the screen can fall through to the store it has always used with
+ * `?? conversations` and the old path stays exactly one expression.
+ *
+ * There is no fetch here and no Effect: the port's sync loop is what populates
+ * the list, and this hook only reads the list it publishes.
+ */
+
+const NO_ROOMS: readonly AlloRoomSummary[] = [];
+const NO_UNSUBSCRIBE: AlloUnsubscribe = () => {};
+const subscribeToNothing = (): AlloUnsubscribe => NO_UNSUBSCRIBE;
+const noRooms = (): readonly AlloRoomSummary[] => NO_ROOMS;
+
+const enabled = CHAT_BACKEND === 'matrix';
+
+export function useMatrixConversations(): readonly Conversation[] | undefined {
+  const rooms = useSyncExternalStore(
+    enabled ? roomListSource.subscribe : subscribeToNothing,
+    enabled ? roomListSource.getSnapshot : noRooms,
+    noRooms,
+  );
+
+  // Derived during render, as a mapping of the snapshot should be. An Effect that
+  // mirrored this into state would render one frame of the previous list every
+  // time a message arrived.
+  return useMemo(() => (enabled ? rooms.map(toConversation) : undefined), [rooms]);
+}

--- a/packages/frontend/hooks/useMatrixRuntime.ts
+++ b/packages/frontend/hooks/useMatrixRuntime.ts
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from 'react';
+
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+import { IDLE_RUNTIME_STATE, matrixRuntime, type MatrixRuntimeState } from '@/lib/chat/matrixRuntime';
+import type { AlloUnsubscribe } from '@/lib/matrix/types';
+
+/**
+ * The state of the app's Matrix client.
+ *
+ * `useSyncExternalStore` and not an Effect: the runtime is an external store —
+ * it exists before React and outlives every component — and this is the hook
+ * React provides for exactly that. Subscribing is also what starts the runtime,
+ * so no screen has to remember to kick it off.
+ *
+ * With the chat backend set to `allo-api` the hook subscribes to nothing and
+ * answers `idle` forever, which is what keeps a build with the flag off from
+ * building a Matrix client because a screen rendered.
+ */
+
+const NO_UNSUBSCRIBE: AlloUnsubscribe = () => {};
+const subscribeToNothing = (): AlloUnsubscribe => NO_UNSUBSCRIBE;
+const alwaysIdle = (): MatrixRuntimeState => IDLE_RUNTIME_STATE;
+
+const enabled = CHAT_BACKEND === 'matrix';
+
+export function useMatrixRuntime(): MatrixRuntimeState {
+  return useSyncExternalStore(
+    enabled ? matrixRuntime.subscribe : subscribeToNothing,
+    enabled ? matrixRuntime.getState : alwaysIdle,
+    // The web export is prerendered, and prerendering never subscribes. Reporting
+    // the idle state there is right: there is no client in a build step.
+    alwaysIdle,
+  );
+}
+
+/** Starts a sign-in. Does nothing at all when the backend is `allo-api`. */
+export function signInToMatrix(): void {
+  if (!enabled) {
+    return;
+  }
+  // The runtime reports its own failures through the state this module's hook
+  // reads, so there is nothing for a caller to catch.
+  void matrixRuntime.signIn();
+}

--- a/packages/frontend/hooks/useMatrixTimeline.ts
+++ b/packages/frontend/hooks/useMatrixTimeline.ts
@@ -1,0 +1,125 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+import { toMessage, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
+import { timelineSource, type TimelineSnapshot } from '@/lib/chat/timelineSource';
+import type { AlloUnsubscribe } from '@/lib/matrix/types';
+import type { Message } from '@/stores/messagesStore';
+import { logger } from '@/utils/logger';
+
+/**
+ * One conversation's messages, from the Matrix port.
+ *
+ * Answers `undefined` when this build talks to the Express API, or when there is
+ * no conversation to draw, so that `ConversationView` can fall through to the
+ * store it has always used.
+ */
+
+/**
+ * How many older events one "load more" asks for.
+ *
+ * The homeserver may return fewer, and on an encrypted room some of them are
+ * state events the timeline does not draw, so this is a request and not a count
+ * of new rows.
+ */
+const PAGE_SIZE = 30;
+
+const NO_MESSAGES: readonly Message[] = [];
+const NO_UNSUBSCRIBE: AlloUnsubscribe = () => {};
+const subscribeToNothing = (): AlloUnsubscribe => NO_UNSUBSCRIBE;
+
+const CLOSED_TIMELINE: TimelineSnapshot = {
+  items: [],
+  isOpening: false,
+  isPaginating: false,
+  reachedStart: false,
+};
+const closedTimeline = (): TimelineSnapshot => CLOSED_TIMELINE;
+
+const enabled = CHAT_BACKEND === 'matrix';
+
+export interface MatrixTimeline {
+  readonly messages: readonly Message[];
+  /** The timeline is being opened; there is nothing to draw *yet*. */
+  readonly isLoading: boolean;
+  readonly isPaginating: boolean;
+  /** The first message of the conversation is on screen; stop asking for more. */
+  readonly reachedStart: boolean;
+  /** Asks the homeserver for older messages. Safe to call on every scroll. */
+  readonly loadOlder: () => void;
+  readonly send: (body: string) => Promise<void>;
+}
+
+export function useMatrixTimeline(
+  conversationId: string | undefined,
+): MatrixTimeline | undefined {
+  const { t } = useTranslation();
+
+  const source = useMemo(
+    () =>
+      enabled && conversationId !== undefined ? timelineSource(conversationId) : undefined,
+    [conversationId],
+  );
+
+  const snapshot = useSyncExternalStore(
+    source?.subscribe ?? subscribeToNothing,
+    source?.getSnapshot ?? closedTimeline,
+    closedTimeline,
+  );
+
+  const labels = useMemo<UnreadableEventLabels>(
+    () => ({
+      undecryptable: t('This message cannot be read on this device.'),
+      redacted: t('This message was deleted.'),
+      unsupported: (description) =>
+        t('Allo cannot show this yet ({{kind}}).', { kind: description }),
+    }),
+    [t],
+  );
+
+  const messages = useMemo(
+    () =>
+      conversationId === undefined
+        ? NO_MESSAGES
+        : snapshot.items.map((item) => toMessage(item, conversationId, labels)),
+    [snapshot.items, conversationId, labels],
+  );
+
+  const loadOlder = useCallback(() => {
+    if (source === undefined) {
+      return;
+    }
+    // Deliberately not awaited: this is called from a list as the user scrolls,
+    // and the snapshot already reports that a pagination is running. Failures are
+    // logged rather than shown, because the conversation is still readable.
+    source.paginateBackwards(PAGE_SIZE).catch((error: unknown) => {
+      logger.error('[chat] older messages could not be loaded', error);
+    });
+  }, [source]);
+
+  const send = useCallback(
+    async (body: string): Promise<void> => {
+      if (source === undefined) {
+        return;
+      }
+      await source.sendText(body);
+    },
+    [source],
+  );
+
+  return useMemo(
+    () =>
+      source === undefined
+        ? undefined
+        : {
+            messages,
+            isLoading: snapshot.isOpening,
+            isPaginating: snapshot.isPaginating,
+            reachedStart: snapshot.reachedStart,
+            loadOlder,
+            send,
+          },
+    [source, messages, snapshot, loadOlder, send],
+  );
+}

--- a/packages/frontend/hooks/useRealtimeMessaging.ts
+++ b/packages/frontend/hooks/useRealtimeMessaging.ts
@@ -3,6 +3,7 @@ import { useOxy } from '@oxyhq/services';
 import { oxyClient } from '@oxyhq/core';
 import { io, Socket } from 'socket.io-client';
 import { SOCKET_URL } from '@/config';
+import { CHAT_BACKEND } from '@/lib/chat/backend';
 import { useMessagesStore } from '@/stores/messagesStore';
 import { useConversationsStore } from '@/stores/conversationsStore';
 import { useDeviceKeysStore } from '@/stores/deviceKeysStore';
@@ -342,6 +343,11 @@ export const useRealtimeMessaging = (conversationId?: string) => {
   }, [user?.id, addMessage, updateMessage, removeMessage, updateConversation, deviceKeysStore]);
 
   const connectSocket = useCallback(() => {
+    // Socket.IO carries the Express backend's messages. A build whose chat
+    // backend is Matrix gets its messages from the homeserver's sync loop
+    // instead, and a socket opened here would deliver events for conversations
+    // that build is not drawing.
+    if (CHAT_BACKEND === 'matrix') return;
     if (!isAuthenticated || !user?.id) return;
 
     // If socket already exists and is connected, just ensure listeners are set up

--- a/packages/frontend/lib/chat/backend.ts
+++ b/packages/frontend/lib/chat/backend.ts
@@ -1,0 +1,62 @@
+/**
+ * Which system the chat screens get their data from.
+ *
+ * Allo is being moved off its own Express/Socket.IO/Signal stack and onto Matrix
+ * (`docs/matrix/data-model.md`). The two live side by side for as long as the move
+ * takes, and this flag is the single place that decides which one a build talks
+ * to. Nothing else in the app is allowed to sniff the environment for it.
+ *
+ * The rule that makes the migration reversible: **with the flag unset, the app
+ * behaves exactly as it did before Matrix existed.** Every switch on this value
+ * has the legacy path as its untouched branch, and the Matrix modules are reached
+ * through a dynamic import so that a build with the flag off never loads a Matrix
+ * SDK at all — not to save bytes, but so that a crash inside one cannot happen in
+ * a configuration that is supposed to be the old app.
+ */
+
+export type ChatBackend =
+  /** The Express API, Socket.IO and the Signal Protocol implementation. */
+  | 'allo-api'
+  /** The Matrix homeserver, through the port in `lib/matrix`. */
+  | 'matrix';
+
+/** The environment variable that selects the backend. */
+export const CHAT_BACKEND_VARIABLE = 'EXPO_PUBLIC_CHAT_BACKEND';
+
+const CHAT_BACKENDS: readonly ChatBackend[] = ['allo-api', 'matrix'];
+
+/**
+ * Reads the flag, refusing anything that is neither backend.
+ *
+ * Unset means `allo-api`, because a build that says nothing wants the app it had.
+ * A *misspelt* value is the case worth being loud about: someone who writes
+ * `EXPO_PUBLIC_CHAT_BACKEND=Matrix` and gets the legacy backend has no way to see
+ * that from inside the app — every screen works, and it is the wrong app. Failing
+ * at import turns that into a message at the moment the mistake is made.
+ */
+export function parseChatBackend(raw: string | undefined): ChatBackend {
+  if (raw === undefined || raw === '') {
+    return 'allo-api';
+  }
+  const backend = CHAT_BACKENDS.find((candidate) => candidate === raw);
+  if (backend === undefined) {
+    throw new Error(
+      `${CHAT_BACKEND_VARIABLE} is "${raw}", which is not a chat backend. ` +
+        `Use one of ${CHAT_BACKENDS.join(', ')}, or leave it unset for ` +
+        'allo-api.',
+    );
+  }
+  return backend;
+}
+
+/**
+ * The backend this build talks to.
+ *
+ * A constant and not a function: Expo's bundler substitutes the literal for
+ * `process.env.EXPO_PUBLIC_*` at build time, so the value cannot change while the
+ * app is running and pretending otherwise would invite code that re-reads it and
+ * gets a different answer halfway through a screen.
+ */
+export const CHAT_BACKEND: ChatBackend = parseChatBackend(
+  process.env.EXPO_PUBLIC_CHAT_BACKEND,
+);

--- a/packages/frontend/lib/chat/matrixConfig.ts
+++ b/packages/frontend/lib/chat/matrixConfig.ts
@@ -1,0 +1,120 @@
+import { Platform } from 'react-native';
+import * as Linking from 'expo-linking';
+
+import type { AlloChatClientConfig, AlloOidcClientMetadata } from '@/lib/matrix/types';
+
+/**
+ * What a build needs to know to talk to a homeserver.
+ *
+ * Read once, here, and nowhere else. Everything is an environment variable
+ * because a homeserver is a deployment decision: the development one is
+ * `matrix.org`, Allo's own does not exist yet, and neither belongs in the source.
+ */
+
+/** Where the homeserver is. No default: see {@link readHomeserverUrl}. */
+export const HOMESERVER_VARIABLE = 'EXPO_PUBLIC_MATRIX_HOMESERVER';
+
+/** A client id agreed with the authorization server in advance, if there is one. */
+export const OIDC_CLIENT_ID_VARIABLE = 'EXPO_PUBLIC_MATRIX_OIDC_CLIENT_ID';
+
+/** Where the authorization server sends the user back. */
+export const OIDC_REDIRECT_URI_VARIABLE = 'EXPO_PUBLIC_MATRIX_OIDC_REDIRECT_URI';
+
+const CLIENT_NAME = 'Allo';
+const CLIENT_URI = 'https://allo.you';
+
+/**
+ * The path the browser is sent back to on web.
+ *
+ * A static file in `public/`, deliberately not a route of the app. The web export
+ * serves `index.html` for unknown paths, so a redirect at an app route would boot
+ * a second copy of Allo in the popup — and a second copy means a second
+ * `MatrixClient` on one IndexedDB, which the SDK says corrupts the crypto store
+ * (`lib/matrix/client.web.ts`, the note at the top). A page that is not the app
+ * cannot do that.
+ */
+const WEB_CALLBACK_PATH = '/matrix-oidc-callback.html';
+
+/** The deep link the browser is sent back to on iOS and Android. */
+const NATIVE_CALLBACK_PATH = 'matrix/oidc';
+
+/**
+ * The homeserver, or an explanation of what is missing.
+ *
+ * There is no fallback on purpose. A default would have to be either Allo's
+ * production homeserver — which does not exist — or someone else's, and a build
+ * that quietly talks to a homeserver nobody chose is worse than one that will not
+ * start.
+ */
+export function readHomeserverUrl(raw: string | undefined): string {
+  if (raw === undefined || raw === '') {
+    throw new Error(
+      `The Matrix chat backend is enabled but ${HOMESERVER_VARIABLE} is not set, ` +
+        'so there is no homeserver to talk to. Set it to the homeserver this ' +
+        'build should use — https://matrix.org while Allo has none of its own.',
+    );
+  }
+  return raw;
+}
+
+/**
+ * Where the authorization server sends the user back.
+ *
+ * Overridable because a deployment may have registered a different one with the
+ * authorization server, and a redirect URI that does not match the registration
+ * is rejected by the server rather than by us.
+ */
+export function resolveRedirectUri(configured: string | undefined): string {
+  if (configured !== undefined && configured !== '') {
+    return configured;
+  }
+  if (Platform.OS === 'web') {
+    return new URL(WEB_CALLBACK_PATH, globalThis.location.origin).toString();
+  }
+  return Linking.createURL(NATIVE_CALLBACK_PATH);
+}
+
+export function readOidcMetadata(
+  homeserverUrl: string,
+  clientId: string | undefined,
+  redirectUri: string,
+): AlloOidcClientMetadata {
+  return {
+    clientName: CLIENT_NAME,
+    clientUri: CLIENT_URI,
+    redirectUri,
+    // Keyed by homeserver rather than by issuer: the issuer is only known after
+    // the client has asked the homeserver for its authorization metadata, and the
+    // port accepts either key.
+    staticRegistrations:
+      clientId === undefined || clientId === ''
+        ? undefined
+        : new Map([[homeserverUrl, clientId]]),
+  };
+}
+
+/**
+ * The configuration the port is built with.
+ *
+ * The store is in memory, and that is a decision rather than an oversight. A
+ * filesystem store keeps a device's encryption keys across launches, which is
+ * only worth anything if the *session* survives too — and it does not: the port
+ * documents that a persisted session goes stale, because the SDK rotates its
+ * tokens without telling the app (`lib/matrix/types.ts`, `AlloSession`). Until
+ * that gap is closed, every launch is a new login and therefore a new Matrix
+ * device, and a crypto store on disk would only accumulate the keys of devices
+ * nothing will ever use again.
+ */
+export function readMatrixClientConfig(): AlloChatClientConfig {
+  const homeserverUrl = readHomeserverUrl(process.env.EXPO_PUBLIC_MATRIX_HOMESERVER);
+  const redirectUri = resolveRedirectUri(process.env.EXPO_PUBLIC_MATRIX_OIDC_REDIRECT_URI);
+  return {
+    homeserverUrl,
+    store: { kind: 'in-memory' },
+    oidc: readOidcMetadata(
+      homeserverUrl,
+      process.env.EXPO_PUBLIC_MATRIX_OIDC_CLIENT_ID,
+      redirectUri,
+    ),
+  };
+}

--- a/packages/frontend/lib/chat/matrixRuntime.ts
+++ b/packages/frontend/lib/chat/matrixRuntime.ts
@@ -1,0 +1,344 @@
+import * as WebBrowser from 'expo-web-browser';
+
+import type {
+  AlloChatClient,
+  AlloChatClientConfig,
+  AlloChatClientFactory,
+  AlloOidcLoginRequest,
+  AlloSyncState,
+  AlloUnsubscribe,
+} from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
+
+import { readMatrixClientConfig } from './matrixConfig';
+
+/**
+ * The one Matrix client the app has, and its lifecycle.
+ *
+ * This lives outside React on purpose. A Matrix client with a sync loop is a
+ * long-running connection to an external system — the one thing an Effect is
+ * genuinely for — but it belongs to the *app*, not to whichever screen happened
+ * to mount first, and an Effect would tie it to a component's lifetime: unmount
+ * the conversation list and the sync loop would stop, remount it and a second one
+ * would start. Under StrictMode that happens on the first render anyway.
+ *
+ * So the client is owned here, at module scope, and React reads it through
+ * {@link MatrixRuntime.subscribe} and {@link MatrixRuntime.getState} — the shape
+ * `useSyncExternalStore` wants. No Effect anywhere in the chain.
+ */
+
+/** How far along the runtime is. */
+export type MatrixPhase =
+  /** Nothing has asked for a client yet. */
+  | 'idle'
+  /** Building the client: loading the SDK, opening its stores. */
+  | 'starting'
+  /** There is a client, and nobody has signed in. */
+  | 'signed-out'
+  /** An authorization is in flight in the browser. */
+  | 'authorizing'
+  /** Signed in, sync running: the room list and timelines can be opened. */
+  | 'ready'
+  /** Something failed. {@link MatrixRuntimeState.error} says what. */
+  | 'failed';
+
+export interface MatrixRuntimeState {
+  readonly phase: MatrixPhase;
+  /** The signed-in user's Matrix id, once there is one. */
+  readonly userId: string | undefined;
+  /**
+   * The sync loop's own state, which is not the same question as the phase: a
+   * `ready` runtime whose sync is `offline` still has a room list to draw, from
+   * the last sync that worked.
+   */
+  readonly sync: AlloSyncState;
+  /** Why the runtime failed, in words a user could be shown. */
+  readonly error: string | undefined;
+}
+
+/** What the browser came back with, if it came back. */
+export type AuthorizationOutcome =
+  | { readonly kind: 'returned'; readonly callbackUrl: string }
+  | { readonly kind: 'dismissed' };
+
+/**
+ * Everything the runtime does that is not its own logic.
+ *
+ * Injected so that a test can drive the whole state machine without a homeserver,
+ * a browser, or either Matrix SDK.
+ */
+export interface MatrixRuntimeDependencies {
+  readonly config: () => AlloChatClientConfig;
+  readonly createClient: AlloChatClientFactory;
+  /**
+   * Opens the authorization page and reports the URL the browser was redirected
+   * back to. The middle of OIDC's three steps, which the port deliberately does
+   * not own.
+   */
+  readonly authorize: (
+    authorizationUrl: string,
+    redirectUri: string,
+  ) => Promise<AuthorizationOutcome>;
+}
+
+/**
+ * What the room list and the timelines need of the runtime.
+ *
+ * Named separately from the class because {@link MatrixRuntime} has private
+ * fields, which makes it a nominal type nothing else can stand in for — and the
+ * two sources want a runtime they can drive from a test. The same shape the port
+ * itself uses for `OidcLoginClient` and `TimelineRow`.
+ */
+export interface MatrixRuntimeLike {
+  subscribe(listener: () => void): AlloUnsubscribe;
+  getState(): MatrixRuntimeState;
+  client(operation: string): AlloChatClient;
+}
+
+/** The client was asked for before there was one. */
+export class MatrixClientNotStartedError extends Error {
+  constructor(operation: string) {
+    super(
+      `${operation} needs a signed-in Matrix client. Wait for the runtime to ` +
+        'reach the "ready" phase.',
+    );
+    this.name = 'MatrixClientNotStartedError';
+  }
+}
+
+/** Nothing has happened yet. Also what a build with the flag off always reports. */
+export const IDLE_RUNTIME_STATE: MatrixRuntimeState = {
+  phase: 'idle',
+  userId: undefined,
+  sync: 'idle',
+  error: undefined,
+};
+
+export class MatrixRuntime implements MatrixRuntimeLike {
+  readonly #dependencies: MatrixRuntimeDependencies;
+  readonly #listeners = new Set<() => void>();
+
+  #state: MatrixRuntimeState = IDLE_RUNTIME_STATE;
+  #client: AlloChatClient | undefined;
+  #config: AlloChatClientConfig | undefined;
+  #starting: Promise<AlloChatClient | undefined> | undefined;
+  #signingIn: Promise<void> | undefined;
+  #syncSubscription: AlloUnsubscribe | undefined;
+
+  constructor(dependencies: MatrixRuntimeDependencies) {
+    this.#dependencies = dependencies;
+  }
+
+  /**
+   * Watches the runtime, and starts it.
+   *
+   * Subscribing is what brings the client up, rather than a separate call some
+   * screen has to remember to make: the first thing that wants to know the state
+   * is by definition the first thing that needs a client. Building is guarded, so
+   * a hundred subscribers still build one.
+   */
+  readonly subscribe = (listener: () => void): AlloUnsubscribe => {
+    this.#listeners.add(listener);
+    // Not awaited, and its failure is not rethrown: a build that fails reports
+    // itself through the state every subscriber is already reading.
+    void this.#ensureClient();
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  };
+
+  readonly getState = (): MatrixRuntimeState => this.#state;
+
+  /**
+   * The client, for the code that drives it.
+   *
+   * Throws rather than returning `undefined` because every caller wants it in the
+   * `ready` phase, and a caller that asks earlier has a bug an optional type would
+   * let it carry around.
+   */
+  client(operation: string): AlloChatClient {
+    if (this.#client === undefined) {
+      throw new MatrixClientNotStartedError(operation);
+    }
+    return this.#client;
+  }
+
+  /**
+   * Signs in, in OIDC's three steps: ask the port for a URL, hand it to a browser,
+   * come back with whatever the browser was redirected to.
+   *
+   * Concurrent calls share one attempt. Two authorizations would each hold state
+   * on the authorization server and only one could be completed.
+   */
+  signIn(): Promise<void> {
+    if (this.#signingIn === undefined) {
+      this.#signingIn = this.#signIn().finally(() => {
+        this.#signingIn = undefined;
+      });
+    }
+    return this.#signingIn;
+  }
+
+  async #signIn(): Promise<void> {
+    const client = await this.#ensureClient();
+    if (client === undefined || this.#state.phase === 'ready') {
+      return;
+    }
+    const config = this.#config;
+    if (config === undefined) {
+      throw new MatrixClientNotStartedError('Signing in');
+    }
+
+    this.#publish({ phase: 'authorizing', error: undefined });
+
+    let request: AlloOidcLoginRequest;
+    try {
+      request = await client.beginOidcLogin();
+    } catch (error) {
+      this.#fail('Allo could not start a sign-in with the homeserver', error);
+      return;
+    }
+
+    let outcome: AuthorizationOutcome;
+    try {
+      outcome = await this.#dependencies.authorize(
+        request.authorizationUrl,
+        config.oidc.redirectUri,
+      );
+    } catch (error) {
+      await this.#abort(request);
+      this.#fail('Allo could not open the sign-in page', error);
+      return;
+    }
+
+    if (outcome.kind === 'dismissed') {
+      // Releases what the authorization server is holding for the attempt. A
+      // user who closes the browser has not failed at anything.
+      await this.#abort(request);
+      this.#publish({ phase: 'signed-out', error: undefined });
+      return;
+    }
+
+    try {
+      // The callback URL carries the authorization code, so it is never logged.
+      const session = await request.complete(outcome.callbackUrl);
+      await client.startSync();
+      this.#publish({ phase: 'ready', userId: session.userId, error: undefined });
+    } catch (error) {
+      this.#fail('Allo could not finish the sign-in', error);
+    }
+  }
+
+  async #ensureClient(): Promise<AlloChatClient | undefined> {
+    if (this.#client !== undefined) {
+      return this.#client;
+    }
+    if (this.#starting === undefined) {
+      this.#publish({ phase: 'starting', error: undefined });
+      this.#starting = this.#build();
+    }
+    return this.#starting;
+  }
+
+  async #build(): Promise<AlloChatClient | undefined> {
+    try {
+      const config = this.#dependencies.config();
+      const client = await this.#dependencies.createClient(config);
+      this.#config = config;
+      this.#client = client;
+      this.#syncSubscription = client.observeSyncState((sync) => {
+        this.#publish({ sync });
+      });
+      this.#publish({ phase: 'signed-out', error: undefined });
+      return client;
+    } catch (error) {
+      // Cleared so that the next attempt — a user pressing sign in again —
+      // rebuilds instead of handing back this failure forever.
+      this.#starting = undefined;
+      this.#fail('Allo could not start its Matrix client', error);
+      return undefined;
+    }
+  }
+
+  async #abort(request: AlloOidcLoginRequest): Promise<void> {
+    try {
+      await request.abort();
+    } catch (error) {
+      // Abandoning an authorization that the server has already forgotten is not
+      // a problem the user can do anything about, and it must not replace the
+      // reason the sign-in is being abandoned in the first place.
+      logger.warn('[chat] a Matrix sign-in could not be abandoned cleanly', error);
+    }
+  }
+
+  #fail(summary: string, error: unknown): void {
+    logger.error(`[chat] ${summary}`, error);
+    const detail = error instanceof Error ? error.message : String(error);
+    this.#publish({ phase: 'failed', error: `${summary}: ${detail}` });
+  }
+
+  /**
+   * Replaces the state and tells everyone, unless nothing changed.
+   *
+   * The equality check is not an optimisation: `useSyncExternalStore` re-renders
+   * whenever the snapshot is a different object, so a runtime that published a new
+   * object for every repeated sync heartbeat would re-render the conversation list
+   * for nothing.
+   */
+  #publish(patch: Partial<MatrixRuntimeState>): void {
+    const next: MatrixRuntimeState = { ...this.#state, ...patch };
+    if (
+      next.phase === this.#state.phase &&
+      next.userId === this.#state.userId &&
+      next.sync === this.#state.sync &&
+      next.error === this.#state.error
+    ) {
+      return;
+    }
+    this.#state = next;
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  /**
+   * Tears everything down. Tests use it; the app has no sign-out yet, which is
+   * the same missing piece as session persistence — see `matrixConfig.ts`.
+   */
+  async close(): Promise<void> {
+    this.#syncSubscription?.();
+    this.#syncSubscription = undefined;
+    const client = this.#client;
+    this.#client = undefined;
+    this.#config = undefined;
+    this.#starting = undefined;
+    this.#publish(IDLE_RUNTIME_STATE);
+    await client?.close();
+  }
+}
+
+/**
+ * How the runtime reaches the world when it is not under test.
+ *
+ * The port is loaded with a dynamic import so that nothing in a Matrix SDK is
+ * *executed* in a build whose flag says `allo-api`. That matters more than bundle
+ * size: the native SDK sets up process-global Rust logging the moment its module
+ * is evaluated, and the web one reaches for IndexedDB. Neither should happen in a
+ * configuration that is supposed to be the app as it was.
+ */
+const defaultDependencies: MatrixRuntimeDependencies = {
+  config: readMatrixClientConfig,
+  createClient: async (config) => {
+    const { createAlloChatClient } = await import('@/lib/matrix/client');
+    return createAlloChatClient(config);
+  },
+  authorize: async (authorizationUrl, redirectUri) => {
+    const result = await WebBrowser.openAuthSessionAsync(authorizationUrl, redirectUri);
+    return result.type === 'success'
+      ? { kind: 'returned', callbackUrl: result.url }
+      : { kind: 'dismissed' };
+  },
+};
+
+/** The app's runtime. Built here and nowhere else. */
+export const matrixRuntime = new MatrixRuntime(defaultDependencies);

--- a/packages/frontend/lib/chat/matrixViewModel.ts
+++ b/packages/frontend/lib/chat/matrixViewModel.ts
@@ -1,0 +1,130 @@
+import type { Conversation } from '@/app/(chat)/index';
+import type { AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
+import type { Message } from '@/stores/messagesStore';
+
+/**
+ * The port's view model, translated into the one Allo's chat components draw.
+ *
+ * This module exists so that `MessageBubble`, `MessageBlock`, the conversation
+ * row and the three-panel layout do not have to learn what a room is. They keep
+ * taking `Conversation` and `Message`; only where those come from changes.
+ *
+ * It is pure and takes its words as arguments, so the mapping can be tested
+ * without React, without i18n and without a homeserver.
+ */
+
+/**
+ * What to say about an event that has no text of its own.
+ *
+ * Three of the port's four content kinds carry no body, and each is a different
+ * fact about the world. They must not collapse into an empty bubble: an event
+ * that arrived and cannot be read is not the same as one that never arrived, and
+ * a device set up today sees the unreadable one for every message sent before it
+ * existed.
+ */
+export interface UnreadableEventLabels {
+  /** It arrived, and this device has no key that opens it. */
+  readonly undecryptable: string;
+  /** It was removed, by its sender or by a moderator. */
+  readonly redacted: string;
+  /** Allo does not draw this kind of event yet. Given the kind's name. */
+  readonly unsupported: (description: string) => string;
+}
+
+/**
+ * A room, as a row of the conversation list.
+ *
+ * Two of `Conversation`'s fields cannot be filled from what the port reports, and
+ * they are left empty rather than invented:
+ *
+ * - `lastMessage`. {@link AlloRoomSummary} carries no latest event. Reading one
+ *   would mean opening a timeline per room, which for a list of hundreds is a
+ *   timeline per room open at once.
+ * - `timestamp`. Nor does it carry an activity time. The *order* of the list is
+ *   not lost — the port hands it back already ordered, and this mapping never
+ *   re-sorts — but the time shown next to each row is. An empty string is what
+ *   `formatConversationTimestamp` renders as nothing, which is the honest answer;
+ *   `Date.now()` would put "now" beside every conversation in the app.
+ *
+ * `theme` is absent for the same kind of reason and is not a gap in the port: a
+ * conversation's theme is to be an encrypted timeline event
+ * (`docs/matrix/data-model.md` §4.1) and no code writes or reads one yet, so
+ * every Matrix conversation falls back to the app's theme.
+ */
+export function toConversation(summary: AlloRoomSummary): Conversation {
+  return {
+    id: summary.roomId,
+    type: summary.isDirect ? 'direct' : 'group',
+    // The room id is a poor name and a better one than nothing: it is what the
+    // user sees while sync has not yet delivered the room's name or enough
+    // members to compute one.
+    name: summary.displayName ?? summary.roomId,
+    lastMessage: '',
+    timestamp: '',
+    unreadCount: summary.unreadCount,
+    avatar: summary.avatarUrl,
+  };
+}
+
+/**
+ * A timeline row, as a message bubble.
+ *
+ * `id` is the port's `key` and not the event id on purpose: it is stable across
+ * the moment a message the user just sent stops being a local echo and becomes an
+ * event with an id, which is exactly what a list key has to survive.
+ */
+export function toMessage(
+  item: AlloTimelineItem,
+  roomId: string,
+  labels: UnreadableEventLabels,
+): Message {
+  return {
+    id: item.key,
+    text: bodyOf(item, labels),
+    senderId: item.sender,
+    senderName: item.senderDisplayName,
+    timestamp: new Date(item.sentAt),
+    isSent: item.isOwn,
+    conversationId: roomId,
+    messageType: 'user',
+    isEncrypted: item.content.kind === 'undecryptable',
+    readStatus: toReadStatus(item),
+  };
+}
+
+function bodyOf(item: AlloTimelineItem, labels: UnreadableEventLabels): string {
+  switch (item.content.kind) {
+    case 'text':
+      return item.content.body;
+    case 'undecryptable':
+      return labels.undecryptable;
+    case 'redacted':
+      return labels.redacted;
+    case 'unsupported':
+      return labels.unsupported(item.content.description);
+  }
+}
+
+/**
+ * How far along an outgoing message is, in the vocabulary the bubble has.
+ *
+ * The two vocabularies do not line up and the mismatch is worth naming rather
+ * than hiding:
+ *
+ * - Only the sender's own messages carry a status. `MessageMetadata` draws
+ *   nothing for anyone else's, so reporting one would be noise.
+ * - Matrix has no delivery receipt at all (`docs/matrix/data-model.md` §9,
+ *   `deliveredTo`), so `delivered` and `read` are never reached here. Every
+ *   message the user sends stops at one tick.
+ * - `failed` has nowhere to go: the bubble's states are pending, sent, delivered
+ *   and read. It is reported as `pending`, which draws the clock — true on iOS
+ *   and Android, where the SDK's send queue really is still trying, and
+ *   optimistic on web, where nothing retries. Telling the two apart needs a state
+ *   in `MessageMetadata` that does not exist.
+ */
+function toReadStatus(item: AlloTimelineItem): Message['readStatus'] {
+  if (!item.isOwn) {
+    return undefined;
+  }
+  return item.sendState === 'sent' ? 'sent' : 'pending';
+}

--- a/packages/frontend/lib/chat/roomListSource.ts
+++ b/packages/frontend/lib/chat/roomListSource.ts
@@ -1,0 +1,139 @@
+import type { AlloRoomListHandle, AlloRoomSummary, AlloUnsubscribe } from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
+
+import { matrixRuntime, type MatrixRuntimeLike } from './matrixRuntime';
+
+/**
+ * The conversation list, as something React can read without an Effect.
+ *
+ * The port hands its room list over as `rooms()` plus a `subscribe`-shaped
+ * callback precisely so that this adapter can exist: `subscribe` and
+ * {@link RoomListSource.getSnapshot} are exactly what `useSyncExternalStore`
+ * asks for. What this class adds on top is the part the port leaves to its
+ * caller — that the list can only be opened once sync is running, so opening has
+ * to wait for the runtime and be given up if the runtime goes away.
+ */
+
+/**
+ * The empty list, as one object.
+ *
+ * `useSyncExternalStore` compares snapshots by identity and throws if one keeps
+ * changing, so "no rooms" has to be the same array every time it is answered.
+ */
+const NO_ROOMS: readonly AlloRoomSummary[] = [];
+
+export class RoomListSource {
+  readonly #runtime: MatrixRuntimeLike;
+  readonly #listeners = new Set<() => void>();
+
+  #rooms: readonly AlloRoomSummary[] = NO_ROOMS;
+  #handle: AlloRoomListHandle | undefined;
+  #watchingRuntime = false;
+  /**
+   * Distinguishes the list this source is currently showing from one an earlier,
+   * superseded `observeRooms` is still resolving towards. Bumped whenever the
+   * handle is dropped, which makes every callback and every pending open from
+   * before that point a no-op.
+   */
+  #generation = 0;
+  #opening = false;
+
+  constructor(runtime: MatrixRuntimeLike) {
+    this.#runtime = runtime;
+  }
+
+  /**
+   * Watches the conversation list.
+   *
+   * Unsubscribing does not close the underlying room list. This source is the
+   * app's one conversation list, the screen that draws it is mounted for
+   * essentially the whole session, and on native every reopen costs a projection
+   * of every room across the FFI boundary. What does close it is the runtime
+   * leaving the `ready` phase, and the port's own `close()`, which releases every
+   * handle it handed out.
+   */
+  readonly subscribe = (listener: () => void): AlloUnsubscribe => {
+    this.#listeners.add(listener);
+    if (!this.#watchingRuntime) {
+      this.#watchingRuntime = true;
+      this.#runtime.subscribe(this.#onRuntimeChanged);
+      // The runtime notifies on change, so a runtime that was already ready when
+      // the first subscriber arrived would otherwise never open anything.
+      this.#onRuntimeChanged();
+    }
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  };
+
+  readonly getSnapshot = (): readonly AlloRoomSummary[] => this.#rooms;
+
+  readonly #onRuntimeChanged = (): void => {
+    const ready = this.#runtime.getState().phase === 'ready';
+    if (ready) {
+      if (this.#handle === undefined && !this.#opening) {
+        void this.#open();
+      }
+      return;
+    }
+    if (this.#handle !== undefined || this.#opening) {
+      this.#drop();
+    }
+  };
+
+  async #open(): Promise<void> {
+    const generation = this.#generation;
+    this.#opening = true;
+    try {
+      const handle = await this.#runtime
+        .client('Observing the conversation list')
+        .observeRooms((rooms) => {
+          this.#publish(generation, rooms);
+        });
+      if (generation !== this.#generation) {
+        // The runtime went away while this was opening. The handle is nobody's
+        // and closing it is the only thing left to do with it.
+        handle.close();
+        return;
+      }
+      this.#handle = handle;
+      // The web half publishes from inside `observeRooms`, before the promise
+      // resolves; the native half publishes later. Reading the handle covers the
+      // first case without assuming either.
+      this.#publish(generation, handle.rooms());
+    } catch (error) {
+      logger.error('[chat] the Matrix conversation list could not be opened', error);
+    } finally {
+      if (generation === this.#generation) {
+        this.#opening = false;
+      }
+    }
+  }
+
+  #drop(): void {
+    this.#generation += 1;
+    this.#opening = false;
+    const handle = this.#handle;
+    this.#handle = undefined;
+    handle?.close();
+    this.#rooms = NO_ROOMS;
+    this.#emit();
+  }
+
+  #publish(generation: number, rooms: readonly AlloRoomSummary[]): void {
+    if (generation !== this.#generation || rooms === this.#rooms) {
+      return;
+    }
+    this.#rooms = rooms;
+    this.#emit();
+  }
+
+  #emit(): void {
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+}
+
+/** The app's conversation list. */
+export const roomListSource = new RoomListSource(matrixRuntime);

--- a/packages/frontend/lib/chat/timelineSource.ts
+++ b/packages/frontend/lib/chat/timelineSource.ts
@@ -1,0 +1,279 @@
+import type {
+  AlloPaginationOutcome,
+  AlloTimelineHandle,
+  AlloTimelineItem,
+  AlloUnsubscribe,
+} from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
+
+import { matrixRuntime, type MatrixRuntimeLike } from './matrixRuntime';
+
+/**
+ * One conversation's timeline, as something React can read without an Effect.
+ *
+ * The counterpart of `roomListSource.ts`, with one difference that decides the
+ * shape: a timeline is per room and there can be many rooms, so unlike the
+ * conversation list this one really is closed when the last reader goes away.
+ * Leaving every visited conversation subscribed would keep a listener per room
+ * for the life of the app.
+ *
+ * Paginating and sending live here rather than in the hook because both are
+ * timeline operations in the port — the Rust binding has no send method on
+ * `Room` — and because whether a pagination is already running, and whether the
+ * start of the conversation has been reached, are facts about the timeline and
+ * not about whichever component is drawing it.
+ */
+
+export interface TimelineSnapshot {
+  /** The rows, oldest first. */
+  readonly items: readonly AlloTimelineItem[];
+  /** The timeline has not been opened yet: there is nothing to draw *yet*. */
+  readonly isOpening: boolean;
+  readonly isPaginating: boolean;
+  /** There are no older events to ask for. */
+  readonly reachedStart: boolean;
+}
+
+const NO_ITEMS: readonly AlloTimelineItem[] = [];
+
+const CLOSED: TimelineSnapshot = {
+  items: NO_ITEMS,
+  isOpening: false,
+  isPaginating: false,
+  reachedStart: false,
+};
+
+const OPENING: TimelineSnapshot = { ...CLOSED, isOpening: true };
+
+/** A timeline operation was asked for on a conversation nothing is watching. */
+export class TimelineNotOpenError extends Error {
+  constructor(operation: string, roomId: string) {
+    super(
+      `${operation} needs the timeline of ${roomId} to be open, and nothing is ` +
+        'watching it.',
+    );
+    this.name = 'TimelineNotOpenError';
+  }
+}
+
+/**
+ * A timeline finished opening into a session that had already ended.
+ *
+ * Ordinary rather than exceptional — signing out, or losing the session, while a
+ * conversation is being opened — and worth its own type so it is not read as the
+ * homeserver having refused anything.
+ */
+export class TimelineAbandonedError extends Error {
+  constructor(roomId: string) {
+    super(
+      `The timeline of ${roomId} finished opening after its session ended, so it ` +
+        'was closed instead of shown.',
+    );
+    this.name = 'TimelineAbandonedError';
+  }
+}
+
+export class TimelineSource {
+  readonly #runtime: MatrixRuntimeLike;
+  readonly #roomId: string;
+  readonly #listeners = new Set<() => void>();
+  readonly #onIdle: () => void;
+
+  #snapshot: TimelineSnapshot = CLOSED;
+  #handle: AlloTimelineHandle | undefined;
+  #opening: Promise<AlloTimelineHandle> | undefined;
+  #watchingRuntime: AlloUnsubscribe | undefined;
+  /** See `roomListSource.ts`: invalidates callbacks from a superseded handle. */
+  #generation = 0;
+
+  constructor(runtime: MatrixRuntimeLike, roomId: string, onIdle: () => void) {
+    this.#runtime = runtime;
+    this.#roomId = roomId;
+    this.#onIdle = onIdle;
+  }
+
+  readonly subscribe = (listener: () => void): AlloUnsubscribe => {
+    this.#listeners.add(listener);
+    if (this.#watchingRuntime === undefined) {
+      this.#watchingRuntime = this.#runtime.subscribe(this.#onRuntimeChanged);
+      this.#onRuntimeChanged();
+    }
+    return () => {
+      this.#listeners.delete(listener);
+      if (this.#listeners.size === 0) {
+        this.#close();
+      }
+    };
+  };
+
+  readonly getSnapshot = (): TimelineSnapshot => this.#snapshot;
+
+  /**
+   * Asks for older events.
+   *
+   * A second call while one is running, or any call once the start has been
+   * reached, is answered from what is already known rather than sent to the
+   * homeserver: a list that fires its "load more" handler on every frame near the
+   * top would otherwise paginate the whole conversation.
+   */
+  readonly paginateBackwards = async (count: number): Promise<AlloPaginationOutcome> => {
+    if (this.#snapshot.reachedStart) {
+      return 'reached-start';
+    }
+    if (this.#snapshot.isPaginating) {
+      return 'more-available';
+    }
+    const handle = await this.#require('Loading older messages');
+    const generation = this.#generation;
+    this.#publish({ isPaginating: true });
+    try {
+      const outcome = await handle.paginateBackwards(count);
+      if (generation === this.#generation) {
+        this.#publish({ isPaginating: false, reachedStart: outcome === 'reached-start' });
+      }
+      return outcome;
+    } catch (error) {
+      if (generation === this.#generation) {
+        this.#publish({ isPaginating: false });
+      }
+      throw error;
+    }
+  };
+
+  /**
+   * Sends plain text.
+   *
+   * Nothing is done here about the local echo: the port puts the sent message in
+   * the timeline itself, with `sendState: 'pending'`, and the row becomes the real
+   * event when the homeserver acknowledges it. An optimistic entry added on top of
+   * that would be a duplicate.
+   */
+  readonly sendText = async (body: string): Promise<void> => {
+    const handle = await this.#require('Sending a message');
+    await handle.sendText(body);
+  };
+
+  readonly #onRuntimeChanged = (): void => {
+    if (this.#runtime.getState().phase === 'ready') {
+      if (this.#handle === undefined && this.#opening === undefined) {
+        void this.#open().catch((error: unknown) => {
+          if (error instanceof TimelineAbandonedError) {
+            // Not a failure: the session ended while the room was opening, and
+            // the handle has already been closed.
+            logger.info(`[chat] ${error.message}`);
+            return;
+          }
+          logger.error(
+            `[chat] the timeline of ${this.#roomId} could not be opened`,
+            error,
+          );
+        });
+      }
+      return;
+    }
+    if (this.#handle !== undefined || this.#opening !== undefined) {
+      this.#drop();
+    }
+  };
+
+  #open(): Promise<AlloTimelineHandle> {
+    const generation = this.#generation;
+    this.#publish(OPENING);
+    const opening = this.#runtime
+      .client('Opening a conversation')
+      .openTimeline(this.#roomId, (items) => {
+        this.#publishItems(generation, items);
+      })
+      .then((handle) => {
+        if (generation !== this.#generation) {
+          handle.close();
+          throw new TimelineAbandonedError(this.#roomId);
+        }
+        this.#handle = handle;
+        this.#opening = undefined;
+        this.#publish({ isOpening: false });
+        this.#publishItems(generation, handle.items());
+        return handle;
+      });
+    this.#opening = opening;
+    return opening;
+  }
+
+  async #require(operation: string): Promise<AlloTimelineHandle> {
+    const handle = this.#handle ?? (await this.#opening);
+    if (handle === undefined) {
+      throw new TimelineNotOpenError(operation, this.#roomId);
+    }
+    return handle;
+  }
+
+  #drop(): void {
+    this.#generation += 1;
+    this.#opening = undefined;
+    const handle = this.#handle;
+    this.#handle = undefined;
+    handle?.close();
+    this.#snapshot = CLOSED;
+    this.#emit();
+  }
+
+  #close(): void {
+    this.#drop();
+    this.#watchingRuntime?.();
+    this.#watchingRuntime = undefined;
+    this.#onIdle();
+  }
+
+  #publishItems(generation: number, items: readonly AlloTimelineItem[]): void {
+    if (generation !== this.#generation || items === this.#snapshot.items) {
+      return;
+    }
+    this.#snapshot = { ...this.#snapshot, items };
+    this.#emit();
+  }
+
+  #publish(patch: Partial<TimelineSnapshot>): void {
+    const next: TimelineSnapshot = { ...this.#snapshot, ...patch };
+    if (
+      next.items === this.#snapshot.items &&
+      next.isOpening === this.#snapshot.isOpening &&
+      next.isPaginating === this.#snapshot.isPaginating &&
+      next.reachedStart === this.#snapshot.reachedStart
+    ) {
+      return;
+    }
+    this.#snapshot = next;
+    this.#emit();
+  }
+
+  #emit(): void {
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+}
+
+/**
+ * The open timelines, one per room.
+ *
+ * A registry and not a fresh source per component, because two components
+ * drawing the same conversation — the list pane and the detail pane of the
+ * three-panel layout — must not open two timelines over one room.
+ */
+const sources = new Map<string, TimelineSource>();
+
+export function timelineSource(roomId: string): TimelineSource {
+  const existing = sources.get(roomId);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const source = new TimelineSource(matrixRuntime, roomId, () => {
+    // Removed only if it is still the registered one: a component that
+    // resubscribed in the same tick has already put a new source here.
+    if (sources.get(roomId) === source) {
+      sources.delete(roomId);
+    }
+  });
+  sources.set(roomId, source);
+  return source;
+}

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -572,5 +572,17 @@
             "title": "Page Not Found - Allo",
             "description": "The page you're looking for doesn't exist."
         }
-    }
+    },
+    "Connecting…": "Connecting…",
+    "Finish signing in": "Finish signing in",
+    "Allo is waiting for the sign-in page in your browser.": "Allo is waiting for the sign-in page in your browser.",
+    "Allo could not sign you in": "Allo could not sign you in",
+    "Sign in to start chatting": "Sign in to start chatting",
+    "Something went wrong. Try again.": "Something went wrong. Try again.",
+    "Your conversations live on your Matrix homeserver. Sign in to load them.": "Your conversations live on your Matrix homeserver. Sign in to load them.",
+    "Try again": "Try again",
+    "Sign in": "Sign in",
+    "This message cannot be read on this device.": "This message cannot be read on this device.",
+    "This message was deleted.": "This message was deleted.",
+    "Allo cannot show this yet ({{kind}}).": "Allo cannot show this yet ({{kind}})."
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -541,5 +541,17 @@
       "title": "Página No Encontrada - allo",
       "description": "La página que buscas no existe."
     }
-  }
+  },
+  "Connecting…": "Conectando…",
+  "Finish signing in": "Termina de iniciar sesión",
+  "Allo is waiting for the sign-in page in your browser.": "Allo está esperando a la página de inicio de sesión de tu navegador.",
+  "Allo could not sign you in": "Allo no ha podido iniciar tu sesión",
+  "Sign in to start chatting": "Inicia sesión para empezar a chatear",
+  "Something went wrong. Try again.": "Algo ha fallado. Inténtalo de nuevo.",
+  "Your conversations live on your Matrix homeserver. Sign in to load them.": "Tus conversaciones viven en tu servidor de Matrix. Inicia sesión para cargarlas.",
+  "Try again": "Reintentar",
+  "Sign in": "Iniciar sesión",
+  "This message cannot be read on this device.": "Este mensaje no se puede leer en este dispositivo.",
+  "This message was deleted.": "Este mensaje se ha borrado.",
+  "Allo cannot show this yet ({{kind}}).": "Allo todavía no puede mostrar esto ({{kind}})."
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -535,5 +535,17 @@
       "title": "Pagina Non Trovata - allo",
       "description": "La pagina che stai cercando non esiste."
     }
-  }
+  },
+  "Connecting…": "Connessione…",
+  "Finish signing in": "Completa l'accesso",
+  "Allo is waiting for the sign-in page in your browser.": "Allo sta aspettando la pagina di accesso nel tuo browser.",
+  "Allo could not sign you in": "Allo non è riuscito a farti accedere",
+  "Sign in to start chatting": "Accedi per iniziare a chattare",
+  "Something went wrong. Try again.": "Qualcosa è andato storto. Riprova.",
+  "Your conversations live on your Matrix homeserver. Sign in to load them.": "Le tue conversazioni vivono sul tuo homeserver Matrix. Accedi per caricarle.",
+  "Try again": "Riprova",
+  "Sign in": "Accedi",
+  "This message cannot be read on this device.": "Questo messaggio non può essere letto su questo dispositivo.",
+  "This message was deleted.": "Questo messaggio è stato eliminato.",
+  "Allo cannot show this yet ({{kind}}).": "Allo non può ancora mostrare questo ({{kind}})."
 }

--- a/packages/frontend/public/matrix-oidc-callback.html
+++ b/packages/frontend/public/matrix-oidc-callback.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Signing in to Allo</title>
+    <style>
+      body {
+        margin: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        background: #0b0b0f;
+        color: #f5f5f7;
+        font: 16px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+        text-align: center;
+        padding: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      Where the authorization server sends the browser back on web.
+
+      This is a static file and deliberately not a route of the app. The web
+      export answers unknown paths with index.html (see `_redirects`), so a
+      redirect aimed at an app route would boot a second copy of Allo inside the
+      popup — and two copies means two MatrixClients on one IndexedDB, which the
+      SDK says corrupts the crypto store. A file that exists is served as itself
+      and can do no such thing.
+
+      There is no script here on purpose: expo-web-browser's web implementation
+      reads the popup's URL and closes it. Nothing on this page has to run for the
+      sign-in to complete, and code that touched the authorization code would be
+      code holding a credential for no reason.
+    -->
+    <p>You can close this window and go back to Allo.</p>
+  </body>
+</html>

--- a/packages/frontend/utils/messageGrouping.ts
+++ b/packages/frontend/utils/messageGrouping.ts
@@ -55,7 +55,7 @@ export function getDayKey(timestamp: Date): string {
  * Group messages by time proximity
  * Messages within MESSAGE_GROUPING_TIME_WINDOW_MS are grouped together
  */
-export function groupMessagesByTime(messages: Message[]): MessageGroup[] {
+export function groupMessagesByTime(messages: readonly Message[]): MessageGroup[] {
   if (messages.length === 0) {
     return [];
   }


### PR DESCRIPTION
## Resumen

La pieza central de la Fase 2: la lista de conversaciones, el timeline con paginación y el envío pasan a poder alimentarse desde el puerto de Matrix, **detrás de una bandera**, con el sistema actual intacto al lado.

`EXPO_PUBLIC_CHAT_BACKEND` elige el origen. **Sin configurar, la app se comporta exactamente como hoy** — y eso no es una promesa, es un test:

> *"leaves an unconfigured build on the Express API"*

Cambiar ese valor por defecto hace fallar tres tests. Es la propiedad que permite fusionar esto sin riesgo.

## Lo que no se toca

`MessageBubble`, `MessageBlock`, `ConversationView`, el layout de tres paneles, los temas por conversación — todo eso es presentación y sobrevive entero. Lo único que cambia es de dónde salen los datos que reciben. Y no se borra ni se modifica nada del sistema de mensajería actual: se corta cuando lo nuevo esté probado, no antes.

## Lo que trae de nuevo

`paginateBackwards` ya existía en el puerto y no lo llamaba nadie. Hoy `fetchMessages` trae **todos** los mensajes sin límite ni cursor, así que cargar historial hacia atrás no es migrar una función: es implementarla por primera vez.

## Plan de pruebas

- Typecheck del frontend en verde reproduciendo condiciones de CI.
- **236 tests en 20 suites**, frente a 155 en 14 antes de este cambio.
- Verificado por mutación: invertir el backend por defecto hace fallar *"leaves an unconfigured build on the Express API"*, *"treats an empty value as unconfigured"* y *"is the Express API in a build that has not asked for anything else"*.
- **Cero `as any`, cero `@ts-ignore`, y cero `useEffect` nuevos** — en la tarea donde más fácil habría sido colarlos.

## Lo que todavía no llega

Documentado en el commit final: qué enciende la bandera y, sobre todo, qué no funciona aún por ese camino.

🤖 Generated with [Claude Code](https://claude.com/claude-code)