### PR TITLE
El key backup de Matrix, con la clave derivada de Oxy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,8 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "12.0.1",
         "@react-native-community/slider": "5.2.0",
+        "@scure/base": "^1.2.6",
+        "@scure/bip39": "^1.6.0",
         "@shopify/flash-list": "^2.0.2",
         "@tanstack/query-async-storage-persister": "^5.101.2",
         "@tanstack/react-query": "^5.101.2",

--- a/docs/matrix/client-strategy.md
+++ b/docs/matrix/client-strategy.md
@@ -672,6 +672,59 @@ peor que no tenerlo, porque cambia lo que el usuario cree.
    passphrase adicional opcional —con entropía, no un PIN— para quien quiera
    separación.
 
+### 3.7 Lo que salió al implementarlo
+
+El esquema está escrito y es el de arriba, sin desviaciones: la derivación en
+`packages/frontend/lib/matrix/recovery/passphrase.ts`, la máquina de estados de
+§3.4 en `recovery/ensureRecovery.ts` —aparte de los dos SDK, para poder probarla
+sin ninguno— y las dos mitades en `client.native.ts` y `client.web.ts`. Los
+puntos 1 a 4 de §3.2 y §3.4 se cumplen tal cual. Cuatro cosas que el diseño no
+podía saber:
+
+1. **De dónde sale la frase de Oxy, y dónde no sale.** El diseño da por hecho el
+   `oxyPhrase` como entrada disponible. La única vía es
+   `KeyManager.getRecoveryMnemonic()` **[V]**
+   (`node_modules/@oxyhq/core/src/crypto/keyManager.ts:1828-1853`), y **devuelve
+   `null` en web sin consultar ningún almacenamiento**: la primera línea del
+   método es `if (isWebPlatform()) return null`, porque Oxy guarda identidades
+   sólo en el llavero nativo. También devuelve `null` en nativo para cualquier
+   identidad creada antes de que Oxy empezara a guardar la frase.
+
+   Consecuencia, dicha sin adornos: **la promesa "el historial se abre solo al
+   entrar con Oxy" se cumple hoy en iOS y Android, y no en web.** No es un fallo
+   de la derivación —web deriva igual de bien si se le da la frase— sino que en
+   web no hay de dónde leerla. El puerto lo reporta como tal en vez de fallar:
+   `readOxyRecoveryPhrase` distingue `absent` (no hay frase aquí; hace falta que
+   el usuario la escriba) de `unavailable` (llavero bloqueado; reintentar), y
+   `ensureMatrixRecovery` responde `skipped` con el motivo. Lo que falta para
+   cerrar web es una pantalla que pida la frase, o que `@oxyhq/core` ofrezca la
+   frase en web — decisión que no es de Allo.
+
+2. **`deriveRecoveryKeyFromPassphrase` no se exporta de la raíz**, como ya
+   avisaba `spikes/matrix-web/RESULTS.md` (restricción 3). Confirmado en
+   `matrix-js-sdk@42`. La importación de `matrix-js-sdk/lib/crypto-api/index.js`
+   está aislada en `client.web.ts` y se le pasa a `web/secretStorage.ts` como
+   argumento, igual que `cryptoWasm.ts` recibe su `initAsync`.
+
+3. **El `setupNewKeyBackup` de web necesita una guarda que el binding nativo trae
+   de fábrica.** `bootstrapSecretStorage({setupNewKeyBackup: true})` llama al
+   reset del backup, que crea una versión nueva en el servidor; toda clave de
+   sala que sólo viva en la versión anterior queda descifrable por una clave que
+   ya no tiene nadie. El SDK nativo se niega con `RecoveryError::BackupExistsOnServer`
+   (§3.2) y el de web no. `web/recovery.ts:planKeyBackup` reproduce esa negativa.
+
+4. **Sin `authUploadDeviceSigningKeys` en web, a propósito.** El spike usaba UIA
+   por contraseña; Allo no tiene contraseña de Matrix que dar. En la primera
+   subida de claves de cross-signing MAS no pide autenticación (MSC3967), que es
+   el caso en el que está esta llamada. Si un homeserver la pidiera igualmente,
+   el error es el suyo y se ve — mejor que un callback que finge autenticar.
+
+Y una nota sobre el punto 5 de la recomendación: la frase está en la UI, en
+Ajustes → Security & Encryption, en los tres idiomas
+(`components/matrix/recoveryDisclosureCopy.ts`). La passphrase adicional
+opcional **no** está implementada; sigue siendo una opción abierta y su ausencia
+no rompe nada de lo anterior.
+
 ---
 
 ## 4. Lo que no pude verificar
@@ -707,15 +760,19 @@ En orden de cuánto duele si sale mal:
    el pegamento de wasm-bindgen **[T]**. Los 7,8 MB del `.wasm` no están ahí
    dentro: siguen siendo una descarga aparte y diferida. Nada de la UI importa
    todavía el puerto, así que hoy el coste es cero.
-2. **El coste de PBKDF2 en un Android real.** Medí 143 ms en máquina de desarrollo
+2. **De dónde saca web la frase de Oxy.** Abierto, y es hoy el hueco más grande
+   del esquema: `KeyManager.getRecoveryMnemonic()` devuelve `null` en web por
+   construcción, así que la derivación funciona y no tiene entrada. Detalle y
+   consecuencias en §3.7 punto 1. Nativo no está afectado.
+3. **El coste de PBKDF2 en un Android real.** Medí 143 ms en máquina de desarrollo
    **[T]**; no en teléfono. No cambia la decisión, sí el copy de la pantalla de espera.
-3. **Que el homeserver que se despliegue sirva sliding sync nativo.** Es un requisito
+4. **Que el homeserver que se despliegue sirva sliding sync nativo.** Es un requisito
    duro para móvil **[B]** y no depende de este documento.
-4. **Nada de lo que afirmo sobre el spec de Matrix por sí mismo.** Todo lo marcado
+5. **Nada de lo que afirmo sobre el spec de Matrix por sí mismo.** Todo lo marcado
    **[R]**/**[B]**/**[J]** es lo que estas implementaciones concretas hacen, que es lo
    que la app va a ejecutar. Donde el spec diga otra cosa, gana el código, pero
    conviene saberlo.
-5. **Multi-pestaña en web.** Sigue abierto, y el spike lo dejó **más flojo** de lo
+6. **Multi-pestaña en web.** Sigue abierto, y el spike lo dejó **más flojo** de lo
    que decía esta línea. El encargo era reproducir y caracterizar el fallo, y **no
    se reprodujo**: dos pestañas con la misma sesión, el mismo `device_id` y el
    mismo IndexedDB envían, descifran y se leen entre ellas sin divergencia, ni

--- a/packages/frontend/__mocks__/@unomed/react-native-matrix-sdk.ts
+++ b/packages/frontend/__mocks__/@unomed/react-native-matrix-sdk.ts
@@ -59,6 +59,13 @@ export enum SyncServiceState {
   Offline = 4,
 }
 
+export enum RecoveryState {
+  Unknown = 0,
+  Enabled = 1,
+  Disabled = 2,
+  Incomplete = 3,
+}
+
 // --- Tag enums -----------------------------------------------------------
 
 export enum TimelineItemContent_Tags {
@@ -112,6 +119,15 @@ export enum ProfileDetails_Tags {
   Error = 'Error',
 }
 
+export enum EnableRecoveryProgress_Tags {
+  Starting = 'Starting',
+  CreatingBackup = 'CreatingBackup',
+  CreatingRecoveryKey = 'CreatingRecoveryKey',
+  BackingUp = 'BackingUp',
+  RoomKeyUploadError = 'RoomKeyUploadError',
+  Done = 'Done',
+}
+
 // --- Variant constructors, for building fixtures -------------------------
 
 export const TimelineItemContent = {
@@ -163,6 +179,15 @@ export const ProfileDetails = {
   Pending: variant(ProfileDetails_Tags.Pending),
   Ready: variant(ProfileDetails_Tags.Ready),
   Error: variant(ProfileDetails_Tags.Error),
+};
+
+export const EnableRecoveryProgress = {
+  Starting: variant(EnableRecoveryProgress_Tags.Starting),
+  CreatingBackup: variant(EnableRecoveryProgress_Tags.CreatingBackup),
+  CreatingRecoveryKey: variant(EnableRecoveryProgress_Tags.CreatingRecoveryKey),
+  BackingUp: variant(EnableRecoveryProgress_Tags.BackingUp),
+  RoomKeyUploadError: variant(EnableRecoveryProgress_Tags.RoomKeyUploadError),
+  Done: variant(EnableRecoveryProgress_Tags.Done),
 };
 
 export const QueueWedgeError = {

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -8,6 +8,7 @@ import type {
   AlloChatClientConfig,
   AlloEncryptionState,
   AlloOidcLoginRequest,
+  AlloRecoveryState,
   AlloRoomListHandle,
   AlloSession,
   AlloSyncState,
@@ -118,6 +119,18 @@ class FakeChatClient implements AlloChatClient {
   }
 
   async openTimeline(): Promise<AlloTimelineHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoveryState(): Promise<AlloRecoveryState> {
+    throw new Error('not used by these tests');
+  }
+
+  async enableRecovery(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoverWithPassphrase(): Promise<void> {
     throw new Error('not used by these tests');
   }
 

--- a/packages/frontend/__tests__/chat/roomListSource.test.ts
+++ b/packages/frontend/__tests__/chat/roomListSource.test.ts
@@ -8,6 +8,7 @@ import type {
   AlloChatClient,
   AlloEncryptionState,
   AlloOidcLoginRequest,
+  AlloRecoveryState,
   AlloRoomListHandle,
   AlloRoomSummary,
   AlloSession,
@@ -121,6 +122,18 @@ class FakeChatClient implements AlloChatClient {
   }
 
   async roomEncryption(): Promise<AlloEncryptionState> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoveryState(): Promise<AlloRecoveryState> {
+    throw new Error('not used by these tests');
+  }
+
+  async enableRecovery(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoverWithPassphrase(): Promise<void> {
     throw new Error('not used by these tests');
   }
 

--- a/packages/frontend/__tests__/chat/timelineSource.test.ts
+++ b/packages/frontend/__tests__/chat/timelineSource.test.ts
@@ -8,6 +8,7 @@ import type {
   AlloChatClient,
   AlloEncryptionState,
   AlloOidcLoginRequest,
+  AlloRecoveryState,
   AlloPaginationOutcome,
   AlloRoomListHandle,
   AlloSession,
@@ -153,6 +154,18 @@ class FakeChatClient implements AlloChatClient {
   }
 
   async roomEncryption(): Promise<AlloEncryptionState> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoveryState(): Promise<AlloRecoveryState> {
+    throw new Error('not used by these tests');
+  }
+
+  async enableRecovery(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoverWithPassphrase(): Promise<void> {
     throw new Error('not used by these tests');
   }
 

--- a/packages/frontend/__tests__/matrix/recovery/disclosure.test.ts
+++ b/packages/frontend/__tests__/matrix/recovery/disclosure.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  RECOVERY_DISCLOSURE_BODY,
+  RECOVERY_DISCLOSURE_TITLE,
+} from '@/components/matrix/recoveryDisclosureCopy';
+
+/**
+ * That the trade this scheme makes is stated to the user, in every language, and
+ * still says the part nobody enjoys writing.
+ *
+ * Deriving the key backup passphrase from the Oxy identity buys the whole
+ * feature — history that opens itself on a new device — at a price: whoever
+ * holds the Oxy phrase can read messages sent *before* they got it, which in the
+ * ordinary Matrix design would be behind a second credential. The design asks
+ * for that to be in the interface rather than in a comment
+ * (`docs/matrix/client-strategy.md` §3.6), because a user who thinks Allo keeps
+ * a secret of its own will guard the phrase less carefully than they should.
+ *
+ * These checks are what a rewrite has to get past. A locale that loses the
+ * strings, or English that turns into "your data is protected", fails here.
+ */
+
+const FRONTEND = join(__dirname, '..', '..', '..');
+const LOCALES = join(FRONTEND, 'locales');
+
+function localeFiles(): string[] {
+  return readdirSync(LOCALES).filter((name) => name.endsWith('.json'));
+}
+
+function readLocale(name: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(readFileSync(join(LOCALES, name), 'utf8'));
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error(`${name} is not an object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+describe('the recovery disclosure', () => {
+  const files = localeFiles();
+
+  it('ships in more than one language', () => {
+    expect(files.length).toBeGreaterThan(1);
+  });
+
+  it.each(files)('is translated in %s', (name) => {
+    const locale = readLocale(name);
+
+    for (const key of [RECOVERY_DISCLOSURE_TITLE, RECOVERY_DISCLOSURE_BODY]) {
+      const translation = locale[key];
+      expect(typeof translation).toBe('string');
+      // Not the key echoed back with a couple of words changed: a real
+      // translation of the body is a paragraph.
+      expect(String(translation).length).toBeGreaterThan(key.length / 2);
+    }
+  });
+
+  it('still says that holding the phrase means reading past messages', () => {
+    // The euphemism-resistant part. Each of these is a fact the user needs, and
+    // a rewrite that drops one has changed what the app promises.
+    expect(RECOVERY_DISCLOSURE_BODY).toContain('anyone who has that phrase can read them');
+    expect(RECOVERY_DISCLOSURE_BODY).toContain('before they got it');
+    expect(RECOVERY_DISCLOSURE_TITLE).toContain('Oxy recovery phrase');
+  });
+
+  it('is rendered by the settings screen', () => {
+    // The copy existing in a component nobody mounts would satisfy every check
+    // above and tell no user anything.
+    const screen = readFileSync(join(FRONTEND, 'app', '(chat)', 'settings', 'index.tsx'), 'utf8');
+
+    expect(screen).toContain('<RecoveryDisclosure />');
+    expect(screen).toContain('@/components/matrix/RecoveryDisclosure');
+  });
+
+  it('draws the copy from this module rather than repeating it', () => {
+    // Otherwise the checks above are about a string the screen no longer shows.
+    const component = readFileSync(
+      join(FRONTEND, 'components', 'matrix', 'RecoveryDisclosure.tsx'),
+      'utf8',
+    );
+
+    expect(component).toContain('t(RECOVERY_DISCLOSURE_TITLE)');
+    expect(component).toContain('t(RECOVERY_DISCLOSURE_BODY)');
+  });
+});

--- a/packages/frontend/__tests__/matrix/recovery/ensureRecovery.test.ts
+++ b/packages/frontend/__tests__/matrix/recovery/ensureRecovery.test.ts
@@ -1,0 +1,236 @@
+import {
+  ensureMatrixRecovery,
+  type RecoveryCapableClient,
+} from '@/lib/matrix/recovery/ensureRecovery';
+import type { AlloRecoveryState } from '@/lib/matrix/types';
+
+/**
+ * The decision that stands between a user and their message history.
+ *
+ * Every case below is a state a device really reaches, and in three of them the
+ * wrong branch is expensive in a way no test at runtime would catch:
+ *
+ * - `disabled` → anything but create: recovery never gets set up, and every
+ *   message the user sends is only readable on the device that sent it.
+ * - `incomplete` → create: a *second* 4S store replaces the first as the
+ *   account's default. The keys to the user's history are still on the server
+ *   and nothing opens them again.
+ * - `enabled`/`unknown` → create: the same loss, from a device that had nothing
+ *   wrong with it.
+ *
+ * The fakes make each of those a visible call rather than an SDK side effect.
+ */
+
+class FakeRecoveryClient implements RecoveryCapableClient {
+  readonly calls: string[] = [];
+  enableRecoveryPassphrase: string | undefined;
+  recoverPassphrase: string | undefined;
+
+  #state: AlloRecoveryState;
+  #failWith: Error | undefined;
+
+  constructor(state: AlloRecoveryState) {
+    this.#state = state;
+  }
+
+  failNextAction(error: Error): void {
+    this.#failWith = error;
+  }
+
+  async recoveryState(): Promise<AlloRecoveryState> {
+    this.calls.push('recoveryState');
+    return this.#state;
+  }
+
+  async enableRecovery(passphrase: string): Promise<void> {
+    this.calls.push('enableRecovery');
+    this.enableRecoveryPassphrase = passphrase;
+    if (this.#failWith !== undefined) {
+      throw this.#failWith;
+    }
+  }
+
+  async recoverWithPassphrase(passphrase: string): Promise<void> {
+    this.calls.push('recoverWithPassphrase');
+    this.recoverPassphrase = passphrase;
+    if (this.#failWith !== undefined) {
+      throw this.#failWith;
+    }
+  }
+}
+
+const PHRASE = 'the oxy phrase';
+const PASSPHRASE = 'derived-passphrase';
+
+/** Reads a phrase, and records that it was read at all. */
+function phraseReader(result: string | null | Error): {
+  read: () => Promise<string | null>;
+  reads: () => number;
+} {
+  let reads = 0;
+  return {
+    read: async () => {
+      reads += 1;
+      if (result instanceof Error) {
+        throw result;
+      }
+      return result;
+    },
+    reads: () => reads,
+  };
+}
+
+const derivePassphrase = async (phrase: string): Promise<string> => {
+  expect(phrase).toBe(PHRASE);
+  return PASSPHRASE;
+};
+
+describe('ensureMatrixRecovery', () => {
+  it('creates 4S when the account has none', async () => {
+    const client = new FakeRecoveryClient('disabled');
+
+    await expect(
+      ensureMatrixRecovery(client, {
+        readPhrase: phraseReader(PHRASE).read,
+        derivePassphrase,
+      }),
+    ).resolves.toEqual({ kind: 'created' });
+
+    expect(client.calls).toEqual(['recoveryState', 'enableRecovery']);
+    expect(client.enableRecoveryPassphrase).toBe(PASSPHRASE);
+  });
+
+  it('recovers, and never creates, when 4S exists and this device lacks secrets', async () => {
+    // The state a new phone is in the moment it finishes signing in. Creating
+    // here would replace the account's 4S store and strand the old one.
+    const client = new FakeRecoveryClient('incomplete');
+
+    await expect(
+      ensureMatrixRecovery(client, {
+        readPhrase: phraseReader(PHRASE).read,
+        derivePassphrase,
+      }),
+    ).resolves.toEqual({ kind: 'recovered' });
+
+    expect(client.calls).toEqual(['recoveryState', 'recoverWithPassphrase']);
+    expect(client.recoverPassphrase).toBe(PASSPHRASE);
+  });
+
+  it('does nothing at all when this device already has everything', async () => {
+    const client = new FakeRecoveryClient('enabled');
+
+    await expect(ensureMatrixRecovery(client)).resolves.toEqual({
+      kind: 'already-enabled',
+    });
+
+    expect(client.calls).toEqual(['recoveryState']);
+  });
+
+  it('does not read the Oxy phrase when there is nothing to do', async () => {
+    // Reading it can raise a biometric prompt and puts a credential in memory.
+    // Neither is acceptable on the ordinary launch of a device that is fine.
+    const reader = phraseReader(PHRASE);
+    const client = new FakeRecoveryClient('enabled');
+
+    await ensureMatrixRecovery(client, { readPhrase: reader.read, derivePassphrase });
+
+    expect(reader.reads()).toBe(0);
+  });
+
+  it('acts on nothing while the crypto stack has not settled', async () => {
+    // `unknown` is the native binding's answer for the first moments of a
+    // session. Guessing `disabled` here destroys 4S; guessing `enabled` skips a
+    // recovery the device needed. Waiting is the only correct move.
+    const reader = phraseReader(PHRASE);
+    const client = new FakeRecoveryClient('unknown');
+
+    await expect(
+      ensureMatrixRecovery(client, { readPhrase: reader.read, derivePassphrase }),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'state-not-settled' });
+
+    expect(client.calls).toEqual(['recoveryState']);
+    expect(reader.reads()).toBe(0);
+  });
+
+  it('reports a device with no stored phrase separately from one that could not be read', async () => {
+    // Two different things to do about them: the first needs the user to type
+    // the phrase, the second needs another attempt in a moment. Collapsing them
+    // either nags a user who can do nothing or silently drops a recovery that
+    // would have worked.
+    const absent = new FakeRecoveryClient('incomplete');
+    await expect(
+      ensureMatrixRecovery(absent, {
+        readPhrase: phraseReader(null).read,
+        derivePassphrase,
+      }),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'no-phrase-on-this-device' });
+    expect(absent.calls).toEqual(['recoveryState']);
+
+    const locked = new FakeRecoveryClient('incomplete');
+    await expect(
+      ensureMatrixRecovery(locked, {
+        readPhrase: phraseReader(new Error('keychain is locked')).read,
+        derivePassphrase,
+      }),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'phrase-unreadable' });
+    expect(locked.calls).toEqual(['recoveryState']);
+  });
+
+  it('creates nothing when the phrase is missing on a device with no 4S either', async () => {
+    // Both halves are absent, which is web today. The temptation is to "set
+    // something up anyway"; there is nothing to set it up from.
+    const client = new FakeRecoveryClient('disabled');
+
+    await expect(
+      ensureMatrixRecovery(client, {
+        readPhrase: phraseReader(null).read,
+        derivePassphrase,
+      }),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'no-phrase-on-this-device' });
+
+    expect(client.calls).toEqual(['recoveryState']);
+  });
+
+  it('lets a failed recovery reach the caller instead of reporting a skip', async () => {
+    // "It did not need doing" and "it was tried and failed" are answers the UI
+    // has to draw differently: only one of them means the user's history is not
+    // here and something is wrong.
+    const client = new FakeRecoveryClient('incomplete');
+    const failure = new Error('the homeserver refused');
+    client.failNextAction(failure);
+
+    await expect(
+      ensureMatrixRecovery(client, {
+        readPhrase: phraseReader(PHRASE).read,
+        derivePassphrase,
+      }),
+    ).rejects.toBe(failure);
+  });
+
+  it('lets a failed creation reach the caller too', async () => {
+    const client = new FakeRecoveryClient('disabled');
+    const failure = new Error('a backup already exists on the server');
+    client.failNextAction(failure);
+
+    await expect(
+      ensureMatrixRecovery(client, {
+        readPhrase: phraseReader(PHRASE).read,
+        derivePassphrase,
+      }),
+    ).rejects.toBe(failure);
+  });
+
+  it('never reports the passphrase in what it returns', async () => {
+    // The outcome is the value that gets logged, put in state, and shown. It
+    // must not be a place a credential can travel.
+    const client = new FakeRecoveryClient('incomplete');
+
+    const outcome = await ensureMatrixRecovery(client, {
+      readPhrase: phraseReader(PHRASE).read,
+      derivePassphrase,
+    });
+
+    expect(JSON.stringify(outcome)).not.toContain(PASSPHRASE);
+    expect(JSON.stringify(outcome)).not.toContain(PHRASE);
+  });
+});

--- a/packages/frontend/__tests__/matrix/recovery/nativeRecovery.test.ts
+++ b/packages/frontend/__tests__/matrix/recovery/nativeRecovery.test.ts
@@ -1,0 +1,79 @@
+import { EnableRecoveryProgress, RecoveryState } from '@unomed/react-native-matrix-sdk';
+
+import {
+  describeEnableRecoveryProgress,
+  toRecoveryState,
+} from '@/lib/matrix/native/recovery';
+
+jest.mock('@unomed/react-native-matrix-sdk');
+
+/**
+ * The native binding's recovery vocabulary, translated.
+ *
+ * Two things are being protected. One is the mapping itself: swap `Disabled`
+ * and `Incomplete` and the state machine creates a second 4S store for a device
+ * that only needed to open the first. The other is what the progress listener is
+ * allowed to say — the `Done` variant carries the recovery key, and a listener
+ * that logs its payload writes a credential that opens the user's whole history
+ * into the log.
+ */
+
+describe('toRecoveryState', () => {
+  it('maps every state the binding has', () => {
+    expect(toRecoveryState(RecoveryState.Disabled)).toBe('disabled');
+    expect(toRecoveryState(RecoveryState.Incomplete)).toBe('incomplete');
+    expect(toRecoveryState(RecoveryState.Enabled)).toBe('enabled');
+    expect(toRecoveryState(RecoveryState.Unknown)).toBe('unknown');
+  });
+
+  it('does not collapse “not settled yet” into any actionable state', () => {
+    // `Unknown` means the crypto stack has not finished starting. Reporting it
+    // as `disabled` would have the caller create 4S over an account that has it.
+    expect(toRecoveryState(RecoveryState.Unknown)).not.toBe('disabled');
+    expect(toRecoveryState(RecoveryState.Unknown)).not.toBe('enabled');
+  });
+});
+
+describe('describeEnableRecoveryProgress', () => {
+  it('never repeats the recovery key the final step carries', () => {
+    const recoveryKey = 'EsTb VXCk 6bV3 vGSX zPtN VNPa Zbnc CrhV kBEQ TTfE Nefv N9Hh';
+
+    const description = describeEnableRecoveryProgress(
+      new EnableRecoveryProgress.Done({ recoveryKey }),
+    );
+
+    expect(description).toBe('done');
+    expect(description).not.toContain(recoveryKey);
+    // Not even a fragment of it: the key is grouped in fours and a description
+    // that quoted "part" of it would still be a leak.
+    expect(description).not.toContain('EsTb');
+  });
+
+  it('reports the steps that carry no secret', () => {
+    expect(describeEnableRecoveryProgress(new EnableRecoveryProgress.Starting())).toBe(
+      'starting',
+    );
+    expect(describeEnableRecoveryProgress(new EnableRecoveryProgress.CreatingBackup())).toBe(
+      'creating the key backup',
+    );
+    expect(
+      describeEnableRecoveryProgress(new EnableRecoveryProgress.CreatingRecoveryKey()),
+    ).toBe('creating the recovery key');
+  });
+
+  it('reports how far the room key upload has got', () => {
+    expect(
+      describeEnableRecoveryProgress(
+        new EnableRecoveryProgress.BackingUp({ backedUpCount: 12, totalCount: 40 }),
+      ),
+    ).toBe('backing up room keys (12/40)');
+  });
+
+  it('reports a failed batch as a step that will retry, not as the end', () => {
+    // The binding keeps going after one; describing it as a failure of the whole
+    // call would have the app tell the user recovery did not happen.
+    expect(
+      describeEnableRecoveryProgress(new EnableRecoveryProgress.RoomKeyUploadError()),
+    ).toBe('a batch of room keys failed to upload; the backup will retry');
+  });
+});

--- a/packages/frontend/__tests__/matrix/recovery/noSilentReset.test.ts
+++ b/packages/frontend/__tests__/matrix/recovery/noSilentReset.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * The operations that break the link to Oxy, and the check that keeps them out.
+ *
+ * Both SDKs offer a handful of calls that replace the 4S key with random bytes
+ * or delete it outright. None of them fails, none of them warns, and after any
+ * of them the passphrase derived from the user's Oxy identity opens nothing —
+ * the account's history is behind a key that was never shown to anybody. See
+ * `docs/matrix/client-strategy.md` §3.2.
+ *
+ * A comment saying "do not call these" is worth very little: the next person to
+ * add a "reset my encryption" screen will reach for exactly these names, because
+ * they are what every other Matrix client uses. So this is a test. It reads the
+ * port's own source and fails on a call to any of them.
+ *
+ * **How to write about these calls without failing this test.** The check looks
+ * for a call *through a receiver* — `something.resetRecoveryKey(` — so prose and
+ * doc comments naming them bare, as this file's own comments do, are fine. That
+ * is deliberate: the alternative is stripping comments before scanning, which
+ * quietly stops working the first time a string literal contains a slash.
+ *
+ * **If one of these is ever genuinely needed**, the change is not to loosen this
+ * test. It is to work out what happens to the history first, put it in the
+ * design, and give the user a way to keep reading their messages afterwards.
+ */
+
+const PORT_DIRECTORY = join(__dirname, '..', '..', '..', 'lib', 'matrix');
+
+/** Method names that silently sever the link, and why each one does. */
+const FORBIDDEN: readonly { readonly method: string; readonly effect: string }[] = [
+  {
+    method: 'resetRecoveryKey',
+    effect: 'replaces the 4S key with 32 random bytes and drops the passphrase block',
+  },
+  {
+    method: 'recoverAndReset',
+    effect: 'opens 4S with the old key and then replaces it with a random one',
+  },
+  {
+    method: 'disableRecovery',
+    effect: 'deletes 4S and the key backup from the account',
+  },
+  {
+    method: 'resetIdentity',
+    effect: 'throws away the cross-signing identity, the backup and the recovery key',
+  },
+  {
+    method: 'resetEncryption',
+    effect: 'the web SDK’s equivalent of a full identity reset',
+  },
+  {
+    method: 'deleteSecretStorage',
+    effect: 'removes the 4S key and every secret stored under it',
+  },
+  {
+    method: 'resetKeyBackup',
+    effect:
+      'mints a new backup version, stranding every room key that only the old one holds',
+  },
+];
+
+function typeScriptFilesUnder(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return typeScriptFilesUnder(path);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+describe('the Matrix port', () => {
+  const files = typeScriptFilesUnder(PORT_DIRECTORY);
+
+  it('has source to check', () => {
+    // Without this the suite passes cheerfully if the directory ever moves.
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it.each(FORBIDDEN)('never calls $method, which $effect', ({ method }) => {
+    const callSite = new RegExp(`\\.\\s*${method}\\s*\\(`);
+
+    const offenders = files.filter((file) => callSite.test(readFileSync(file, 'utf8')));
+
+    expect(offenders.map((file) => relative(PORT_DIRECTORY, file))).toEqual([]);
+  });
+
+  it('offers no way to reach them from outside either', () => {
+    // The port is the app's only door to a Matrix SDK, so a method it does not
+    // expose is a method no screen can call. This asserts the door stays shut:
+    // the contract's recovery surface is these three and nothing more.
+    const contract = readFileSync(join(PORT_DIRECTORY, 'types.ts'), 'utf8');
+
+    expect(contract).toContain('recoveryState(): Promise<AlloRecoveryState>;');
+    expect(contract).toContain('enableRecovery(passphrase: string): Promise<void>;');
+    expect(contract).toContain('recoverWithPassphrase(passphrase: string): Promise<void>;');
+
+    for (const { method } of FORBIDDEN) {
+      expect(contract).not.toMatch(new RegExp(`^\\s*${method}\\s*\\(`, 'm'));
+    }
+  });
+});

--- a/packages/frontend/__tests__/matrix/recovery/oxyIdentity.test.ts
+++ b/packages/frontend/__tests__/matrix/recovery/oxyIdentity.test.ts
@@ -1,0 +1,67 @@
+import { readOxyRecoveryPhrase } from '@/lib/matrix/recovery/oxyIdentity';
+
+/**
+ * Reading the Oxy phrase, and the distinction the rest of the feature rests on.
+ *
+ * `KeyManager.getRecoveryMnemonic()` has two ways of not returning a phrase and
+ * they mean opposite things: `null` is "this device holds none", a thrown error
+ * is "storage could not be read". Flattening the second into the first is the
+ * bug that makes an app decide a returning user is a new one — here it would
+ * mean silently skipping a recovery that a retry a second later would have
+ * completed.
+ */
+
+describe('readOxyRecoveryPhrase', () => {
+  it('returns the phrase when the keychain holds one', async () => {
+    await expect(readOxyRecoveryPhrase(async () => 'zoo zoo zoo')).resolves.toEqual({
+      kind: 'available',
+      phrase: 'zoo zoo zoo',
+    });
+  });
+
+  it('reports a successful read that found nothing as absent', async () => {
+    // Web always lands here — Oxy keeps identities in the native keychain only —
+    // as does a native install whose identity predates Oxy storing the phrase.
+    await expect(readOxyRecoveryPhrase(async () => null)).resolves.toEqual({
+      kind: 'absent',
+    });
+  });
+
+  it('reports a storage failure as unavailable, not as absent', async () => {
+    const lookup = await readOxyRecoveryPhrase(async () => {
+      throw new Error('Failed to read recovery mnemonic from secure storage.');
+    });
+
+    expect(lookup).toEqual({
+      kind: 'unavailable',
+      reason: 'Failed to read recovery mnemonic from secure storage.',
+    });
+  });
+
+  it('describes a thrown non-error rather than losing it', async () => {
+    // Secure-storage modules reject with all sorts of things.
+    await expect(
+      readOxyRecoveryPhrase(async () => {
+        throw 'keychain unavailable';
+      }),
+    ).resolves.toEqual({ kind: 'unavailable', reason: 'keychain unavailable' });
+  });
+
+  it('treats an empty slot as absent rather than as a phrase', async () => {
+    // A slot that exists and holds nothing is not a phrase. Passing it on would
+    // report the user's own recovery phrase as invalid.
+    await expect(readOxyRecoveryPhrase(async () => '')).resolves.toEqual({ kind: 'absent' });
+    await expect(readOxyRecoveryPhrase(async () => '   \n')).resolves.toEqual({
+      kind: 'absent',
+    });
+  });
+
+  it('does not swallow the phrase’s own whitespace once there is a phrase', async () => {
+    // Normalisation belongs to the derivation, which lowercases and trims to
+    // match Oxy. This function reports what it found.
+    await expect(readOxyRecoveryPhrase(async () => '  zoo zoo  ')).resolves.toEqual({
+      kind: 'available',
+      phrase: '  zoo zoo  ',
+    });
+  });
+});

--- a/packages/frontend/__tests__/matrix/recovery/passphrase.test.ts
+++ b/packages/frontend/__tests__/matrix/recovery/passphrase.test.ts
@@ -1,0 +1,162 @@
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { base64urlnopad } from '@scure/base';
+import { mnemonicToSeed } from '@scure/bip39';
+
+import { MatrixRecoveryPhraseInvalidError } from '@/lib/matrix/errors';
+import {
+  MATRIX_RECOVERY_KDF_INFO,
+  MATRIX_RECOVERY_KDF_SALT,
+  deriveMatrixRecoveryPassphrase,
+} from '@/lib/matrix/recovery/passphrase';
+
+/**
+ * The derivation, which is the one thing here that can never change by accident.
+ *
+ * The passphrase is not a value anyone stores: it is recomputed from the Oxy
+ * phrase every time a device needs to open the key backup. So a change to the
+ * salt, the label, the seed, the length or the encoding does not fail — it
+ * derives a *different, perfectly valid* passphrase, the homeserver refuses it,
+ * and every user already on the old scheme is told their history cannot be
+ * opened. There is no loud failure available at runtime. These tests are it.
+ *
+ * Which is why the expected value below is a literal. A test that recomputed the
+ * answer the way the code does would agree with every mutation of the code.
+ *
+ * The second test recomputes it anyway, from the primitives and through a
+ * *different* copy of HKDF than the one the code uses: the frontend resolves
+ * `@noble/hashes` at version 2, and `hkdfSha256` inside `@oxyhq/core` resolves
+ * its own version 1. Two independent implementations agreeing on RFC 5869 is
+ * worth more than one agreeing with itself.
+ */
+
+/** The BIP-39 test vector, so the input is one anybody can reproduce. */
+const PHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/**
+ * The passphrase this scheme derives from {@link PHRASE}. Pinned.
+ *
+ * If a change to `passphrase.ts` makes this fail, that is the test doing its
+ * job: every backup created under the old value can only be opened by the old
+ * value, so changing the scheme means a new `-v2` label and a migration for the
+ * accounts already on `-v1`, not a new expectation here.
+ */
+const EXPECTED = '8yo397uhecwizLTrXZZ9AKZ5YWgJYYD-prr70hXxlQc';
+
+const utf8 = new TextEncoder();
+
+describe('deriveMatrixRecoveryPassphrase', () => {
+  it('derives the pinned passphrase for the BIP-39 test vector', async () => {
+    await expect(deriveMatrixRecoveryPassphrase(PHRASE)).resolves.toBe(EXPECTED);
+  });
+
+  it('is HKDF-SHA256 over the whole 64-byte seed under Allo’s own labels', async () => {
+    const seed = await mnemonicToSeed(PHRASE);
+    // The whole seed, not the 32 bytes Oxy slices off for its signing key.
+    expect(seed.length).toBe(64);
+
+    const expected = hkdf(
+      sha256,
+      seed,
+      utf8.encode('allo-matrix-v1'),
+      utf8.encode('allo-matrix-4s-passphrase'),
+      32,
+    );
+
+    const passphrase = await deriveMatrixRecoveryPassphrase(PHRASE);
+    expect(base64urlnopad.decode(passphrase)).toEqual(expected);
+  });
+
+  it('is independent of the labels Oxy derives its own backup key with', async () => {
+    // Domain separation is what bounds the blast radius: leaking the Matrix
+    // passphrase must reveal nothing about Oxy's backup key. Same seed, same
+    // KDF, different labels — so the outputs must not agree.
+    const seed = await mnemonicToSeed(PHRASE);
+    const oxyBackupKey = hkdf(
+      sha256,
+      seed,
+      utf8.encode('oxy-identity-backup-v1'),
+      utf8.encode('oxy-backup-encryption-key'),
+      32,
+    );
+
+    const passphrase = await deriveMatrixRecoveryPassphrase(PHRASE);
+    expect(base64urlnopad.decode(passphrase)).not.toEqual(oxyBackupKey);
+  });
+
+  it('does not fall back to the first 32 seed bytes that are Oxy’s signing key', async () => {
+    // If the derivation ever collapsed to that, a device compromise that leaked
+    // only the signing key would hand over every message ever sent as well.
+    const seed = await mnemonicToSeed(PHRASE);
+    const passphrase = await deriveMatrixRecoveryPassphrase(PHRASE);
+    expect(base64urlnopad.decode(passphrase)).not.toEqual(seed.subarray(0, 32));
+  });
+
+  it('produces 43 characters of ASCII base64url with no padding', async () => {
+    const passphrase = await deriveMatrixRecoveryPassphrase(PHRASE);
+    // 32 bytes, unpadded. The alphabet matters as much as the length: both SDKs
+    // feed this string to PBKDF2 as UTF-8, and staying inside ASCII is what
+    // makes Rust's `as_bytes()` and JavaScript's `TextEncoder` produce the same
+    // input without depending on Unicode normalisation.
+    expect(passphrase).toHaveLength(43);
+    expect(passphrase).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('normalises case and surrounding whitespace, as Oxy does', async () => {
+    // A phrase pasted with a trailing newline has to reach the same key, or the
+    // same user gets two backups depending on how they typed it.
+    await expect(deriveMatrixRecoveryPassphrase(`  ${PHRASE.toUpperCase()}\n`)).resolves.toBe(
+      EXPECTED,
+    );
+  });
+
+  it('derives a different passphrase for a different phrase', async () => {
+    const other =
+      'legal winner thank year wave sausage worth useful legal winner thank yellow';
+    await expect(deriveMatrixRecoveryPassphrase(other)).resolves.not.toBe(EXPECTED);
+  });
+
+  it('refuses a phrase whose checksum does not hold', async () => {
+    // Twelve real BIP-39 words with a bad checksum: the shape a mistyped last
+    // word takes. Deriving from it would produce a valid-looking passphrase that
+    // opens nothing, and the user would be told their history was lost.
+    const mistyped =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon';
+    await expect(deriveMatrixRecoveryPassphrase(mistyped)).rejects.toBeInstanceOf(
+      MatrixRecoveryPhraseInvalidError,
+    );
+  });
+
+  it('refuses a phrase containing a word outside the wordlist', async () => {
+    const notWords = 'this is not a bip39 phrase at all it is just english';
+    await expect(deriveMatrixRecoveryPassphrase(notWords)).rejects.toBeInstanceOf(
+      MatrixRecoveryPhraseInvalidError,
+    );
+  });
+
+  it('refuses an empty phrase rather than deriving from nothing', async () => {
+    await expect(deriveMatrixRecoveryPassphrase('')).rejects.toBeInstanceOf(
+      MatrixRecoveryPhraseInvalidError,
+    );
+  });
+
+  it('says nothing about the phrase in the error it raises', async () => {
+    // The phrase is the whole Oxy identity, and an error message is the easiest
+    // way for one to reach a log or a crash report.
+    const secret = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo';
+    expect.assertions(1);
+    try {
+      await deriveMatrixRecoveryPassphrase(secret);
+    } catch (error) {
+      expect(error instanceof Error ? error.message : String(error)).not.toContain('zoo');
+    }
+  });
+
+  it('keeps its labels versioned and distinct from Oxy’s', () => {
+    // Exported so that a future scheme change is visibly a new label rather than
+    // an edit to an old one.
+    expect(MATRIX_RECOVERY_KDF_SALT).toBe('allo-matrix-v1');
+    expect(MATRIX_RECOVERY_KDF_INFO).toBe('allo-matrix-4s-passphrase');
+  });
+});

--- a/packages/frontend/__tests__/matrix/web/recovery.test.ts
+++ b/packages/frontend/__tests__/matrix/web/recovery.test.ts
@@ -1,0 +1,90 @@
+import { planKeyBackup, toRecoveryState } from '@/lib/matrix/web/recovery';
+
+/**
+ * The two judgements the web half has to assemble, which the native binding
+ * makes for itself.
+ *
+ * Both of them decide whether something irreversible happens, so both are worth
+ * more than the four lines each takes to write.
+ */
+
+describe('toRecoveryState', () => {
+  it('reports no 4S on the account as disabled', () => {
+    expect(
+      toRecoveryState({ defaultKeyId: null, crossSigningReady: false, backupActive: false }),
+    ).toBe('disabled');
+  });
+
+  it('reports 4S that exists as never disabled, whatever this device has', () => {
+    // The dangerous direction. `disabled` sends the caller to `enableRecovery`,
+    // which creates a second store and makes it the account's default — the old
+    // one, holding the keys to the history, stops being reachable.
+    for (const crossSigningReady of [true, false]) {
+      for (const backupActive of [true, false]) {
+        expect(
+          toRecoveryState({ defaultKeyId: 'KEYID', crossSigningReady, backupActive }),
+        ).not.toBe('disabled');
+      }
+    }
+  });
+
+  it('reports a device with cross-signing and a running backup as enabled', () => {
+    expect(
+      toRecoveryState({ defaultKeyId: 'KEYID', crossSigningReady: true, backupActive: true }),
+    ).toBe('enabled');
+  });
+
+  it('reports a device with cross-signing but no running backup as incomplete', () => {
+    // It is verified, and it still cannot read a word of anything sent before it
+    // existed. That is not "done".
+    expect(
+      toRecoveryState({ defaultKeyId: 'KEYID', crossSigningReady: true, backupActive: false }),
+    ).toBe('incomplete');
+  });
+
+  it('reports a device with a running backup but no cross-signing as incomplete', () => {
+    // Unverified, so everyone it talks to sees an unverified device — and it
+    // does not hold the self-signing key that recovery would give it.
+    expect(
+      toRecoveryState({ defaultKeyId: 'KEYID', crossSigningReady: false, backupActive: true }),
+    ).toBe('incomplete');
+  });
+
+  it('never answers unknown', () => {
+    // Web has no equivalent of the binding's unsettled state: every input is a
+    // definite answer or an exception. An `unknown` here would stall recovery
+    // forever, because nothing on this platform would ever resolve it.
+    const answers = [null, 'KEYID'].flatMap((defaultKeyId) =>
+      [true, false].flatMap((crossSigningReady) =>
+        [true, false].map((backupActive) =>
+          toRecoveryState({ defaultKeyId, crossSigningReady, backupActive }),
+        ),
+      ),
+    );
+    expect(answers).not.toContain('unknown');
+  });
+});
+
+describe('planKeyBackup', () => {
+  it('creates a backup when the server holds none', () => {
+    expect(planKeyBackup({ serverHasBackup: false, backupActive: false })).toBe('create');
+  });
+
+  it('adopts the backup this device is already running', () => {
+    // Creating here would mint a new version and abandon the old one.
+    expect(planKeyBackup({ serverHasBackup: true, backupActive: true })).toBe('adopt-active');
+  });
+
+  it('refuses when the server holds a backup this device is not using', () => {
+    // The case that loses history. A new version would leave every room key that
+    // only the old version holds decryptable by a key nobody is left holding.
+    // The native SDK raises `BackupExistsOnServer` for exactly this.
+    expect(planKeyBackup({ serverHasBackup: true, backupActive: false })).toBe('refuse');
+  });
+
+  it('never creates over a backup that is already on the server', () => {
+    for (const backupActive of [true, false]) {
+      expect(planKeyBackup({ serverHasBackup: true, backupActive })).not.toBe('create');
+    }
+  });
+});

--- a/packages/frontend/__tests__/matrix/web/secretStorage.test.ts
+++ b/packages/frontend/__tests__/matrix/web/secretStorage.test.ts
@@ -1,0 +1,249 @@
+import { MatrixSecretStorageKeyUnusableError } from '@/lib/matrix/errors';
+import {
+  MAX_PBKDF2_ITERATIONS,
+  createSecretStorageKeyCallback,
+  type StoredSecretStorageKey,
+} from '@/lib/matrix/web/secretStorage';
+
+/**
+ * The callback the web crypto stack asks for the secret storage key with.
+ *
+ * Everything it is handed comes from the homeserver, which makes this a boundary
+ * and not an internal call. The homeserver cannot learn the passphrase — it
+ * never sees it — but it decides the salt and the iteration count, and an
+ * unchecked iteration count is a loop bound taken from a stranger.
+ */
+
+const AES = 'm.secret_storage.v1.aes-hmac-sha2';
+const PASSPHRASE = 'derived-passphrase';
+
+/** Stands in for PBKDF2, so a test costs microseconds instead of half a second. */
+function recordingDerivation() {
+  const calls: { passphrase: string; salt: string; iterations: number; bits?: number }[] = [];
+  return {
+    calls,
+    derive: async (
+      passphrase: string,
+      salt: string,
+      iterations: number,
+      bits?: number,
+    ): Promise<Uint8Array<ArrayBuffer>> => {
+      calls.push({ passphrase, salt, iterations, bits });
+      return new Uint8Array(32);
+    },
+  };
+}
+
+function passphraseKey(overrides: Partial<StoredSecretStorageKey> = {}): StoredSecretStorageKey {
+  return {
+    algorithm: AES,
+    passphrase: { algorithm: 'm.pbkdf2', salt: 'a-random-salt', iterations: 500_000 },
+    ...overrides,
+  };
+}
+
+describe('createSecretStorageKeyCallback', () => {
+  it('stretches the passphrase with the salt and iterations the server published', async () => {
+    // Not with constants of its own: the salt is random per account and lives on
+    // the server, so a client that assumed one would derive a key that opens
+    // nothing.
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    const result = await callback({ keys: { KEYID: passphraseKey() } }, 'm.cross_signing.master');
+
+    expect(result).toEqual(['KEYID', new Uint8Array(32)]);
+    expect(derivation.calls).toEqual([
+      { passphrase: PASSPHRASE, salt: 'a-random-salt', iterations: 500_000, bits: undefined },
+    ]);
+  });
+
+  it('passes the published key size through when there is one', async () => {
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    await callback(
+      {
+        keys: {
+          KEYID: passphraseKey({
+            passphrase: {
+              algorithm: 'm.pbkdf2',
+              salt: 'salt',
+              iterations: 500_000,
+              bits: 256,
+            },
+          }),
+        },
+      },
+      'm.megolm_backup.v1',
+    );
+
+    expect(derivation.calls[0]?.bits).toBe(256);
+  });
+
+  it('reads the passphrase at call time, not at construction', async () => {
+    // The SDK registers this callback while the client is built, long before any
+    // recovery has run. A callback that captured the passphrase would answer
+    // `null` forever.
+    const derivation = recordingDerivation();
+    let passphrase: string | undefined;
+    const callback = createSecretStorageKeyCallback(() => passphrase, derivation.derive);
+
+    expect(await callback({ keys: { KEYID: passphraseKey() } }, 'secret')).toBeNull();
+
+    passphrase = PASSPHRASE;
+    expect(await callback({ keys: { KEYID: passphraseKey() } }, 'secret')).not.toBeNull();
+  });
+
+  it('skips a key that was created from a raw key rather than a passphrase', async () => {
+    // Not Allo's key. Refusing the whole account over it would be wrong; so
+    // would deriving a passphrase key for a slot that has no passphrase.
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    const result = await callback(
+      { keys: { RAWKEY: { algorithm: AES } } },
+      'm.cross_signing.master',
+    );
+
+    expect(result).toBeNull();
+    expect(derivation.calls).toHaveLength(0);
+  });
+
+  it('skips a key stored under an algorithm this client does not implement', async () => {
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    const result = await callback(
+      {
+        keys: {
+          FUTURE: { algorithm: 'm.secret_storage.v2.something', passphrase: passphraseKey().passphrase },
+          OURS: passphraseKey(),
+        },
+      },
+      'm.cross_signing.master',
+    );
+
+    expect(result?.[0]).toBe('OURS');
+  });
+
+  it('refuses a derivation function Matrix does not define', async () => {
+    // The spec defines exactly one. Anything else is a homeserver saying
+    // something wrong, and quietly running PBKDF2 anyway would derive a key that
+    // cannot work while pretending the description was understood.
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    await expect(
+      callback(
+        {
+          keys: {
+            KEYID: passphraseKey({
+              passphrase: { algorithm: 'm.scrypt', salt: 'salt', iterations: 500_000 },
+            }),
+          },
+        },
+        'm.cross_signing.master',
+      ),
+    ).rejects.toBeInstanceOf(MatrixSecretStorageKeyUnusableError);
+    expect(derivation.calls).toHaveLength(0);
+  });
+
+  it('refuses an iteration count above what it will run', async () => {
+    // A number from the network used as a loop bound. Without this the app
+    // computes until the user gives up, with nothing on screen and no error.
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    await expect(
+      callback(
+        {
+          keys: {
+            KEYID: passphraseKey({
+              passphrase: {
+                algorithm: 'm.pbkdf2',
+                salt: 'salt',
+                iterations: MAX_PBKDF2_ITERATIONS + 1,
+              },
+            }),
+          },
+        },
+        'm.cross_signing.master',
+      ),
+    ).rejects.toBeInstanceOf(MatrixSecretStorageKeyUnusableError);
+    expect(derivation.calls).toHaveLength(0);
+  });
+
+  it('still runs the count both SDKs actually publish', async () => {
+    // The bound has to leave room for the real world: 500 000 is what the Rust
+    // SDK and matrix-js-sdk both create keys with.
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    await callback({ keys: { KEYID: passphraseKey() } }, 'm.cross_signing.master');
+
+    expect(derivation.calls[0]?.iterations).toBe(500_000);
+    expect(MAX_PBKDF2_ITERATIONS).toBeGreaterThanOrEqual(500_000);
+  });
+
+  it('refuses an iteration count that is not a positive whole number', async () => {
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    for (const iterations of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      await expect(
+        callback(
+          {
+            keys: {
+              KEYID: passphraseKey({
+                passphrase: { algorithm: 'm.pbkdf2', salt: 'salt', iterations },
+              }),
+            },
+          },
+          'm.cross_signing.master',
+        ),
+      ).rejects.toBeInstanceOf(MatrixSecretStorageKeyUnusableError);
+    }
+    expect(derivation.calls).toHaveLength(0);
+  });
+
+  it('answers null when there is no passphrase to stretch', async () => {
+    // Before any recovery has run. The SDK turns this into a failure of whatever
+    // wanted the secret, which is the truth.
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => undefined, derivation.derive);
+
+    expect(await callback({ keys: { KEYID: passphraseKey() } }, 'secret')).toBeNull();
+    expect(derivation.calls).toHaveLength(0);
+  });
+
+  it('answers null when the account publishes no keys at all', async () => {
+    const derivation = recordingDerivation();
+    const callback = createSecretStorageKeyCallback(() => PASSPHRASE, derivation.derive);
+
+    expect(await callback({ keys: {} }, 'secret')).toBeNull();
+  });
+
+  it('never puts the passphrase in the error it raises', async () => {
+    const callback = createSecretStorageKeyCallback(
+      () => PASSPHRASE,
+      recordingDerivation().derive,
+    );
+
+    expect.assertions(1);
+    try {
+      await callback(
+        {
+          keys: {
+            KEYID: passphraseKey({
+              passphrase: { algorithm: 'm.scrypt', salt: 'salt', iterations: 1 },
+            }),
+          },
+        },
+        'm.cross_signing.master',
+      );
+    } catch (error) {
+      expect(error instanceof Error ? error.message : String(error)).not.toContain(PASSPHRASE);
+    }
+  });
+});

--- a/packages/frontend/app/(chat)/settings/index.tsx
+++ b/packages/frontend/app/(chat)/settings/index.tsx
@@ -4,6 +4,7 @@ import { ThemedView } from "@/components/ThemedView";
 import { Header } from "@/components/layout/Header";
 import { HeaderIconButton } from "@/components/layout/HeaderIconButton";
 import { Toggle } from "@/components/Toggle";
+import { RecoveryDisclosure } from "@/components/matrix/RecoveryDisclosure";
 import { BackArrowIcon } from "@/assets/icons/back-arrow-icon";
 import { useOxy } from "@oxyhq/services";
 import { useTranslation } from "react-i18next";
@@ -618,6 +619,7 @@ export default function SettingsScreen() {
                         title="Device ID"
                         description={deviceId}
                     />
+                    <RecoveryDisclosure />
                 </SettingsListGroup>
 
                 {/* App Preferences */}

--- a/packages/frontend/components/matrix/RecoveryDisclosure.tsx
+++ b/packages/frontend/components/matrix/RecoveryDisclosure.tsx
@@ -1,0 +1,51 @@
+import { Ionicons } from '@expo/vector-icons';
+import { SettingsListItem } from '@oxyhq/bloom/settings-list';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useTheme } from '@/hooks/useTheme';
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+
+import {
+  RECOVERY_DISCLOSURE_BODY,
+  RECOVERY_DISCLOSURE_TITLE,
+} from './recoveryDisclosureCopy';
+
+/**
+ * The sentence a user has to be able to read before they decide how carefully to
+ * keep their Oxy recovery phrase.
+ *
+ * Allo unlocks its Matrix key backup with a key derived from that phrase
+ * (`lib/matrix/recovery/passphrase.ts`), which is what makes a new device open
+ * the old conversations by itself. It also changes what the phrase is worth to
+ * somebody else. Before, whoever held it could take the account and read
+ * everything sent *from then on*; now they can read everything sent *before*
+ * as well, which in the ordinary Matrix design would have been behind a second
+ * credential the user keeps separately.
+ *
+ * That is a real trade and the design (`docs/matrix/client-strategy.md` §3.6)
+ * asks for it to be made in the user's words rather than in a comment: someone
+ * who treats the phrase as the key to everything is acting correctly, and
+ * someone who believes Allo keeps a secret of its own is not. So this is a
+ * screen and not a code comment, and the wording says what happens rather than
+ * that "your data is protected".
+ *
+ * Only rendered when the build talks to Matrix. On the legacy backend the claim
+ * would simply be false — nothing derives anything from the Oxy phrase there.
+ */
+export function RecoveryDisclosure() {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  if (CHAT_BACKEND !== 'matrix') {
+    return null;
+  }
+
+  return (
+    <SettingsListItem
+      icon={<Ionicons name="key-outline" size={20} color={theme.colors.textSecondary} />}
+      title={t(RECOVERY_DISCLOSURE_TITLE)}
+      description={t(RECOVERY_DISCLOSURE_BODY)}
+    />
+  );
+}

--- a/packages/frontend/components/matrix/recoveryDisclosureCopy.ts
+++ b/packages/frontend/components/matrix/recoveryDisclosureCopy.ts
@@ -1,0 +1,23 @@
+/**
+ * The words of the recovery disclosure, in one place.
+ *
+ * Separate from the component that draws them for two reasons. The copy is the
+ * requirement — `docs/matrix/client-strategy.md` §3.6 asks for this to be said
+ * to the user in plain words, not recorded in a comment — so it is worth being
+ * able to check that every locale still carries it and that it still says the
+ * uncomfortable part. And a `.ts` module can be checked without a renderer,
+ * which a `.tsx` one cannot.
+ *
+ * These strings are also the i18next keys, which is how the rest of the app
+ * works: the English sentence is the key, and `locales/*.json` map it.
+ */
+
+export const RECOVERY_DISCLOSURE_TITLE =
+  'Your Oxy recovery phrase opens your Allo history';
+
+export const RECOVERY_DISCLOSURE_BODY =
+  'Allo unlocks your encrypted message backup with a key derived from your Oxy ' +
+  'recovery phrase. That is why a new device can read your old conversations as ' +
+  'soon as you sign in — and it means anyone who has that phrase can read them ' +
+  'too, including messages sent before they got it. Keep it as carefully as you ' +
+  'would keep the conversations themselves.';

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -11,6 +11,8 @@ import {
 } from '@unomed/react-native-matrix-sdk';
 import type {
   ClientLike,
+  EnableRecoveryProgress,
+  EncryptionLike,
   OidcConfiguration,
   RoomLike,
   RoomListEntriesListener,
@@ -35,6 +37,7 @@ import type {
   AlloOidcLoginRequest,
   AlloOidcPrompt,
   AlloPaginationOutcome,
+  AlloRecoveryState,
   AlloRoomListHandle,
   AlloRoomSummary,
   AlloSession,
@@ -47,6 +50,7 @@ import { logger } from '@/utils/logger';
 
 import { applyListUpdate } from './native/listDiff';
 import { NativeOidcLoginRequest } from './native/oidcLogin';
+import { describeEnableRecoveryProgress, toRecoveryState } from './native/recovery';
 import { RoomSummaryCache } from './native/roomSummaries';
 import { TimelineProjection } from './native/timelineProjection';
 import { toAlloSession } from './native/session';
@@ -156,6 +160,7 @@ class NativeAlloChatClient implements AlloChatClient {
   #sync: SyncServiceLike | undefined;
   #syncStateHandle: TaskHandleLike | undefined;
   #syncState: AlloSyncState = 'idle';
+  #encryptionHandle: EncryptionLike | undefined;
 
   constructor(client: ClientLike, oidc: OidcConfiguration) {
     this.#client = client;
@@ -236,6 +241,42 @@ class NativeAlloChatClient implements AlloChatClient {
     return toEncryptionState(await room.latestEncryptionState());
   }
 
+  async recoveryState(): Promise<AlloRecoveryState> {
+    const encryption = this.#encryption();
+    // The binding starts the crypto stack in background tasks once a session is
+    // installed, and `recoveryState()` answers `Unknown` until they have run.
+    // Reading it without waiting is how a device that only needed to recover
+    // decides it has nothing to do.
+    await encryption.waitForE2eeInitializationTasks();
+    return toRecoveryState(encryption.recoveryState());
+  }
+
+  async enableRecovery(passphrase: string): Promise<void> {
+    // The return value is the 4S key in base58 — a second credential that opens
+    // exactly what the passphrase opens. Allo derives its passphrase from the
+    // Oxy identity and can produce it again at any time, so there is nothing to
+    // show the user and nothing to keep. It is dropped here rather than stored
+    // in a variable that someone later logs.
+    await this.#encryption().enableRecovery(
+      // Not waiting for every room key to reach the backup. On an account with
+      // history that is minutes of uploading, and this call sits between a
+      // finished sign-in and a usable app. The backup engine carries on in the
+      // background either way; what the user is waiting for is 4S existing, and
+      // that is done long before the upload is.
+      false,
+      passphrase,
+      this.#recoveryProgress,
+    );
+  }
+
+  async recoverWithPassphrase(passphrase: string): Promise<void> {
+    // One call does what web needs three for: it opens 4S, takes the
+    // cross-signing keys and the backup decryption key out of it, and imports
+    // the room keys. The parameter is named `recoveryKey` and documented to
+    // accept either form; a passphrase is what Allo has.
+    await this.#encryption().recover(passphrase);
+  }
+
   async openTimeline(
     roomId: string,
     onChange: (items: readonly AlloTimelineItem[]) => void,
@@ -260,6 +301,7 @@ class NativeAlloChatClient implements AlloChatClient {
     this.#syncStateListeners.clear();
     this.#syncStateHandle?.cancel();
     this.#syncStateHandle = undefined;
+    this.#encryptionHandle = undefined;
 
     const sync = this.#sync;
     // Dropped, not merely stopped: the state listener is gone with it, and
@@ -269,6 +311,32 @@ class NativeAlloChatClient implements AlloChatClient {
     this.#syncState = 'idle';
     await sync?.stop();
   }
+
+  /**
+   * The encryption handle, built once.
+   *
+   * `encryption()` mints a new object across the FFI boundary on every call, and
+   * the recovery path asks for it several times in a row.
+   */
+  #encryption(): EncryptionLike {
+    this.#encryptionHandle ??= this.#client.encryption();
+    return this.#encryptionHandle;
+  }
+
+  /**
+   * Progress while 4S is being created.
+   *
+   * The translation is a separate, tested function because one of the variants
+   * carries the recovery key: see `native/recovery.ts`.
+   */
+  readonly #recoveryProgress = {
+    onUpdate: (progress: EnableRecoveryProgress): void => {
+      const description = describeEnableRecoveryProgress(progress);
+      if (description !== undefined) {
+        logger.info(`${LOG_TAG} enabling recovery: ${description}`);
+      }
+    },
+  };
 
   #requireSync(operation: string): SyncServiceLike {
     if (this.#sync === undefined) {

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -15,6 +15,12 @@ import {
   createClient,
   isValidAuthMetadata,
 } from 'matrix-js-sdk';
+// Not exported from the root of `matrix-js-sdk@42`, only from this path inside
+// the package — which a future version may move. The spike found the same
+// (`spikes/matrix-web/RESULTS.md`, constraint 3). Depending on an internal path
+// beats reimplementing PBKDF2, which would have to agree byte for byte with what
+// Rust computes on the other platform.
+import { deriveRecoveryKeyFromPassphrase } from 'matrix-js-sdk/lib/crypto-api/index.js';
 import type {
   AccessTokens,
   MatrixClient,
@@ -26,6 +32,8 @@ import type {
 } from 'matrix-js-sdk';
 
 import {
+  MatrixBackupExistsOnServerError,
+  MatrixCryptoUnavailableError,
   MatrixNotLoggedInError,
   MatrixOidcCallbackError,
   MatrixRoomNotFoundError,
@@ -42,6 +50,7 @@ import type {
   AlloOidcLoginOptions,
   AlloOidcLoginRequest,
   AlloPaginationOutcome,
+  AlloRecoveryState,
   AlloRoomListHandle,
   AlloRoomSummary,
   AlloSession,
@@ -59,7 +68,9 @@ import {
   generateAuthorizationState,
   type OidcGrant,
 } from './web/oidcLogin';
+import { planKeyBackup, toRecoveryState } from './web/recovery';
 import { directRoomIds, orderRoomList, type RoomListEntry } from './web/roomList';
+import { createSecretStorageKeyCallback } from './web/secretStorage';
 import { decodeAuthData, encodeAuthData } from './web/session';
 import { toEncryptionState, toRoomSummary, toSyncState, toTimelineItem } from './web/translate';
 
@@ -115,6 +126,12 @@ const INITIAL_SYNC_LIMIT = 20;
 /** `m.room.encryption` is room state with an empty state key. */
 const ENCRYPTION_STATE_KEY = '';
 
+/**
+ * The SDK's crypto surface. Taken off the client rather than imported, because
+ * `matrix-js-sdk@42` does not export `CryptoApi` from its root.
+ */
+type WebCryptoApi = NonNullable<ReturnType<MatrixClient['getCrypto']>>;
+
 export const createAlloChatClient: AlloChatClientFactory = async (config) =>
   new WebAlloChatClient(config);
 
@@ -135,6 +152,25 @@ class WebAlloChatClient implements AlloChatClient {
   #syncState: AlloSyncState = 'idle';
   #syncing = false;
   #watchingSyncState = false;
+  /**
+   * The 4S passphrase, for as long as this client exists.
+   *
+   * Held rather than passed, because the SDK does not take it as an argument: it
+   * calls back for the secret storage key whenever it needs one, including long
+   * after the recovery call that set this returned — a secret shared by another
+   * device mid-session arrives that way. A callback that could only answer
+   * during `enableRecovery` would leave those requests unanswered.
+   *
+   * It is a credential, and this is the honest account of what that means here.
+   * It is never logged, never persisted and never sent anywhere; it is dropped
+   * on {@link close}. It is *not* wiped: JavaScript strings cannot be
+   * overwritten, so unlike the native binding — which zeroes its copy after
+   * PBKDF2 — this holds a string until the garbage collector gets to it. What
+   * bounds the exposure is not this field but where the value comes from: it is
+   * derived from the Oxy phrase, which is already on the device, so an attacker
+   * who can read this process's memory had the input to it either way.
+   */
+  #recoveryPassphrase: string | undefined;
 
   constructor(config: AlloChatClientConfig) {
     this.#config = config;
@@ -265,6 +301,88 @@ class WebAlloChatClient implements AlloChatClient {
     }
   }
 
+  async recoveryState(): Promise<AlloRecoveryState> {
+    const client = this.#requireClient('Reading the recovery state');
+    const crypto = this.#requireCrypto('Reading the recovery state');
+    return toRecoveryState({
+      defaultKeyId: await client.secretStorage.getDefaultKeyId(),
+      crossSigningReady: await crypto.isCrossSigningReady(),
+      backupActive: (await crypto.getActiveSessionBackupVersion()) !== null,
+    });
+  }
+
+  /**
+   * Creates 4S and the key backup.
+   *
+   * Note what is *not* passed: neither `setupNewSecretStorage` nor
+   * `setupNewCrossSigning`. Both mean "reset even if it already exists", and
+   * both are what the spike used because it built a fresh account on every run.
+   * In the app they would be the bug this whole path exists to avoid — the
+   * caller has already established that there is nothing to reset, and passing
+   * them would turn a mistaken state reading into a destroyed store.
+   *
+   * Nor is `authUploadDeviceSigningKeys`. Uploading cross-signing keys can
+   * require interactive auth, and the only interactive auth Allo could satisfy
+   * is a Matrix password its users do not have — sessions come from Matrix
+   * Authentication Service with Oxy upstream. On a first upload MAS asks for
+   * none, which is the case this call is in; if a deployment's homeserver asks
+   * anyway, the request fails with the homeserver's own error, which is a better
+   * thing to read than a callback that pretends to authenticate and cannot.
+   */
+  async enableRecovery(passphrase: string): Promise<void> {
+    const crypto = this.#requireCrypto('Enabling recovery');
+    this.#recoveryPassphrase = passphrase;
+
+    const plan = planKeyBackup({
+      serverHasBackup: (await crypto.getKeyBackupInfo()) !== null,
+      backupActive: (await crypto.getActiveSessionBackupVersion()) !== null,
+    });
+    if (plan === 'refuse') {
+      this.#recoveryPassphrase = undefined;
+      throw new MatrixBackupExistsOnServerError();
+    }
+
+    await crypto.bootstrapCrossSigning({});
+    await crypto.bootstrapSecretStorage({
+      setupNewKeyBackup: plan === 'create',
+      createSecretStorageKey: () => crypto.createRecoveryKeyFromPassphrase(passphrase),
+    });
+    // `bootstrapSecretStorage` creates the backup version on the server, but the
+    // local engine only starts using it once it has been checked and trusted.
+    // Without this the device has a backup it is not uploading to, and
+    // `recoveryState()` — correctly — keeps reporting `incomplete`.
+    await crypto.checkKeyBackupAndEnable();
+  }
+
+  /**
+   * Takes everything this device is missing out of the account's existing 4S.
+   *
+   * Three calls where the native binding has one, in an order that is not
+   * interchangeable — the spike found that skipping the middle one fails with
+   * `No decryption key found in crypto store`
+   * (`spikes/matrix-web/RESULTS.md`, constraint 2):
+   *
+   * 1. `bootstrapCrossSigning({})` pulls the cross-signing private keys out of
+   *    4S and signs this device with the self-signing key it just got, which is
+   *    why recovery leaves the device verified with nobody scanning anything.
+   * 2. `loadSessionBackupPrivateKeyFromSecretStorage()` pulls the megolm backup
+   *    decryption key out of 4S and into the crypto store.
+   * 3. `restoreKeyBackup()` downloads the room keys and imports them, which is
+   *    the step that turns unreadable rows into messages.
+   */
+  async recoverWithPassphrase(passphrase: string): Promise<void> {
+    const crypto = this.#requireCrypto('Recovering from the key backup');
+    this.#recoveryPassphrase = passphrase;
+
+    await crypto.bootstrapCrossSigning({});
+    await crypto.loadSessionBackupPrivateKeyFromSecretStorage();
+    await crypto.checkKeyBackupAndEnable();
+    const result = await crypto.restoreKeyBackup();
+    logger.info(
+      `${LOG_TAG} recovered ${result.imported} of ${result.total} room keys from the backup`,
+    );
+  }
+
   async openTimeline(
     roomId: string,
     onChange: (items: readonly AlloTimelineItem[]) => void,
@@ -295,6 +413,7 @@ class WebAlloChatClient implements AlloChatClient {
     }
     this.#syncing = false;
     this.#syncState = 'idle';
+    this.#recoveryPassphrase = undefined;
     client?.stopClient();
   }
 
@@ -416,6 +535,17 @@ class WebAlloChatClient implements AlloChatClient {
       refreshToken: session.refreshToken,
       tokenRefreshFunction: refresher.tokenRefreshFunction,
       store,
+      // How the crypto stack asks for the key to secret storage. Registered at
+      // construction because that is the only place the SDK takes it, and it
+      // reads the passphrase through a closure rather than capturing one, so a
+      // recovery that happens later still has an answer. See
+      // `web/secretStorage.ts`.
+      cryptoCallbacks: {
+        getSecretStorageKey: createSecretStorageKeyCallback(
+          () => this.#recoveryPassphrase,
+          deriveRecoveryKeyFromPassphrase,
+        ),
+      },
       // Allo's calls do not go through Matrix, so the SDK has no reason to poll
       // the homeserver for TURN servers.
       disableVoip: true,
@@ -519,6 +649,14 @@ class WebAlloChatClient implements AlloChatClient {
       throw new MatrixNotLoggedInError(operation);
     }
     return this.#client;
+  }
+
+  #requireCrypto(operation: string): WebCryptoApi {
+    const crypto = this.#requireClient(operation).getCrypto();
+    if (crypto === undefined) {
+      throw new MatrixCryptoUnavailableError(operation);
+    }
+    return crypto;
   }
 
   #requireSyncing(operation: string): MatrixClient {

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -331,17 +331,18 @@ class WebAlloChatClient implements AlloChatClient {
    */
   async enableRecovery(passphrase: string): Promise<void> {
     const crypto = this.#requireCrypto('Enabling recovery');
-    this.#recoveryPassphrase = passphrase;
 
+    // Decided before the passphrase is held, so that a refusal leaves nothing
+    // behind and nothing has been started.
     const plan = planKeyBackup({
       serverHasBackup: (await crypto.getKeyBackupInfo()) !== null,
       backupActive: (await crypto.getActiveSessionBackupVersion()) !== null,
     });
     if (plan === 'refuse') {
-      this.#recoveryPassphrase = undefined;
       throw new MatrixBackupExistsOnServerError();
     }
 
+    this.#recoveryPassphrase = passphrase;
     await crypto.bootstrapCrossSigning({});
     await crypto.bootstrapSecretStorage({
       setupNewKeyBackup: plan === 'create',

--- a/packages/frontend/lib/matrix/errors.ts
+++ b/packages/frontend/lib/matrix/errors.ts
@@ -119,3 +119,75 @@ export class MatrixStoreUnavailableError extends MatrixPortError {
     super(`The Matrix client has nowhere to keep its data: ${detail}`);
   }
 }
+
+/**
+ * A recovery phrase that is not a BIP-39 mnemonic.
+ *
+ * The message names no words and quotes nothing back: the phrase is the whole
+ * Oxy identity, and an error string is the one place a credential most easily
+ * escapes into a log.
+ */
+export class MatrixRecoveryPhraseInvalidError extends MatrixPortError {
+  constructor() {
+    super(
+      'That is not a valid Oxy recovery phrase, so no key can be derived from ' +
+        'it. Check the words rather than the message history.',
+    );
+  }
+}
+
+/**
+ * The crypto machine was asked for before it existed.
+ *
+ * On web the SDK's `getCrypto()` answers `undefined` until the WebAssembly has
+ * been loaded and initialised, which the port does while a session starts. A
+ * caller seeing this has asked before there was a session.
+ */
+export class MatrixCryptoUnavailableError extends MatrixPortError {
+  constructor(operation: string) {
+    super(
+      `${operation} needs the encryption stack, which is only brought up once ` +
+        'there is a session. Finish a login or restore a session first.',
+    );
+  }
+}
+
+/**
+ * Recovery was asked to create a key backup while the server already holds one
+ * this device cannot use.
+ *
+ * Refused rather than resolved, because both ways of resolving it lose
+ * something: creating a new backup version orphans every room key that only the
+ * old version holds, and adopting the old one needs a key this device does not
+ * have. The native SDK refuses the same case with `BackupExistsOnServer`; this
+ * is the web half saying the same thing rather than quietly resetting.
+ */
+export class MatrixBackupExistsOnServerError extends MatrixPortError {
+  constructor() {
+    super(
+      'The homeserver already holds a key backup that this device has not ' +
+        'enabled. Creating a new one would abandon the keys in it, so recovery ' +
+        'stops here: open the existing backup with the recovery passphrase ' +
+        'instead.',
+    );
+  }
+}
+
+/**
+ * The homeserver described its secret storage key in a way the client will not
+ * act on.
+ *
+ * Everything in `m.secret_storage.key.*` comes from the server, so it is
+ * external input and is treated as such. A hostile or broken homeserver cannot
+ * steal the passphrase — it never sees it — but it can publish a description
+ * that makes the client derive a useless key or spend an unbounded amount of
+ * time trying. Refusing loudly is the only outcome that is not one of those.
+ */
+export class MatrixSecretStorageKeyUnusableError extends MatrixPortError {
+  constructor(keyId: string, reason: string) {
+    super(
+      `The secret storage key ${keyId} published by the homeserver cannot be ` +
+        `used: ${reason}`,
+    );
+  }
+}

--- a/packages/frontend/lib/matrix/native/recovery.ts
+++ b/packages/frontend/lib/matrix/native/recovery.ts
@@ -1,0 +1,63 @@
+import { EnableRecoveryProgress_Tags, RecoveryState } from '@unomed/react-native-matrix-sdk';
+import type { EnableRecoveryProgress } from '@unomed/react-native-matrix-sdk';
+
+import type { AlloRecoveryState } from '@/lib/matrix/types';
+
+/**
+ * Translation of the binding's recovery vocabulary into the port's, and the one
+ * rule about what may be said out loud while recovery runs.
+ *
+ * Pure functions of SDK records, which is what makes this the part of the native
+ * recovery path that can be tested without a device.
+ */
+
+/**
+ * A lookup table rather than a switch, so the compiler notices when the binding
+ * gains a variant: a missing key is a type error, not a silent fall-through to
+ * whichever branch happened to be last.
+ */
+const RECOVERY_STATES: Record<RecoveryState, AlloRecoveryState> = {
+  [RecoveryState.Unknown]: 'unknown',
+  [RecoveryState.Enabled]: 'enabled',
+  [RecoveryState.Disabled]: 'disabled',
+  [RecoveryState.Incomplete]: 'incomplete',
+};
+
+export function toRecoveryState(state: RecoveryState): AlloRecoveryState {
+  return RECOVERY_STATES[state];
+}
+
+/**
+ * A log line for one step of `enableRecovery`, or `undefined` for a step not
+ * worth a line.
+ *
+ * **The reason this function exists at all is the `Done` variant.** It carries
+ * `recoveryKey`: the base58 form of the 4S key, a credential exactly as powerful
+ * as the passphrase it was derived from — anyone holding it opens the user's
+ * entire message history. The obvious implementation of a progress listener is
+ * `logger.info(JSON.stringify(progress))`, and that one writes it to the log.
+ * So the translation is a named, tested function instead of a line inside a
+ * callback, and `Done` is reported by name with its payload dropped.
+ *
+ * `RoomKeyUploadError` is a step failing, not the whole call: the binding keeps
+ * going and retries, so it is reported as a warning rather than raised.
+ */
+export function describeEnableRecoveryProgress(
+  progress: EnableRecoveryProgress,
+): string | undefined {
+  switch (progress.tag) {
+    case EnableRecoveryProgress_Tags.Starting:
+      return 'starting';
+    case EnableRecoveryProgress_Tags.CreatingBackup:
+      return 'creating the key backup';
+    case EnableRecoveryProgress_Tags.CreatingRecoveryKey:
+      return 'creating the recovery key';
+    case EnableRecoveryProgress_Tags.BackingUp:
+      return `backing up room keys (${progress.inner.backedUpCount}/${progress.inner.totalCount})`;
+    case EnableRecoveryProgress_Tags.RoomKeyUploadError:
+      return 'a batch of room keys failed to upload; the backup will retry';
+    case EnableRecoveryProgress_Tags.Done:
+      // Deliberately not `progress.inner.recoveryKey`.
+      return 'done';
+  }
+}

--- a/packages/frontend/lib/matrix/recovery/ensureRecovery.ts
+++ b/packages/frontend/lib/matrix/recovery/ensureRecovery.ts
@@ -1,4 +1,4 @@
-import type { AlloRecoveryState } from '@/lib/matrix/types';
+import type { AlloChatClient } from '@/lib/matrix/types';
 
 import { readOxyRecoveryPhrase, type OxyRecoveryPhraseReader } from './oxyIdentity';
 import { deriveMatrixRecoveryPassphrase } from './passphrase';
@@ -24,12 +24,17 @@ import { deriveMatrixRecoveryPassphrase } from './passphrase';
  * not protect what this protects.
  */
 
-/** The three methods of the port this decision needs. Nothing else. */
-export interface RecoveryCapableClient {
-  recoveryState(): Promise<AlloRecoveryState>;
-  enableRecovery(passphrase: string): Promise<void>;
-  recoverWithPassphrase(passphrase: string): Promise<void>;
-}
+/**
+ * The three methods of the port this decision needs. Nothing else.
+ *
+ * Taken from {@link AlloChatClient} rather than restated, so a change to any of
+ * the three signatures is a compile error here instead of a fake that still
+ * satisfies an interface the real client no longer matches.
+ */
+export type RecoveryCapableClient = Pick<
+  AlloChatClient,
+  'recoveryState' | 'enableRecovery' | 'recoverWithPassphrase'
+>;
 
 /** Why recovery was not attempted. Each of these is a different thing to say. */
 export type AlloRecoverySkipReason =

--- a/packages/frontend/lib/matrix/recovery/ensureRecovery.ts
+++ b/packages/frontend/lib/matrix/recovery/ensureRecovery.ts
@@ -1,0 +1,122 @@
+import type { AlloRecoveryState } from '@/lib/matrix/types';
+
+import { readOxyRecoveryPhrase, type OxyRecoveryPhraseReader } from './oxyIdentity';
+import { deriveMatrixRecoveryPassphrase } from './passphrase';
+
+/**
+ * The one decision the recovery scheme makes, and where it is made.
+ *
+ * Every branch below comes from `docs/matrix/client-strategy.md` §3.4: what to
+ * do depends only on {@link AlloRecoveryState}, and each of the three actionable
+ * states has exactly one right answer. Two of the wrong answers are expensive
+ * enough to be worth naming:
+ *
+ * - calling `enableRecovery` in state `enabled` or `incomplete` builds a second
+ *   4S store and makes it the default. The first one, with the keys that decrypt
+ *   the user's history, is still on the server and nothing opens it any more.
+ * - skipping recovery in state `incomplete` leaves a device that can read
+ *   nothing sent before it existed, and that stays unverified — which is the
+ *   state a new phone is in the moment it finishes signing in.
+ *
+ * The logic lives here, apart from both SDKs, so it can be tested without either
+ * one: the client is a three-method interface a fake satisfies in a dozen lines.
+ * That is deliberate. A green suite that only proved the SDKs get called would
+ * not protect what this protects.
+ */
+
+/** The three methods of the port this decision needs. Nothing else. */
+export interface RecoveryCapableClient {
+  recoveryState(): Promise<AlloRecoveryState>;
+  enableRecovery(passphrase: string): Promise<void>;
+  recoverWithPassphrase(passphrase: string): Promise<void>;
+}
+
+/** Why recovery was not attempted. Each of these is a different thing to say. */
+export type AlloRecoverySkipReason =
+  /**
+   * This device holds no copy of the Oxy phrase, so nothing can be derived
+   * without asking the user for it. Always the case on web, and the case on
+   * native for identities created before Oxy kept the phrase. Permanent until
+   * the user types the phrase in — retrying changes nothing.
+   */
+  | 'no-phrase-on-this-device'
+  /**
+   * The keychain could not be read. Temporary by nature — a locked device, a
+   * storage module still coming up — so the right response is to try again, not
+   * to tell the user anything.
+   */
+  | 'phrase-unreadable'
+  /**
+   * The crypto stack has not finished starting, so the state is `unknown` and
+   * every action would be a guess. Also temporary.
+   */
+  | 'state-not-settled';
+
+/** What {@link ensureMatrixRecovery} did. */
+export type AlloRecoveryOutcome =
+  /** There was no 4S; this device created it from the Oxy-derived passphrase. */
+  | { readonly kind: 'created' }
+  /**
+   * 4S existed and this device took what it was missing from it. Messages older
+   * than this device are readable now, and it is cross-signing verified.
+   */
+  | { readonly kind: 'recovered' }
+  /** Nothing to do: this device already had everything. */
+  | { readonly kind: 'already-enabled' }
+  /** Nothing was attempted. {@link AlloRecoverySkipReason} says why. */
+  | { readonly kind: 'skipped'; readonly reason: AlloRecoverySkipReason };
+
+/**
+ * Seams for tests. The defaults are the real thing, so app code passes nothing.
+ */
+export interface EnsureMatrixRecoveryOptions {
+  readonly readPhrase?: OxyRecoveryPhraseReader;
+  readonly derivePassphrase?: (phrase: string) => Promise<string>;
+}
+
+/**
+ * Brings this device's key backup to where it should be, deriving the passphrase
+ * from the Oxy identity and asking the user for nothing.
+ *
+ * Safe to call whenever a session becomes usable — after a fresh sign-in and
+ * after restoring a stored one — because `already-enabled` is the ordinary
+ * answer and it costs one call.
+ *
+ * Failures of the two actions are **not** caught. A recovery that fails is not
+ * the same as one that was not needed, and the caller has to be able to tell a
+ * user that their history did not come back.
+ */
+export async function ensureMatrixRecovery(
+  client: RecoveryCapableClient,
+  options: EnsureMatrixRecoveryOptions = {},
+): Promise<AlloRecoveryOutcome> {
+  const state = await client.recoveryState();
+
+  // Read before the phrase is fetched, so the ordinary launch of an already
+  // recovered device never touches the keychain: no biometric prompt the user
+  // did not ask for, and no credential in memory with nothing to do.
+  if (state === 'enabled') {
+    return { kind: 'already-enabled' };
+  }
+  if (state === 'unknown') {
+    return { kind: 'skipped', reason: 'state-not-settled' };
+  }
+
+  const lookup = await readOxyRecoveryPhrase(options.readPhrase);
+  if (lookup.kind === 'absent') {
+    return { kind: 'skipped', reason: 'no-phrase-on-this-device' };
+  }
+  if (lookup.kind === 'unavailable') {
+    return { kind: 'skipped', reason: 'phrase-unreadable' };
+  }
+
+  const derive = options.derivePassphrase ?? deriveMatrixRecoveryPassphrase;
+  const passphrase = await derive(lookup.phrase);
+
+  if (state === 'disabled') {
+    await client.enableRecovery(passphrase);
+    return { kind: 'created' };
+  }
+  await client.recoverWithPassphrase(passphrase);
+  return { kind: 'recovered' };
+}

--- a/packages/frontend/lib/matrix/recovery/oxyIdentity.ts
+++ b/packages/frontend/lib/matrix/recovery/oxyIdentity.ts
@@ -1,0 +1,81 @@
+import { KeyManager } from '@oxyhq/core';
+
+/**
+ * Getting the Oxy recovery phrase off this device.
+ *
+ * The phrase is the input to {@link deriveMatrixRecoveryPassphrase}, and it is
+ * the one part of the scheme Allo does not own: Oxy generates it, shows it to
+ * the user once, and keeps a copy in the device keychain so Settings can show it
+ * again. Allo reads that copy and never writes one.
+ *
+ * **Where this does not work, and it is not a bug in this file.**
+ * `KeyManager.getRecoveryMnemonic()` answers `null` on web without consulting
+ * any storage — Oxy keeps identities in the native keychain only — and it also
+ * answers `null` on native for any identity created before Oxy started keeping
+ * the phrase. In both cases the phrase exists (the user wrote it down when they
+ * made the account) but this process cannot see it, so nothing can be derived
+ * without asking. That is why the three outcomes below are three and not a
+ * `string | null`: "there is no phrase here" and "the keychain is locked, ask
+ * again in a moment" want opposite responses, and collapsing either into a
+ * failure would either nag a user who can do nothing or silently skip a recovery
+ * that would have worked on retry.
+ */
+
+/** What reading the phrase from the device found. */
+export type OxyRecoveryPhraseLookup =
+  /** The phrase. A credential: derive from it and drop it. */
+  | { readonly kind: 'available'; readonly phrase: string }
+  /**
+   * The read succeeded and this device holds no phrase. Web always lands here,
+   * as does a native install whose identity predates Oxy keeping the phrase.
+   * Nothing to retry: recovery needs the user to type it.
+   */
+  | { readonly kind: 'absent' }
+  /**
+   * Storage could not be read at all — a locked keychain, a module that failed
+   * to load. Distinct from `absent` precisely because it *is* worth retrying,
+   * and because treating a locked keychain as "no identity" is how an app
+   * decides a user is new when they are not.
+   */
+  | { readonly kind: 'unavailable'; readonly reason: string };
+
+/**
+ * How the phrase is read. Injected so the outcomes above can be tested without
+ * a keychain, and so nothing in a test can reach a real identity.
+ */
+export type OxyRecoveryPhraseReader = () => Promise<string | null>;
+
+/** Oxy's own reader: the device keychain, native only. */
+const deviceKeychainReader: OxyRecoveryPhraseReader = () =>
+  KeyManager.getRecoveryMnemonic();
+
+/**
+ * Reads the Oxy recovery phrase, reporting what happened rather than what was
+ * found.
+ *
+ * The phrase is returned, not logged and not cached: the caller derives the
+ * Matrix passphrase from it and lets both go. An empty or whitespace-only string
+ * is reported as `absent`, because a keychain slot that exists but holds nothing
+ * is not a phrase and pushing it into a BIP-39 validator would report it as the
+ * user's mistake.
+ */
+export async function readOxyRecoveryPhrase(
+  read: OxyRecoveryPhraseReader = deviceKeychainReader,
+): Promise<OxyRecoveryPhraseLookup> {
+  let phrase: string | null;
+  try {
+    phrase = await read();
+  } catch (error) {
+    // Never the error object itself into a message that might reach a log with
+    // the phrase inside it; only its description.
+    return {
+      kind: 'unavailable',
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (phrase === null || phrase.trim() === '') {
+    return { kind: 'absent' };
+  }
+  return { kind: 'available', phrase };
+}

--- a/packages/frontend/lib/matrix/recovery/passphrase.ts
+++ b/packages/frontend/lib/matrix/recovery/passphrase.ts
@@ -1,0 +1,96 @@
+import { hkdfSha256 } from '@oxyhq/core';
+import { base64urlnopad } from '@scure/base';
+import { mnemonicToSeed, validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+import { MatrixRecoveryPhraseInvalidError } from '@/lib/matrix/errors';
+
+/**
+ * The passphrase that opens Allo's Matrix key backup, derived from the user's
+ * Oxy identity.
+ *
+ * Matrix's server-side secret storage (4S) is unlocked either by a 32-byte key
+ * the user has to keep, or by a passphrase the key is derived from. Allo takes
+ * the second door and derives the passphrase from the BIP-39 phrase that already
+ * *is* the Oxy identity, so that a user who signs in with Oxy gets their message
+ * history back without ever being shown a second secret to write down. See
+ * `docs/matrix/client-strategy.md` §3.
+ *
+ * **No cryptography is invented here.** This is HKDF-SHA256 — the same function
+ * Oxy already uses for its own encrypted backup — with a label of its own, and
+ * everything after it is Matrix's: the SDKs run the result through PBKDF2 with a
+ * salt the homeserver publishes, at parameters that are identical on both
+ * platforms (§3.3).
+ *
+ * The security of the whole scheme is therefore exactly the security of the Oxy
+ * seed: 128 bits behind a 12-word phrase, 256 behind a 24-word one. The 500 000
+ * PBKDF2 iterations Matrix applies on top exist to protect passphrases people
+ * chose themselves and buy nothing here — which is fine, because there is no
+ * dictionary to attack when the input is 256 bits of HKDF output (§3.5).
+ */
+
+/**
+ * HKDF `salt`. Versioned, so that changing the scheme is a new label rather than
+ * a silent change of meaning: `-v2` would derive a different passphrase, and a
+ * user's old backup would stay openable with the old one.
+ */
+export const MATRIX_RECOVERY_KDF_SALT = 'allo-matrix-v1';
+
+/**
+ * HKDF `info`. Its only job is to be different from every other label derived
+ * from the same seed.
+ *
+ * Oxy derives its own backup material from this seed under
+ * `oxy-backup-encryption-key` and `oxy-backup-lookup-id`. A separate label is
+ * what makes those independent: leaking Allo's Matrix passphrase reveals nothing
+ * about Oxy's backup key, and the reverse.
+ */
+export const MATRIX_RECOVERY_KDF_INFO = 'allo-matrix-4s-passphrase';
+
+/** 256 bits, matching the 4S key the passphrase will be stretched into. */
+export const MATRIX_RECOVERY_PASSPHRASE_BYTES = 32;
+
+const utf8 = new TextEncoder();
+
+/**
+ * Derives the 4S passphrase from an Oxy recovery phrase.
+ *
+ * The result is 43 characters of base64url with no padding, which is ASCII by
+ * construction. That is not cosmetic: the native binding hands the passphrase to
+ * Rust's `passphrase.as_bytes()` and the web SDK to `TextEncoder.encode`, so
+ * keeping it ASCII is what guarantees the two platforms feed PBKDF2 the same
+ * bytes without depending on how either normalises Unicode (§3.4).
+ *
+ * The return value is a credential. It must never be logged, never be sent to
+ * Allo's backend, and never be written anywhere but the memory of the call that
+ * needs it. JavaScript gives no way to wipe a string afterwards — Rust's FFI
+ * zeroes its copy, and the TypeScript side simply cannot — so the discipline
+ * that is available is to hold it briefly and let it go.
+ *
+ * @throws {MatrixRecoveryPhraseInvalidError} if the phrase is not a valid BIP-39
+ * mnemonic. Checked rather than assumed: a mistyped word derives a perfectly
+ * well-formed passphrase that simply opens nothing, and "your history is gone"
+ * is a far worse thing to report than "that phrase is not right".
+ */
+export async function deriveMatrixRecoveryPassphrase(
+  oxyRecoveryPhrase: string,
+): Promise<string> {
+  // The same normalisation Oxy applies before its own derivations, so that both
+  // sides of the identity agree on what the phrase is.
+  const phrase = oxyRecoveryPhrase.trim().toLowerCase();
+  if (!validateMnemonic(phrase, wordlist)) {
+    throw new MatrixRecoveryPhraseInvalidError();
+  }
+
+  // The whole 64-byte seed, not the first 32 bytes Oxy slices off for its
+  // signing key. A device compromise that leaks only that private key therefore
+  // cannot reach the message history.
+  const seed = await mnemonicToSeed(phrase);
+  const derived = hkdfSha256(
+    seed,
+    utf8.encode(MATRIX_RECOVERY_KDF_SALT),
+    utf8.encode(MATRIX_RECOVERY_KDF_INFO),
+    MATRIX_RECOVERY_PASSPHRASE_BYTES,
+  );
+  return base64urlnopad.encode(derived);
+}

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -207,6 +207,31 @@ export interface AlloSession {
 }
 
 /**
+ * How far this device has got with Matrix's server-side secret storage (4S) and
+ * the key backup that hangs off it.
+ *
+ * These four values describe **this device**, not the account. `enabled` is not
+ * "the server has a backup", it is "the server has one *and* this device holds
+ * every secret it needs from it" — which is the question that decides whether
+ * old messages are readable here. The native binding answers it directly with
+ * `RecoveryState`; the web half assembles the same answer from three calls.
+ */
+export type AlloRecoveryState =
+  /** No 4S on the account. Nobody has ever set recovery up. */
+  | 'disabled'
+  /** 4S exists, and this device is missing something it holds. */
+  | 'incomplete'
+  /** This device has everything. Old messages are readable and it is verified. */
+  | 'enabled'
+  /**
+   * Not settled yet. The crypto stack starts up in the background and cannot
+   * answer until it has; the honest report is that the question is still open,
+   * because acting on a guess here either creates a second 4S store or skips a
+   * recovery the device needed.
+   */
+  | 'unknown';
+
+/**
  * Where the client keeps its state and its crypto store.
  *
  * `in-memory` throws away the device identity when the process dies, which makes
@@ -268,6 +293,18 @@ export interface AlloTimelineHandle {
  * There is no password login and there will not be one. Allo's homeserver issues
  * sessions through Matrix Authentication Service with Oxy upstream, so the user
  * never has a Matrix password to give.
+ *
+ * **Two operations both SDKs offer are missing on purpose.** `resetRecoveryKey`
+ * and `recoverAndReset` each replace the 4S key with 32 random bytes and strip
+ * the passphrase block out of the account data. Neither fails, neither warns,
+ * and after either one the passphrase derived from the user's Oxy identity stops
+ * opening anything — the link that this port exists to maintain is gone, and the
+ * only way back is a key nobody was ever shown. They are absent from this
+ * interface so that no screen can reach them, and
+ * `__tests__/matrix/recovery/noSilentReset.test.ts` fails if an implementation
+ * calls one anyway. Changing the recovery key is
+ * {@link AlloChatClient.enableRecovery} with a newly derived passphrase, which
+ * keeps the link. See `docs/matrix/client-strategy.md` §3.2.
  */
 export interface AlloChatClient {
   /**
@@ -304,6 +341,46 @@ export interface AlloChatClient {
     roomId: string,
     onChange: (items: readonly AlloTimelineItem[]) => void,
   ): Promise<AlloTimelineHandle>;
+
+  /**
+   * How far this device has got with 4S. See {@link AlloRecoveryState}.
+   *
+   * Asynchronous on both platforms even though the native binding answers
+   * synchronously, because the answer is only worth having once the crypto
+   * stack has finished starting, and waiting for that is the implementation's
+   * job rather than every caller's.
+   */
+  recoveryState(): Promise<AlloRecoveryState>;
+
+  /**
+   * Creates 4S and the key backup for this account, unlocked by `passphrase`.
+   *
+   * Only correct in state `disabled`. Calling it when 4S already exists creates
+   * a *second* store and makes it the default, which abandons the first one and
+   * every secret in it — the native SDK reallocates the key outright, and the
+   * web SDK is no kinder. {@link ensureMatrixRecovery} is what enforces that,
+   * and it is the only intended caller.
+   *
+   * `passphrase` is a credential: never log it, never persist it, never send it
+   * anywhere. Allo derives it from the Oxy identity — see
+   * `lib/matrix/recovery/passphrase.ts`.
+   */
+  enableRecovery(passphrase: string): Promise<void>;
+
+  /**
+   * Opens the account's existing 4S with `passphrase` and takes from it
+   * everything this device is missing: the cross-signing keys, the key backup
+   * decryption key, and then the room keys themselves.
+   *
+   * Two consequences worth stating because the UI depends on them. Messages
+   * that arrived before this device existed become readable — that is the whole
+   * point. And the device signs itself with the self-signing key it just
+   * recovered, so it ends up cross-signing verified without anyone scanning a QR
+   * code or comparing emoji.
+   *
+   * Only correct in state `incomplete`.
+   */
+  recoverWithPassphrase(passphrase: string): Promise<void>;
 
   /** Stops sync and releases every handle this client handed out. */
   close(): Promise<void>;

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -289,6 +289,10 @@ export interface AlloTimelineHandle {
  * - {@link startSync} must happen before {@link observeRooms} or
  *   {@link openTimeline}: both are views over the sync loop's state, and there is
  *   nothing to view before it runs.
+ * - the three recovery calls need a session, and nothing more. They are about
+ *   this device's encryption keys, not about the room list, so they do not wait
+ *   for sync — which is what lets recovery finish before the first timeline is
+ *   drawn, and the messages in it be readable when it is.
  *
  * There is no password login and there will not be one. Allo's homeserver issues
  * sessions through Matrix Authentication Service with Oxy upstream, so the user

--- a/packages/frontend/lib/matrix/web/recovery.ts
+++ b/packages/frontend/lib/matrix/web/recovery.ts
@@ -1,0 +1,87 @@
+import type { AlloRecoveryState } from '@/lib/matrix/types';
+
+/**
+ * The two judgements the web recovery path makes, kept apart from the calls that
+ * feed them.
+ *
+ * The native binding answers both of these itself — `recoveryState()` is one
+ * call, and `enableRecovery` refuses on its own when a backup it cannot use
+ * already exists. On web they have to be assembled, and assembling them is where
+ * the expensive mistakes are: reporting `disabled` for an account that has 4S
+ * leads straight to creating a second store and stranding the first, and
+ * creating a backup version over one already on the server strands every room
+ * key that only the old version holds.
+ *
+ * So both are pure functions of a handful of readings, and both are tested.
+ */
+
+/**
+ * Assembles {@link AlloRecoveryState} from what the SDK can be asked.
+ *
+ * @param defaultKeyId the account's default 4S key, or `null` if there is no 4S
+ * at all. Authoritative whenever it is read: before the initial sync the SDK
+ * fetches the account data from the homeserver rather than reporting the empty
+ * store, so "not synced yet" never arrives here disguised as "no recovery".
+ * @param crossSigningReady whether this device holds usable cross-signing keys.
+ * @param backupActive whether this device's backup engine is running against a
+ * version on the server.
+ *
+ * `unknown` is never returned. On web the crypto stack is fully up before this
+ * can be called and every input above is a definite answer or an exception; the
+ * state exists in the port for the native binding, which really does spend the
+ * first moments of a session unable to say.
+ */
+export function toRecoveryState({
+  defaultKeyId,
+  crossSigningReady,
+  backupActive,
+}: {
+  defaultKeyId: string | null;
+  crossSigningReady: boolean;
+  backupActive: boolean;
+}): AlloRecoveryState {
+  if (defaultKeyId === null) {
+    return 'disabled';
+  }
+  // Both, not either. A device with cross-signing but no running backup cannot
+  // read anything older than itself, which is the whole thing the user is
+  // promised; a device with a backup but no cross-signing is not verified and
+  // shows up as untrusted to everyone they talk to.
+  return crossSigningReady && backupActive ? 'enabled' : 'incomplete';
+}
+
+/** What to do about the key backup while 4S is being created. */
+export type KeyBackupPlan =
+  /** Nothing on the server. Create a version and put its key in 4S. */
+  | 'create'
+  /** This device is already backing up. Store that key in 4S; create nothing. */
+  | 'adopt-active'
+  /**
+   * The server holds a backup this device is not using. Refuse: see
+   * {@link MatrixBackupExistsOnServerError}.
+   */
+  | 'refuse';
+
+/**
+ * Decides whether creating a key backup is safe.
+ *
+ * The case worth spelling out is the third. `bootstrapSecretStorage` with
+ * `setupNewKeyBackup` calls the SDK's backup reset, which mints a *new* version
+ * on the server; every room key that lives only in the old version stays there,
+ * decryptable by a key nothing is left holding. That is the user's history
+ * quietly disappearing at the exact moment the app claimed to be protecting it.
+ * The native SDK treats the same situation as an error rather than resolving it,
+ * and this is the web half agreeing.
+ */
+export function planKeyBackup({
+  serverHasBackup,
+  backupActive,
+}: {
+  serverHasBackup: boolean;
+  backupActive: boolean;
+}): KeyBackupPlan {
+  if (!serverHasBackup) {
+    return 'create';
+  }
+  return backupActive ? 'adopt-active' : 'refuse';
+}

--- a/packages/frontend/lib/matrix/web/secretStorage.ts
+++ b/packages/frontend/lib/matrix/web/secretStorage.ts
@@ -1,0 +1,147 @@
+import { MatrixSecretStorageKeyUnusableError } from '@/lib/matrix/errors';
+
+/**
+ * Answering the SDK when it needs the key to server-side secret storage.
+ *
+ * On web the crypto stack asks the application for this key rather than holding
+ * one: every time it reads a secret out of 4S or writes one into it, it calls
+ * `getSecretStorageKey` with the key descriptions the homeserver publishes in
+ * account data, and expects the raw 32 bytes back. Allo answers by stretching
+ * the passphrase derived from the Oxy identity with the PBKDF2 parameters that
+ * the description carries — the same computation the native binding does inside
+ * `recover()`, which is why one 4S store works for both platforms.
+ *
+ * Nothing here imports a Matrix SDK — the PBKDF2 is handed in, the same way
+ * `web/cryptoWasm.ts` is handed its `initAsync`. That is what lets the checks
+ * below be tested against fabricated key descriptions with no SDK, no browser
+ * and no homeserver, and it is why the awkward import of
+ * `deriveRecoveryKeyFromPassphrase` lives in `client.web.ts` instead.
+ *
+ * Writing that PBKDF2 by hand rather than borrowing the SDK's would be the wrong
+ * economy: it has to agree byte for byte with what Rust computes on the other
+ * platform, and the SDK's copy is the one that is known to.
+ */
+
+/** The only secret storage algorithm the spec defines, and the only one Allo reads. */
+const AES_HMAC_SHA2 = 'm.secret_storage.v1.aes-hmac-sha2';
+
+/** The only key derivation function the spec defines for passphrases. */
+const PBKDF2 = 'm.pbkdf2';
+
+/**
+ * The most PBKDF2 iterations Allo will run.
+ *
+ * Both SDKs create keys with 500 000, so this is four times the number any
+ * honest homeserver publishes. The bound is not about cryptographic strength —
+ * it is about a number that arrives over the network being used as a loop count.
+ * A homeserver that publishes 10⁹ cannot learn the passphrase (§3.5), but
+ * without a bound it can make the app compute until the user gives up, with no
+ * error and nothing on screen. With one, it gets a refusal it can be blamed for.
+ *
+ * There is deliberately no *lower* bound. A small count would be a real weakness
+ * for a passphrase a human chose; Allo's is 256 bits of HKDF output, so
+ * stretching it adds nothing that could be taken away, and a floor could only
+ * ever refuse a store Allo still has to open.
+ */
+export const MAX_PBKDF2_ITERATIONS = 2_000_000;
+
+/**
+ * How a key says it was derived, as it actually arrives.
+ *
+ * The SDK types `algorithm` as the literal `"m.pbkdf2"` — which is what the spec
+ * defines, and not what a homeserver is obliged to send. Typing it as `string`
+ * is what makes the check below something the compiler agrees can happen,
+ * instead of dead code a reviewer deletes.
+ */
+export interface StoredPassphraseInfo {
+  readonly algorithm: string;
+  readonly salt: string;
+  readonly iterations: number;
+  readonly bits?: number;
+}
+
+/**
+ * A key description as it actually arrives.
+ *
+ * The SDK types `passphrase` as always present; the spec does not require it,
+ * and a 4S store created from a raw key has no passphrase block at all. This
+ * type says what is true, and being wider than the SDK's own in both places is
+ * what lets the callback be handed to it without a cast.
+ */
+export interface StoredSecretStorageKey {
+  readonly algorithm: string;
+  readonly passphrase?: StoredPassphraseInfo;
+}
+
+/** Yields the current 4S passphrase, or `undefined` when there is none to give. */
+export type SecretStoragePassphraseSource = () => string | undefined;
+
+/** The shape `matrix-js-sdk` calls, narrowed to what this port answers. */
+export type SecretStorageKeyCallback = (
+  opts: { keys: Record<string, StoredSecretStorageKey> },
+  secretName: string,
+) => Promise<[string, Uint8Array<ArrayBuffer>] | null>;
+
+/**
+ * The shape of `deriveRecoveryKeyFromPassphrase` from `matrix-js-sdk`: PBKDF2 as
+ * the Matrix spec defines it for secret storage.
+ */
+export type RecoveryKeyDerivation = (
+  passphrase: string,
+  salt: string,
+  iterations: number,
+  numBits?: number,
+) => Promise<Uint8Array<ArrayBuffer>>;
+
+/**
+ * Builds the `getSecretStorageKey` callback.
+ *
+ * Returns `null` — which the SDK turns into a failure of whatever needed the
+ * secret — in the two cases where there is honestly no answer: no passphrase is
+ * available, or no published key was created from one. It *throws* when a key
+ * was created from a passphrase but describes its derivation in a way this
+ * client will not run, because that is not "no answer", it is a homeserver
+ * saying something wrong and the difference belongs in the logs.
+ */
+export function createSecretStorageKeyCallback(
+  getPassphrase: SecretStoragePassphraseSource,
+  derive: RecoveryKeyDerivation,
+): SecretStorageKeyCallback {
+  return async ({ keys }) => {
+    const passphrase = getPassphrase();
+    if (passphrase === undefined) {
+      return null;
+    }
+
+    for (const [keyId, description] of Object.entries(keys)) {
+      // A key stored under an algorithm this client does not implement, or one
+      // created from a raw key rather than a passphrase. Neither is Allo's, so
+      // look at the next one rather than refusing the whole account.
+      if (description.algorithm !== AES_HMAC_SHA2 || description.passphrase === undefined) {
+        continue;
+      }
+
+      const { algorithm, salt, iterations, bits } = description.passphrase;
+      if (algorithm !== PBKDF2) {
+        throw new MatrixSecretStorageKeyUnusableError(
+          keyId,
+          `it says its key is derived with "${algorithm}", and the only ` +
+            `derivation Matrix defines is ${PBKDF2}`,
+        );
+      }
+      if (!Number.isInteger(iterations) || iterations <= 0 || iterations > MAX_PBKDF2_ITERATIONS) {
+        throw new MatrixSecretStorageKeyUnusableError(
+          keyId,
+          `it asks for ${iterations} PBKDF2 iterations, and this client runs at ` +
+            `most ${MAX_PBKDF2_ITERATIONS}`,
+        );
+      }
+
+      // Half a second of CPU on a phone, once. The salt and the iteration count
+      // are the server's; the passphrase never leaves this process.
+      return [keyId, await derive(passphrase, salt, iterations, bits)];
+    }
+
+    return null;
+  };
+}

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -584,5 +584,7 @@
     "Sign in": "Sign in",
     "This message cannot be read on this device.": "This message cannot be read on this device.",
     "This message was deleted.": "This message was deleted.",
-    "Allo cannot show this yet ({{kind}}).": "Allo cannot show this yet ({{kind}})."
+    "Allo cannot show this yet ({{kind}}).": "Allo cannot show this yet ({{kind}}).",
+    "Your Oxy recovery phrase opens your Allo history": "Your Oxy recovery phrase opens your Allo history",
+    "Allo unlocks your encrypted message backup with a key derived from your Oxy recovery phrase. That is why a new device can read your old conversations as soon as you sign in — and it means anyone who has that phrase can read them too, including messages sent before they got it. Keep it as carefully as you would keep the conversations themselves.": "Allo unlocks your encrypted message backup with a key derived from your Oxy recovery phrase. That is why a new device can read your old conversations as soon as you sign in — and it means anyone who has that phrase can read them too, including messages sent before they got it. Keep it as carefully as you would keep the conversations themselves."
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -553,5 +553,7 @@
   "Sign in": "Iniciar sesión",
   "This message cannot be read on this device.": "Este mensaje no se puede leer en este dispositivo.",
   "This message was deleted.": "Este mensaje se ha borrado.",
-  "Allo cannot show this yet ({{kind}}).": "Allo todavía no puede mostrar esto ({{kind}})."
+  "Allo cannot show this yet ({{kind}}).": "Allo todavía no puede mostrar esto ({{kind}}).",
+  "Your Oxy recovery phrase opens your Allo history": "Tu frase de recuperación de Oxy abre tu historial de Allo",
+  "Allo unlocks your encrypted message backup with a key derived from your Oxy recovery phrase. That is why a new device can read your old conversations as soon as you sign in — and it means anyone who has that phrase can read them too, including messages sent before they got it. Keep it as carefully as you would keep the conversations themselves.": "Allo abre tu copia de seguridad de mensajes cifrados con una clave derivada de tu frase de recuperación de Oxy. Por eso un dispositivo nuevo puede leer tus conversaciones antiguas nada más iniciar sesión, y por eso cualquiera que tenga esa frase también puede leerlas, incluidos los mensajes enviados antes de que la consiguiera. Guárdala con el mismo cuidado con el que guardarías las propias conversaciones."
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -547,5 +547,7 @@
   "Sign in": "Accedi",
   "This message cannot be read on this device.": "Questo messaggio non può essere letto su questo dispositivo.",
   "This message was deleted.": "Questo messaggio è stato eliminato.",
-  "Allo cannot show this yet ({{kind}}).": "Allo non può ancora mostrare questo ({{kind}})."
+  "Allo cannot show this yet ({{kind}}).": "Allo non può ancora mostrare questo ({{kind}}).",
+  "Your Oxy recovery phrase opens your Allo history": "La tua frase di recupero Oxy apre la cronologia di Allo",
+  "Allo unlocks your encrypted message backup with a key derived from your Oxy recovery phrase. That is why a new device can read your old conversations as soon as you sign in — and it means anyone who has that phrase can read them too, including messages sent before they got it. Keep it as carefully as you would keep the conversations themselves.": "Allo sblocca il backup cifrato dei tuoi messaggi con una chiave derivata dalla tua frase di recupero Oxy. È per questo che un nuovo dispositivo può leggere le tue vecchie conversazioni appena accedi, ed è per questo che chiunque abbia quella frase può leggerle a sua volta, compresi i messaggi inviati prima che la ottenesse. Conservala con la stessa cura con cui conserveresti le conversazioni stesse."
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
   "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "/node_modules/(?!(.pnpm|@noble|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|standard-navigation))",
+      "/node_modules/(?!(.pnpm|@noble|@oxyhq|@scure|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|standard-navigation))",
       "/node_modules/react-native-reanimated/plugin/",
       "/node_modules/@react-native/babel-preset/"
     ]
@@ -61,6 +61,8 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "12.0.1",
     "@react-native-community/slider": "5.2.0",
+    "@scure/base": "^1.2.6",
+    "@scure/bip39": "^1.6.0",
     "@shopify/flash-list": "^2.0.2",
     "@tanstack/query-async-storage-persister": "^5.101.2",
     "@tanstack/react-query": "^5.101.2",


### PR DESCRIPTION
## Qué resuelve

El key backup de Matrix se protege con una clave de recuperación que el usuario tiene que apuntar y guardar. Es la peor parte de la experiencia y la razón por la que la gente pierde su historial.

Oxy ya le da a cada usuario un secreto derivado **en el cliente** — una frase BIP39, con HKDF y separación de dominio ya montada. De ahí sale ahora la clave de 4S: **el usuario nunca ve una segunda clave**, y al entrar con Oxy su historial se abre solo.

El servidor sigue sin poder descifrar, porque esa clave sale de un secreto que nunca ha tenido.

## No es criptografía nueva

Es `hkdfSha256` de `@oxyhq/core` con una etiqueta distinta (`allo-matrix-v1` / `allo-matrix-4s-passphrase`) y el resto lo hace Matrix. Y el esquema **ya estaba demostrado antes de escribirlo**: `spikes/matrix-web/RESULTS.md` lo ejecutó contra un homeserver real — passphrase arbitrario a 4S, dispositivo nuevo recuperando historial anterior a su existencia, y auto-verificación del dispositivo (`ownDeviceCrossSigningVerified=true`), con control negativo.

## Los dos límites del diseño, respetados

- **`resetRecoveryKey()` y `recoverAndReset()` no son alcanzables desde la UI.** Rompen el vínculo con Oxy en silencio.
- **Quien tenga la frase de Oxy tiene todo el historial de Allo.** Ya era cierto para la identidad; ahora lo es para los mensajes. Está dicho donde un usuario puede leerlo, no sólo en un comentario.

## Plan de pruebas

- Typecheck del frontend en verde en condiciones de CI.
- **319 tests en 29 suites**, frente a 247 en 21.
- Verificado por mutación: reutilizar el `info` de Oxy en vez de una etiqueta propia hace fallar cuatro tests, entre ellos *"keeps its labels versioned and distinct from Oxy's"* — la propiedad que impide reutilizar la misma clave derivada en dos dominios. Y hay un vector BIP-39 congelado, así que la derivación no puede cambiar en silencio.
- Cero `as any`, cero `@ts-ignore`, cero `useEffect` nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)