### PR TITLE
La sesión de Matrix sobrevive al arranque, y se puede cerrar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "expo-constants": "~57.0.5",
         "expo-contacts": "~57.0.1",
         "expo-crypto": "~57.0.1",
+        "expo-file-system": "~57.0.1",
         "expo-font": "~57.0.1",
         "expo-haptics": "~57.0.1",
         "expo-image": "~57.0.1",

--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -64,12 +64,17 @@ bun run dev:frontend
 
 ```
 lib/chat/
-  backend.ts          la bandera
-  matrixConfig.ts     homeserver, OIDC, almacén
-  matrixRuntime.ts    el cliente y su ciclo de vida, fuera de React
-  roomListSource.ts   la lista de salas como external store
-  timelineSource.ts   un timeline por sala, ídem, más paginar y enviar
-  matrixViewModel.ts  AlloRoomSummary → Conversation, AlloTimelineItem → Message
+  backend.ts             la bandera
+  matrixConfig.ts        homeserver, OIDC, almacén
+  matrixRuntime.ts       el cliente y su ciclo de vida, fuera de React
+  matrixSession.ts       la sesión guardada: versión, validación, homeserver
+  matrixSessionStorage.ts dónde vive: llavero en nativo, localStorage en web
+  roomListSource.ts      la lista de salas como external store
+  timelineSource.ts      un timeline por sala, ídem, más paginar y enviar
+  matrixViewModel.ts     AlloRoomSummary → Conversation, AlloTimelineItem → Message
+lib/matrix/
+  store.native.ts        dos directorios, y cómo borrarlos
+  store.web.ts           una base de IndexedDB, y cómo borrarla
 hooks/
   useMatrixRuntime.ts       useSyncExternalStore sobre el runtime
   useMatrixConversations.ts → Conversation[] | undefined
@@ -77,6 +82,22 @@ hooks/
 components/matrix/
   MatrixSignInGate.tsx      pinta a sus hijos salvo que falte sesión
 ```
+
+**Un dispositivo Matrix por instalación.** Un login acuña un dispositivo, y de
+ese dispositivo cuelgan unas claves de cifrado; una app que hace login en cada
+arranque llena la cuenta de dispositivos que nadie puede verificar y que no leen
+el historial de los demás. Lo que lo evita son dos hechos, ambos en
+`matrixRuntime.ts`:
+
+- **la sesión guardada manda.** El almacén en disco pertenece a la sesión que hay
+  en el llavero y a ninguna otra, así que un arranque que no encuentra sesión
+  borra el almacén *antes* de abrirlo. Eso hace que todas las formas de perder
+  una sesión —un cierre de sesión, un cierre a medias, un registro de una versión
+  vieja de Allo— terminen en el mismo estado limpio.
+- **la sesión no es una foto.** El SDK rota sus tokens por su cuenta, así que lo
+  que se escribió en el login caduca en menos de una hora. `observeSession` es
+  cómo el puerto lo cuenta —delegado del constructor en nativo, callback del
+  `TokenRefresher` en web— y el runtime está suscrito mientras el cliente viva.
 
 **Ningún componente de presentación cambió.** `MessageBubble`, `MessageBlock`,
 `DaySeparator`, las filas de la lista, el layout de tres paneles y los temas por
@@ -106,6 +127,12 @@ encenderlo.
 - Timeline de una conversación, con paginación hacia atrás al llegar arriba.
 - Envío de texto.
 - Login OIDC en tres pasos, con `expo-web-browser`.
+- **Sesión persistida**: el segundo arranque no pasa por el navegador. Se guarda
+  en el llavero del móvil (`AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`, para que una
+  restauración de iCloud no lleve la sesión a un teléfono donde no están las
+  claves) y en `localStorage` en web.
+- **Cerrar sesión**, desde Ajustes. Avisa al homeserver, y borre o no borre el
+  homeserver, se lleva la sesión guardada, el almacén de estado y el de cripto.
 - Estados propios para los eventos sin texto: no descifrable, redactado, y
   «Allo no sabe dibujar esto todavía». Ninguno se pinta como una burbuja vacía.
 
@@ -113,28 +140,28 @@ encenderlo.
 
 Por orden de cuánto se nota:
 
-1. **La sesión no se persiste.** Cada arranque es un login nuevo y, por tanto, un
-   dispositivo Matrix nuevo. No es un olvido: `AlloSession` documenta que el SDK
-   rota los tokens sin avisar a la app y que una sesión guardada se queda rancia
-   y deja de restaurarse. Cerrar ese hueco es trabajo en el puerto. Por lo mismo
-   el almacén es `in-memory`: un almacén de cripto en disco sólo acumularía las
-   claves de dispositivos que nadie va a volver a usar.
-2. **La fila de la lista no tiene ni vista previa ni hora.** `AlloRoomSummary` no
+1. **La fila de la lista no tiene ni vista previa ni hora.** `AlloRoomSummary` no
    lleva último evento ni marca de actividad. El orden no se pierde —lo da el
    puerto— pero el texto y la hora se quedan vacíos, que es lo que el formateador
    dibuja como nada. Inventar `Date.now()` pondría «ahora» al lado de cada
    conversación de la app.
-3. **El tamaño de letra por mensaje no viaja.** `AlloTimelineHandle.sendText`
+2. **El tamaño de letra por mensaje no viaja.** `AlloTimelineHandle.sendText`
    manda un cuerpo y nada más; `so.oxy.allo.font_size` (§4.2 de
    `data-model.md`) necesita una llamada que el puerto no tiene.
-4. **Un envío fallido dibuja el reloj, no un error.** `MessageMetadata` sólo
+3. **Un envío fallido dibuja el reloj, no un error.** `MessageMetadata` sólo
    conoce pendiente / enviado / entregado / leído. El reloj es cierto en móvil,
    donde la cola del SDK sigue reintentando, y optimista en web, donde no.
-5. **Sin reacciones, sin edición, sin borrado, sin adjuntos, sin recibos de
+4. **Sin reacciones, sin edición, sin borrado, sin adjuntos, sin recibos de
    lectura, sin indicador de escribiendo, sin crear conversaciones.** El puerto
    no expone ninguna de esas operaciones todavía.
-6. **Sin cerrar sesión.** El único camino de vuelta es reiniciar la app.
-7. **Las invitaciones aparecen como filas normales.** El puerto las incluye
+5. **Una sesión revocada desde fuera no se nota hasta el siguiente arranque.** Si
+   el usuario borra este dispositivo desde otro cliente, el sync empieza a fallar
+   y la app lo dibuja como un error de sincronización, no como «te han cerrado la
+   sesión». El binding lo cuenta (`ClientDelegate.didReceiveAuthError`) y
+   `matrix-js-sdk` también (`HttpApiEvent.SessionLoggedOut`); el puerto no expone
+   ninguno de los dos todavía. El camino de vuelta existe —cerrar sesión desde
+   Ajustes— pero hay que saber que hace falta.
+6. **Las invitaciones aparecen como filas normales.** El puerto las incluye
    («todo lo que el usuario no ha abandonado»), y abrir una probablemente no dé
    timeline. No se filtran aquí: la definición de qué es una conversación es del
    puerto, no de este mapeo.
@@ -148,3 +175,16 @@ la app arrancaría una segunda copia de Allo dentro del popup — y dos copias s
 dos `MatrixClient` sobre un IndexedDB, que es la corrupción del almacén de cripto
 que avisa el SDK. Sigue en pie lo que dice `client.web.ts`: Allo en web es segura
 en una pestaña y no está probada en dos.
+
+La sesión vive en `localStorage`, no en un llavero, porque un navegador no tiene
+ninguno: lo que la protege es el origen, la misma protección de la que ya depende
+el almacén de cripto en IndexedDB. Un navegador que lo niega —modo privado, algún
+webview— se rechaza al primer intento de leerla, igual que el puerto ya rechaza
+uno sin IndexedDB, y por la misma razón: la alternativa es hacer login en cada
+arranque y acuñar un dispositivo cada vez.
+
+Al cerrar sesión se borran las tres bases: el estado sincronizado y las dos del
+motor de cripto. Una que quede de un cierre de sesión interrumpido sólo ocupa
+sitio —lleva el id del dispositivo en el nombre, así que la sesión siguiente no
+puede abrirla— y se barre en el arranque siguiente si el navegador ofrece
+`indexedDB.databases()`, que Firefox no tuvo hasta la 126.

--- a/packages/frontend/__mocks__/@unomed/react-native-matrix-sdk.ts
+++ b/packages/frontend/__mocks__/@unomed/react-native-matrix-sdk.ts
@@ -59,6 +59,11 @@ export enum SyncServiceState {
   Offline = 4,
 }
 
+export enum SlidingSyncVersion {
+  None = 0,
+  Native = 1,
+}
+
 // --- Tag enums -----------------------------------------------------------
 
 export enum TimelineItemContent_Tags {

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -3,9 +3,12 @@ import {
   type AuthorizationOutcome,
   type MatrixRuntimeDependencies,
 } from '@/lib/chat/matrixRuntime';
+import { encodeStoredSession } from '@/lib/chat/matrixSession';
+import type { MatrixSessionStorage } from '@/lib/chat/matrixSessionStorage';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
+  AlloClientStore,
   AlloEncryptionState,
   AlloOidcLoginRequest,
   AlloRoomListHandle,
@@ -16,17 +19,24 @@ import type {
 } from '@/lib/matrix/types';
 
 /**
- * The client's lifecycle: building it, signing in through a browser, and what
- * happens when any of that fails.
+ * The client's lifecycle: building it, reinstating the session of a previous
+ * launch, signing in through a browser, signing out, and what happens when any
+ * of that fails.
  *
  * Everything the runtime touches that is not its own logic is injected, so all
- * of this runs without a homeserver, without a browser and without either Matrix
- * SDK.
+ * of this runs without a homeserver, without a browser, without a keychain and
+ * without either Matrix SDK.
  */
+
+const STORE: AlloClientStore = {
+  kind: 'filesystem',
+  dataPath: '/allo/matrix',
+  cachePath: '/allo/matrix-cache',
+};
 
 const CONFIG: AlloChatClientConfig = {
   homeserverUrl: 'https://matrix.example',
-  store: { kind: 'in-memory' },
+  store: STORE,
   oidc: {
     clientName: 'Allo',
     redirectUri: 'allo://matrix/oidc',
@@ -42,6 +52,84 @@ const SESSION: AlloSession = {
   refreshToken: 'secret-refresh-token',
   authData: undefined,
 };
+
+/** The same session after the SDK has rotated its tokens. */
+const REFRESHED_SESSION: AlloSession = {
+  ...SESSION,
+  accessToken: 'secret-access-token-2',
+  refreshToken: 'secret-refresh-token-2',
+};
+
+/**
+ * The keychain, or `localStorage`, as one string and a log of what was done to
+ * it.
+ *
+ * The log is what most of these tests assert on. Persisting a session is a
+ * sequence — read, erase, write, clear — and almost everything that can go wrong
+ * with it is an ordering mistake that leaves the right values in the wrong order.
+ */
+class FakeSessionStorage implements MatrixSessionStorage {
+  /** Every operation asked of it, in the order it was asked. */
+  readonly calls: string[] = [];
+  /** The same, in the harness's log of everything the runtime did. */
+  readonly events: string[];
+
+  value: string | undefined;
+  writeFails: Error | undefined;
+  clearFails: Error | undefined;
+  /** While true, a write does not finish until {@link releaseWrites}. */
+  holdWrites = false;
+
+  #held: (() => void)[] = [];
+
+  constructor(events: string[] = []) {
+    this.events = events;
+  }
+
+  async read(): Promise<string | undefined> {
+    this.#record('read');
+    return this.value;
+  }
+
+  async write(value: string): Promise<void> {
+    this.#record('write');
+    if (this.holdWrites) {
+      await new Promise<void>((resolve) => {
+        this.#held.push(resolve);
+      });
+    }
+    if (this.writeFails !== undefined) {
+      throw this.writeFails;
+    }
+    this.value = value;
+  }
+
+  async clear(): Promise<void> {
+    this.#record('clear');
+    if (this.clearFails !== undefined) {
+      throw this.clearFails;
+    }
+    this.value = undefined;
+  }
+
+  #record(call: string): void {
+    this.calls.push(call);
+    this.events.push(call);
+  }
+
+  releaseWrites(): void {
+    for (const release of this.#held.splice(0)) {
+      release();
+    }
+  }
+
+  /** What is stored, as the session it holds. */
+  storedSession(): AlloSession | undefined {
+    return this.value === undefined
+      ? undefined
+      : (JSON.parse(this.value) as { session: AlloSession }).session;
+  }
+}
 
 class FakeLoginRequest implements AlloOidcLoginRequest {
   readonly authorizationUrl = 'https://auth.example/authorize?state=xyz';
@@ -61,14 +149,25 @@ class FakeLoginRequest implements AlloOidcLoginRequest {
 
 class FakeChatClient implements AlloChatClient {
   readonly request = new FakeLoginRequest();
+  /** Every call the runtime made, shared with the rest of the harness. */
+  readonly events: string[];
   beginOidcLoginCalls = 0;
   startSyncCalls = 0;
   closes = 0;
+  logouts = 0;
+  restoredWith: AlloSession | undefined;
   beginOidcLoginFails: Error | undefined;
   startSyncFails: Error | undefined;
+  restoreSessionFails: Error | undefined;
+  logoutFails: Error | undefined;
 
   #syncListeners = new Set<(state: AlloSyncState) => void>();
+  #sessionListeners = new Set<(session: AlloSession) => void>();
   #syncState: AlloSyncState = 'idle';
+
+  constructor(events: string[]) {
+    this.events = events;
+  }
 
   async beginOidcLogin(): Promise<AlloOidcLoginRequest> {
     this.beginOidcLoginCalls += 1;
@@ -78,13 +177,47 @@ class FakeChatClient implements AlloChatClient {
     return this.request;
   }
 
-  async restoreSession(): Promise<void> {}
+  async restoreSession(session: AlloSession): Promise<void> {
+    this.events.push('restoreSession');
+    this.restoredWith = session;
+    if (this.restoreSessionFails !== undefined) {
+      throw this.restoreSessionFails;
+    }
+  }
 
   session(): AlloSession {
     return SESSION;
   }
 
+  observeSession(onChange: (session: AlloSession) => void): AlloUnsubscribe {
+    this.#sessionListeners.add(onChange);
+    return () => {
+      this.#sessionListeners.delete(onChange);
+    };
+  }
+
+  /** Stands in for the SDK rotating the session's tokens on its own. */
+  rotateSession(session: AlloSession): void {
+    for (const listener of this.#sessionListeners) {
+      listener(session);
+    }
+  }
+
+  /** How many listeners the runtime currently has on the session. */
+  sessionListenerCount(): number {
+    return this.#sessionListeners.size;
+  }
+
+  async logout(): Promise<void> {
+    this.events.push('logout');
+    this.logouts += 1;
+    if (this.logoutFails !== undefined) {
+      throw this.logoutFails;
+    }
+  }
+
   async startSync(): Promise<void> {
+    this.events.push('startSync');
     this.startSyncCalls += 1;
     if (this.startSyncFails !== undefined) {
       throw this.startSyncFails;
@@ -128,9 +261,26 @@ class FakeChatClient implements AlloChatClient {
 
 interface Harness {
   readonly runtime: MatrixRuntime;
-  readonly client: FakeChatClient;
+  /**
+   * The client this launch is on.
+   *
+   * A getter and not a field: signing out builds a new one, and a test that held
+   * on to the first would be asserting about a client the runtime has already
+   * thrown away.
+   */
+  client(): FakeChatClient;
+  /** Every client ever built, oldest first. */
+  readonly clients: FakeChatClient[];
+  readonly storage: FakeSessionStorage;
+  /**
+   * Everything the runtime did, in order, across storage, the store and the
+   * client. What most of these tests are actually about is this sequence.
+   */
+  readonly events: string[];
   /** What the browser step was asked to open, in order. */
   readonly opened: string[];
+  /** The stores the runtime asked to have erased, in order. */
+  readonly erased: AlloClientStore[];
   createClientCalls: number;
 }
 
@@ -138,24 +288,55 @@ function harness(
   overrides: Partial<MatrixRuntimeDependencies> & {
     outcome?: () => Promise<AuthorizationOutcome>;
     createClientFails?: () => Error | undefined;
+    storage?: FakeSessionStorage;
+    eraseStoreFails?: Error;
   } = {},
 ): Harness {
-  const client = new FakeChatClient();
+  const storage = overrides.storage ?? new FakeSessionStorage();
+  const events = storage.events;
+  // One client up front, so a test can arm its failures before the runtime asks
+  // for it. Every rebuild after that gets a new one.
+  const clients: FakeChatClient[] = [new FakeChatClient(events)];
   const opened: string[] = [];
+  const erased: AlloClientStore[] = [];
+  let builds = 0;
   const result: Harness = {
-    client,
+    client: () => {
+      const client = clients[Math.max(builds - 1, 0)];
+      if (client === undefined) {
+        throw new Error('the harness lost track of its clients');
+      }
+      return client;
+    },
+    clients,
+    storage,
+    events,
     opened,
+    erased,
     createClientCalls: 0,
     runtime: new MatrixRuntime({
       config: () => CONFIG,
       createClient: async () => {
         result.createClientCalls += 1;
+        events.push('createClient');
         const failure = overrides.createClientFails?.();
         if (failure !== undefined) {
           throw failure;
         }
-        return client;
+        builds += 1;
+        if (clients.length < builds) {
+          clients.push(new FakeChatClient(events));
+        }
+        return result.client();
       },
+      eraseStore: async (store) => {
+        events.push('eraseStore');
+        erased.push(store);
+        if (overrides.eraseStoreFails !== undefined) {
+          throw overrides.eraseStoreFails;
+        }
+      },
+      sessionStorage: storage,
       authorize: async (url) => {
         opened.push(url);
         return (await overrides.outcome?.()) ?? { kind: 'returned', callbackUrl: 'allo://matrix/oidc?code=abc' };
@@ -164,6 +345,13 @@ function harness(
     }),
   };
   return result;
+}
+
+/** A session already written down, as a previous launch would have left it. */
+function stored(session: AlloSession = SESSION): FakeSessionStorage {
+  const storage = new FakeSessionStorage();
+  storage.value = encodeStoredSession(session);
+  return storage;
 }
 
 /** Lets every already-queued promise settle. */
@@ -247,8 +435,8 @@ describe('MatrixRuntime sign-in', () => {
     await settle();
 
     expect(context.opened).toEqual(['https://auth.example/authorize?state=xyz']);
-    expect(context.client.request.completedWith).toBe('allo://matrix/oidc?code=abc');
-    expect(context.client.startSyncCalls).toBe(1);
+    expect(context.client().request.completedWith).toBe('allo://matrix/oidc?code=abc');
+    expect(context.client().startSyncCalls).toBe(1);
     expect(context.runtime.getState()).toMatchObject({
       phase: 'ready',
       userId: '@nate:matrix.example',
@@ -264,7 +452,7 @@ describe('MatrixRuntime sign-in', () => {
     await context.runtime.signIn();
     await settle();
 
-    expect(context.client.request.aborts).toBe(1);
+    expect(context.client().request.aborts).toBe(1);
     expect(context.runtime.getState().phase).toBe('signed-out');
     expect(context.runtime.getState().error).toBeUndefined();
   });
@@ -286,7 +474,7 @@ describe('MatrixRuntime sign-in', () => {
     release();
     await Promise.all([first, second]);
 
-    expect(context.client.beginOidcLoginCalls).toBe(1);
+    expect(context.client().beginOidcLoginCalls).toBe(1);
     expect(context.opened).toHaveLength(1);
   });
 
@@ -296,12 +484,12 @@ describe('MatrixRuntime sign-in', () => {
     await context.runtime.signIn();
     await context.runtime.signIn();
 
-    expect(context.client.beginOidcLoginCalls).toBe(1);
+    expect(context.client().beginOidcLoginCalls).toBe(1);
   });
 
   it('reports a completion the homeserver rejected', async () => {
     const context = harness();
-    context.client.request.completion = async () => {
+    context.client().request.completion = async () => {
       throw new Error('M_UNKNOWN_TOKEN');
     };
 
@@ -319,7 +507,7 @@ describe('MatrixRuntime sign-in', () => {
     // only the final state would not notice: the failure lands a moment later
     // and the end state is the same either way.
     const context = harness();
-    context.client.startSyncFails = new Error('sliding sync is not available');
+    context.client().startSyncFails = new Error('sliding sync is not available');
     const phases: string[] = [];
     context.runtime.subscribe(() => {
       phases.push(context.runtime.getState().phase);
@@ -342,7 +530,7 @@ describe('MatrixRuntime sign-in', () => {
     await context.runtime.signIn();
     await settle();
 
-    expect(context.client.startSyncCalls).toBe(1);
+    expect(context.client().startSyncCalls).toBe(1);
     expect(phases).toContain('ready');
   });
 
@@ -375,7 +563,7 @@ describe('MatrixRuntime notifications', () => {
     // whole conversation list for nothing.
     const context = harness();
     await context.runtime.signIn();
-    context.client.emitSyncState('running');
+    context.client().emitSyncState('running');
 
     let notifications = 0;
     context.runtime.subscribe(() => {
@@ -384,12 +572,12 @@ describe('MatrixRuntime notifications', () => {
     await settle();
     notifications = 0;
 
-    context.client.emitSyncState('running');
-    context.client.emitSyncState('running');
+    context.client().emitSyncState('running');
+    context.client().emitSyncState('running');
 
     expect(notifications).toBe(0);
 
-    context.client.emitSyncState('offline');
+    context.client().emitSyncState('offline');
     expect(notifications).toBe(1);
   });
 
@@ -398,7 +586,7 @@ describe('MatrixRuntime notifications', () => {
     await context.runtime.signIn();
 
     const first = context.runtime.getState();
-    context.client.emitSyncState(first.sync);
+    context.client().emitSyncState(first.sync);
 
     expect(context.runtime.getState()).toBe(first);
   });
@@ -414,8 +602,324 @@ describe('MatrixRuntime notifications', () => {
     await settle();
     unsubscribe();
 
-    context.client.emitSyncState('offline');
+    context.client().emitSyncState('offline');
 
     expect(notifications).toBe(0);
+  });
+});
+
+describe('MatrixRuntime session persistence', () => {
+  it('reinstates a stored session without opening a browser', async () => {
+    // The whole point. A launch that finds a session does not sign in again, so
+    // the homeserver is not asked to mint a second Matrix device.
+    const context = harness({ storage: stored() });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.opened).toEqual([]);
+    expect(context.client().beginOidcLoginCalls).toBe(0);
+    expect(context.client().restoredWith).toEqual(SESSION);
+    expect(context.runtime.getState()).toMatchObject({
+      phase: 'ready',
+      userId: '@nate:matrix.example',
+    });
+  });
+
+  it('erases the store before it opens one it has no session for', async () => {
+    // Order, not just the fact. What may be on disk is the store of a session
+    // that is gone — a sign-out the app did not live to finish — and the SDKs'
+    // stores hold one user each. Erasing after the client has opened it is the
+    // same as not erasing at all.
+    const context = harness();
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.erased).toEqual([STORE]);
+    expect(context.events.indexOf('eraseStore')).toBeLessThan(
+      context.events.indexOf('createClient'),
+    );
+  });
+
+  it('leaves the store alone when it has a session to put back into it', async () => {
+    // The store belongs to the session being restored. Erasing here would throw
+    // away the device's encryption keys and every message it could still read.
+    const context = harness({ storage: stored() });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.erased).toEqual([]);
+  });
+
+  it('refuses a session stored for a different homeserver, and forgets it', async () => {
+    // A build repointed at another homeserver. The device id in this session was
+    // never issued there, and restoring it would ask that server about a device
+    // it has never heard of.
+    const context = harness({
+      storage: stored({ ...SESSION, homeserverUrl: 'https://elsewhere.example' }),
+    });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.client().restoredWith).toBeUndefined();
+    expect(context.storage.value).toBeUndefined();
+    expect(context.erased).toEqual([STORE]);
+    expect(context.runtime.getState().phase).toBe('signed-out');
+  });
+
+  it('writes the session down before it starts syncing', async () => {
+    // The Matrix device exists on the homeserver the moment the login completes.
+    // Everything between that and the write is a window in which the app can die
+    // and leave a device nothing will ever recognise.
+    const context = harness();
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.storage.storedSession()).toEqual(SESSION);
+    expect(context.events.indexOf('write')).toBeLessThan(
+      context.events.indexOf('startSync'),
+    );
+  });
+
+  it('writes down every session the SDK rotates to', async () => {
+    // Under OIDC the tokens are short-lived and the SDK refreshes them on its
+    // own. A session written once at login is correct for minutes and stale for
+    // good, which is a session that looks persisted and stops restoring.
+    const context = harness();
+    await context.runtime.signIn();
+    await settle();
+
+    context.client().rotateSession(REFRESHED_SESSION);
+    await settle();
+
+    expect(context.storage.storedSession()).toEqual(REFRESHED_SESSION);
+  });
+
+  it('writes rotations one at a time, in the order they arrived', async () => {
+    // Two writes that overlap can finish in either order, and the loser leaves
+    // the older tokens on disk. Rotations arrive from the SDK, which does not
+    // wait for anything.
+    const context = harness();
+    await context.runtime.signIn();
+    await settle();
+    const last: AlloSession = { ...SESSION, accessToken: 'secret-access-token-3' };
+
+    context.storage.holdWrites = true;
+    context.client().rotateSession(REFRESHED_SESSION);
+    await settle();
+    context.client().rotateSession(last);
+    await settle();
+
+    // Three rotations' worth of writes have been asked for; two have started.
+    expect(context.storage.calls.filter((call) => call === 'write')).toHaveLength(2);
+
+    context.storage.holdWrites = false;
+    context.storage.releaseWrites();
+    await settle();
+
+    expect(context.storage.calls.filter((call) => call === 'write')).toHaveLength(3);
+    expect(context.storage.storedSession()).toEqual(last);
+  });
+
+  it('keeps the stored session when a restore fails', async () => {
+    // A homeserver that is down, or a phone opened with no network. Discarding
+    // on the first failure would cost the user the device this whole mechanism
+    // exists to keep.
+    const context = harness({ storage: stored() });
+    context.client().restoreSessionFails = new Error('the homeserver is unreachable');
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.runtime.getState().phase).toBe('failed');
+    expect(context.storage.storedSession()).toEqual(SESSION);
+  });
+
+  it('starts over on an erased store when the user signs in after a failed restore', async () => {
+    // The client has had a session put into it, so it cannot be given another —
+    // and the store under it belongs to the session that could not be reopened.
+    const context = harness({ storage: stored() });
+    context.client().restoreSessionFails = new Error('this session is not valid');
+    context.runtime.subscribe(() => {});
+    await settle();
+    const spent = context.clients[0];
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.createClientCalls).toBe(2);
+    expect(spent?.beginOidcLoginCalls).toBe(0);
+    expect(context.erased).toEqual([STORE]);
+    expect(context.runtime.getState()).toMatchObject({
+      phase: 'ready',
+      userId: '@nate:matrix.example',
+    });
+  });
+
+  it('gives the device back when a sign-in cannot be remembered', async () => {
+    // A session that cannot be written down mints a Matrix device for one run of
+    // the app, and the next launch mints another. Handing it back is the only
+    // ending that does not accumulate them.
+    const context = harness();
+    context.storage.writeFails = new Error('the keychain refused the write');
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.clients[0]?.logouts).toBe(1);
+    expect(context.runtime.getState().phase).toBe('failed');
+    expect(context.runtime.getState().error).toContain('could not remember');
+  });
+
+  it('signs in once across two launches', async () => {
+    // One Matrix device per installation, stated as the thing a user would
+    // notice: the second launch never reaches the browser.
+    const storage = new FakeSessionStorage();
+
+    const first = harness({ storage });
+    await first.runtime.signIn();
+    await settle();
+    await first.runtime.close();
+
+    const second = harness({ storage });
+    second.runtime.subscribe(() => {});
+    await settle();
+
+    expect(first.opened).toHaveLength(1);
+    expect(second.opened).toEqual([]);
+    expect(second.client().restoredWith?.deviceId).toBe('DEVICE');
+    expect(second.runtime.getState().phase).toBe('ready');
+  });
+
+  it('never puts the session in the state it publishes', async () => {
+    // The state is read by components and drawn on screen. The tokens in a
+    // session are credentials.
+    const context = harness();
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(JSON.stringify(context.runtime.getState())).not.toContain('secret-');
+  });
+});
+
+describe('MatrixRuntime sign-out', () => {
+  /** A runtime that has restored a session and is syncing. */
+  async function signedIn(): Promise<Harness> {
+    const context = harness({ storage: stored() });
+    context.runtime.subscribe(() => {});
+    await settle();
+    return context;
+  }
+
+  it('clears the session, tells the homeserver, and comes back signed out', async () => {
+    const context = await signedIn();
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.clients[0]?.logouts).toBe(1);
+    expect(context.storage.value).toBeUndefined();
+    expect(context.runtime.getState()).toMatchObject({
+      phase: 'signed-out',
+      userId: undefined,
+      error: undefined,
+    });
+  });
+
+  it('clears the stored session before it tells the homeserver', async () => {
+    // Interrupted after the clear, the next launch finds no session and erases
+    // the store: clean. Interrupted the other way round it finds a session for a
+    // device the homeserver has already forgotten, and fails to restore it on
+    // every launch from then on.
+    const context = await signedIn();
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.events.indexOf('clear')).toBeLessThan(context.events.indexOf('logout'));
+  });
+
+  it('builds the next client on an erased store', async () => {
+    const context = await signedIn();
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.createClientCalls).toBe(2);
+    expect(context.erased).toEqual([STORE]);
+    expect(context.events.lastIndexOf('eraseStore')).toBeLessThan(
+      context.events.lastIndexOf('createClient'),
+    );
+  });
+
+  it('stops listening to a session it has signed out of', async () => {
+    // A subscription left on the old client would write a dead session back into
+    // storage the next time its SDK rotated the tokens, and the launch after
+    // that would try to restore it.
+    const context = await signedIn();
+    const previous = context.clients[0];
+
+    await context.runtime.signOut();
+    await settle();
+    previous?.rotateSession(REFRESHED_SESSION);
+    await settle();
+
+    expect(previous?.sessionListenerCount()).toBe(0);
+    expect(context.storage.value).toBeUndefined();
+  });
+
+  it('finishes the sign-out when the local teardown fails', async () => {
+    // The store did not go. The rebuild erases it anyway, because there is no
+    // session left for it to belong to.
+    const context = await signedIn();
+    if (context.clients[0] !== undefined) {
+      context.clients[0].logoutFails = new Error('the crypto store would not close');
+    }
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.storage.value).toBeUndefined();
+    expect(context.erased).toEqual([STORE]);
+    expect(context.runtime.getState().phase).toBe('signed-out');
+  });
+
+  it('refuses to sign out when the stored session cannot be cleared', async () => {
+    // Reporting a sign-out while leaving an access token on the device is the
+    // one outcome worse than not signing out.
+    const context = await signedIn();
+    context.storage.clearFails = new Error('the keychain refused');
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.clients[0]?.logouts).toBe(0);
+    expect(context.runtime.getState().phase).toBe('failed');
+    expect(context.runtime.getState().error).toContain('could not forget');
+  });
+
+  it('shares one attempt between simultaneous sign-outs', async () => {
+    // The second would be working on a client the first has already taken apart.
+    const context = await signedIn();
+
+    await Promise.all([context.runtime.signOut(), context.runtime.signOut()]);
+    await settle();
+
+    expect(context.clients[0]?.logouts).toBe(1);
+    expect(context.createClientCalls).toBe(2);
+  });
+
+  it('does nothing when nobody has signed in', async () => {
+    const context = harness();
+
+    await context.runtime.signOut();
+
+    expect(context.storage.calls).toEqual([]);
+    expect(context.runtime.getState().phase).toBe('idle');
   });
 });

--- a/packages/frontend/__tests__/chat/matrixSession.test.ts
+++ b/packages/frontend/__tests__/chat/matrixSession.test.ts
@@ -1,0 +1,152 @@
+import {
+  STORED_SESSION_VERSION,
+  decodeStoredSession,
+  encodeStoredSession,
+} from '@/lib/chat/matrixSession';
+import type { AlloSession } from '@/lib/matrix/types';
+
+/**
+ * The session as it is written down between launches.
+ *
+ * Every case here is a way of reading back something a *different* Allo wrote —
+ * an older version, a build pointed at another homeserver, storage that answered
+ * with something truncated. The rule they all check is the same: a record that
+ * cannot be used in full is refused, never repaired. A half-valid session is not
+ * a session that half works; it is one the SDK accepts and then cannot renew, and
+ * the user meets that as messages that stop arriving rather than as a sign-in
+ * screen.
+ */
+
+const HOMESERVER = 'https://matrix.allo.you';
+
+const SESSION: AlloSession = {
+  userId: '@alice:allo.you',
+  deviceId: 'DEVICE1',
+  homeserverUrl: HOMESERVER,
+  // Distinctive on purpose: one of the cases below checks that no reason a
+  // record is refused for ever quotes one of them.
+  accessToken: 'secret-access-token',
+  refreshToken: 'secret-refresh-token',
+  authData: '{"issuer":"https://account.allo.you/"}',
+};
+
+/** A stored record with one field replaced, as JSON. */
+function record(session: Record<string, unknown>, version: unknown = STORED_SESSION_VERSION): string {
+  return JSON.stringify({ version, session });
+}
+
+describe('encodeStoredSession and decodeStoredSession', () => {
+  it('round-trips a session unchanged', () => {
+    const outcome = decodeStoredSession(encodeStoredSession(SESSION), HOMESERVER);
+
+    expect(outcome).toEqual({ kind: 'session', session: SESSION });
+  });
+
+  it('round-trips a session with no refresh token and no auth data', () => {
+    // A homeserver that issues no refresh token is a homeserver, not a damaged
+    // record. `JSON.stringify` drops the keys entirely, so this is also the check
+    // that reading an absent optional back is not a refusal.
+    const minimal: AlloSession = {
+      ...SESSION,
+      refreshToken: undefined,
+      authData: undefined,
+    };
+
+    expect(decodeStoredSession(encodeStoredSession(minimal), HOMESERVER)).toEqual({
+      kind: 'session',
+      session: minimal,
+    });
+  });
+
+  it('reports nothing stored as absent rather than as a problem', () => {
+    // The ordinary state of a fresh install, and the one case that must not be
+    // logged as a session being abandoned.
+    expect(decodeStoredSession(undefined, HOMESERVER)).toEqual({ kind: 'absent' });
+    expect(decodeStoredSession('', HOMESERVER)).toEqual({ kind: 'absent' });
+  });
+});
+
+describe('decodeStoredSession refusals', () => {
+  /** The reason a record was refused, or a failure if it was not refused. */
+  function refusal(raw: string, homeserverUrl = HOMESERVER): string {
+    const outcome = decodeStoredSession(raw, homeserverUrl);
+    if (outcome.kind !== 'unusable') {
+      throw new Error(`expected a refusal, got ${outcome.kind}`);
+    }
+    return outcome.reason;
+  }
+
+  it('refuses something that is not JSON', () => {
+    expect(refusal('not json at all')).toContain('not JSON');
+  });
+
+  it('refuses JSON that is not an object', () => {
+    expect(refusal('"a string"')).toContain('not an object');
+    expect(refusal('null')).toContain('not an object');
+  });
+
+  it('refuses a version it did not write', () => {
+    // Guessing at an older shape ends in a client that believes it has a session
+    // and cannot refresh it. The cost of refusing is one sign-in.
+    expect(refusal(record({ ...SESSION }, STORED_SESSION_VERSION + 1))).toContain(
+      String(STORED_SESSION_VERSION + 1),
+    );
+    // Written by something that carried no version at all.
+    expect(refusal(JSON.stringify({ session: SESSION }))).toContain('version');
+  });
+
+  it('refuses a record with no session in it', () => {
+    expect(refusal(JSON.stringify({ version: STORED_SESSION_VERSION }))).toContain(
+      'no session',
+    );
+  });
+
+  it('names the field that is missing', () => {
+    expect(refusal(record({ ...SESSION, userId: undefined }))).toContain('no user');
+    expect(refusal(record({ ...SESSION, deviceId: undefined }))).toContain('no device');
+    expect(refusal(record({ ...SESSION, homeserverUrl: undefined }))).toContain(
+      'no homeserver',
+    );
+    expect(refusal(record({ ...SESSION, accessToken: undefined }))).toContain(
+      'no access token',
+    );
+  });
+
+  it('treats an empty string as a missing field', () => {
+    // An empty device id is not a device. It would restore into a client whose
+    // encryption keys hang off nothing.
+    expect(refusal(record({ ...SESSION, deviceId: '' }))).toContain('no device');
+  });
+
+  it('refuses an optional field that is not a string', () => {
+    // Absent is a homeserver that issues no refresh token; a number is a damaged
+    // record, and the two must not be confused.
+    expect(refusal(record({ ...SESSION, refreshToken: 42 }))).toContain('refresh token');
+    expect(refusal(record({ ...SESSION, authData: { issuer: 'x' } }))).toContain(
+      'authentication data',
+    );
+  });
+
+  it('refuses a session issued by another homeserver, and names both', () => {
+    // A build repointed elsewhere. The device id in this session was never issued
+    // by the homeserver this build talks to.
+    const reason = refusal(encodeStoredSession(SESSION), 'https://elsewhere.example');
+
+    expect(reason).toContain(HOMESERVER);
+    expect(reason).toContain('https://elsewhere.example');
+  });
+
+  it('never quotes a credential in the reason it gives', () => {
+    // Reasons are logged. The tokens in a session are not.
+    const reasons = [
+      refusal(record({ ...SESSION, userId: undefined })),
+      refusal(record({ ...SESSION, refreshToken: 42 })),
+      refusal(encodeStoredSession(SESSION), 'https://elsewhere.example'),
+    ];
+
+    for (const reason of reasons) {
+      expect(reason).not.toContain('secret-');
+      expect(reason).not.toContain('account.allo.you');
+    }
+  });
+});

--- a/packages/frontend/__tests__/chat/roomListSource.test.ts
+++ b/packages/frontend/__tests__/chat/roomListSource.test.ts
@@ -108,6 +108,14 @@ class FakeChatClient implements AlloChatClient {
     throw new Error('not used by these tests');
   }
 
+  observeSession(): AlloUnsubscribe {
+    throw new Error('not used by these tests');
+  }
+
+  async logout(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
   async startSync(): Promise<void> {
     throw new Error('not used by these tests');
   }

--- a/packages/frontend/__tests__/chat/timelineSource.test.ts
+++ b/packages/frontend/__tests__/chat/timelineSource.test.ts
@@ -136,6 +136,14 @@ class FakeChatClient implements AlloChatClient {
     throw new Error('not used by these tests');
   }
 
+  observeSession(): AlloUnsubscribe {
+    throw new Error('not used by these tests');
+  }
+
+  async logout(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
   async startSync(): Promise<void> {
     throw new Error('not used by these tests');
   }

--- a/packages/frontend/__tests__/matrix/session.test.ts
+++ b/packages/frontend/__tests__/matrix/session.test.ts
@@ -8,6 +8,10 @@ import { toAlloSession } from '@/lib/matrix/native/session';
  * beside it, runs under any test runner: the authentication path depends only on
  * this and on the port's own types, so proving it does not require loading a
  * native module that a test process cannot load.
+ *
+ * The delegate in the same module is exercised in `sessionDelegate.test.ts`,
+ * which needs the binding's `SlidingSyncVersion` to build a `Session` and
+ * therefore needs the stub.
  */
 
 describe('toAlloSession', () => {

--- a/packages/frontend/__tests__/matrix/sessionDelegate.test.ts
+++ b/packages/frontend/__tests__/matrix/sessionDelegate.test.ts
@@ -1,0 +1,152 @@
+import { SlidingSyncVersion } from '@unomed/react-native-matrix-sdk';
+import type { Session } from '@unomed/react-native-matrix-sdk';
+
+import { MatrixPortError } from '@/lib/matrix/errors';
+import { NativeSessionDelegate } from '@/lib/matrix/native/session';
+import type { AlloSession } from '@/lib/matrix/types';
+
+jest.mock('@unomed/react-native-matrix-sdk');
+
+/**
+ * The binding's only way of telling the app that the session has changed.
+ *
+ * It is not shaped like an observer — it is a delegate handed to the builder
+ * before the client exists — and everything asserted here is about turning that
+ * into something the app can subscribe to without letting the SDK's constraints
+ * leak: the callbacks are synchronous, they come from Rust's thread, and one of
+ * them is on the path a token refresh takes.
+ */
+
+const SESSION: Session = {
+  userId: '@alice:allo.you',
+  deviceId: 'DEVICE1',
+  homeserverUrl: 'https://matrix.allo.you',
+  accessToken: 'secret-access-token',
+  refreshToken: 'secret-refresh-token',
+  oidcData: '{"issuer":"https://account.allo.you/"}',
+  slidingSyncVersion: SlidingSyncVersion.Native,
+};
+
+const REFRESHED: Session = {
+  ...SESSION,
+  accessToken: 'secret-access-token-2',
+  refreshToken: 'secret-refresh-token-2',
+};
+
+/** A client that answers with one session, as the binding's would. */
+function reader(session: Session = SESSION): { session(): Session } {
+  return { session: () => session };
+}
+
+describe('NativeSessionDelegate observing', () => {
+  it('reports a saved session to every listener, translated', () => {
+    const delegate = new NativeSessionDelegate();
+    const seen: AlloSession[] = [];
+    delegate.observe((session) => seen.push(session));
+    delegate.observe((session) => seen.push(session));
+
+    delegate.saveSessionInKeychain(REFRESHED);
+
+    // Translated, not the SDK's record: `oidcData` has become the port's opaque
+    // `authData` and `slidingSyncVersion` has been left behind, because it is a
+    // property of how this client was built and not of the session.
+    expect(seen).toEqual([
+      {
+        userId: '@alice:allo.you',
+        deviceId: 'DEVICE1',
+        homeserverUrl: 'https://matrix.allo.you',
+        accessToken: 'secret-access-token-2',
+        refreshToken: 'secret-refresh-token-2',
+        authData: '{"issuer":"https://account.allo.you/"}',
+      },
+      expect.anything(),
+    ]);
+    expect(seen).toHaveLength(2);
+  });
+
+  it('stops reporting to a listener that has unsubscribed', () => {
+    const delegate = new NativeSessionDelegate();
+    let calls = 0;
+    const unsubscribe = delegate.observe(() => {
+      calls += 1;
+    });
+
+    unsubscribe();
+    delegate.saveSessionInKeychain(REFRESHED);
+
+    expect(calls).toBe(0);
+  });
+
+  it('reports nothing until the SDK saves something', () => {
+    // Changes only. The session a login produced is that call's own result, and
+    // replaying it here would make a subscriber unable to tell a rotation from
+    // its own sign-in.
+    const delegate = new NativeSessionDelegate();
+    let calls = 0;
+
+    delegate.observe(() => {
+      calls += 1;
+    });
+
+    expect(calls).toBe(0);
+  });
+
+  it('carries on when a listener throws', () => {
+    // This is the SDK's token refresh path, called synchronously from Rust. A
+    // listener that failed must not become a refresh that failed, and must not
+    // stop the listener queued behind it.
+    const delegate = new NativeSessionDelegate();
+    const seen: string[] = [];
+    delegate.observe(() => {
+      throw new Error('the keychain refused');
+    });
+    delegate.observe((session) => seen.push(session.accessToken));
+
+    expect(() => delegate.saveSessionInKeychain(REFRESHED)).not.toThrow();
+    expect(seen).toEqual(['secret-access-token-2']);
+  });
+});
+
+describe('NativeSessionDelegate answering the SDK', () => {
+  it('answers with the session the client is holding', () => {
+    // Read from the client rather than from storage, which is not what the SDK's
+    // name for it suggests: a copy out of the keychain could be older than what
+    // the client already has.
+    const delegate = new NativeSessionDelegate();
+    delegate.bind(reader());
+
+    expect(delegate.retrieveSessionFromKeychain('@alice:allo.you')).toEqual(SESSION);
+  });
+
+  it('refuses before it has a client to read', () => {
+    const delegate = new NativeSessionDelegate();
+
+    expect(() => delegate.retrieveSessionFromKeychain('@alice:allo.you')).toThrow(
+      MatrixPortError,
+    );
+  });
+
+  it('refuses to answer for a user this client is not', () => {
+    // A client holds one user's session. Being asked for another one means the
+    // SDK and this delegate disagree about which client this is, and answering
+    // anyway would hand the SDK the wrong credentials.
+    const delegate = new NativeSessionDelegate();
+    delegate.bind(reader());
+
+    expect(() => delegate.retrieveSessionFromKeychain('@bob:allo.you')).toThrow(
+      /@bob:allo\.you/,
+    );
+  });
+
+  it('follows the client rather than remembering an answer', () => {
+    // The client is the authority on its own session, so a rotation the delegate
+    // was never told about is still answered correctly.
+    let current = SESSION;
+    const delegate = new NativeSessionDelegate();
+    delegate.bind({ session: () => current });
+
+    current = REFRESHED;
+
+    expect(delegate.retrieveSessionFromKeychain('@alice:allo.you')).toEqual(REFRESHED);
+  });
+});

--- a/packages/frontend/__tests__/matrix/sessionDelegate.test.ts
+++ b/packages/frontend/__tests__/matrix/sessionDelegate.test.ts
@@ -91,6 +91,22 @@ describe('NativeSessionDelegate observing', () => {
     expect(calls).toBe(0);
   });
 
+  it('reports nothing once its client has been closed', () => {
+    // Rust holds the delegate, so it outlives the client it was built for. A
+    // listener left on it would keep being told about a session the client no
+    // longer has.
+    const delegate = new NativeSessionDelegate();
+    let calls = 0;
+    delegate.observe(() => {
+      calls += 1;
+    });
+
+    delegate.releaseObservers();
+    delegate.saveSessionInKeychain(REFRESHED);
+
+    expect(calls).toBe(0);
+  });
+
   it('carries on when a listener throws', () => {
     // This is the SDK's token refresh path, called synchronously from Rust. A
     // listener that failed must not become a refresh that failed, and must not

--- a/packages/frontend/__tests__/matrix/web/store.test.ts
+++ b/packages/frontend/__tests__/matrix/web/store.test.ts
@@ -1,0 +1,177 @@
+import { MatrixPortError } from '@/lib/matrix/errors';
+import {
+  cryptoDatabasePrefix,
+  eraseWebStore,
+  resolveAlloChatStore,
+  syncDatabaseName,
+} from '@/lib/matrix/store.web';
+import type { AlloClientStore } from '@/lib/matrix/types';
+
+/**
+ * Where the web client keeps its data, and what erasing it has to reach.
+ *
+ * The names are the whole subject. `clearStores` and `initRustCrypto` are given
+ * a prefix each and neither one checks the other's: given the wrong name the SDK
+ * deletes nothing, reports success, and leaves a device's encryption keys in the
+ * browser. So the names are built in one place and asserted here against the
+ * strings the SDK actually derives from them.
+ */
+
+const STORE: AlloClientStore = {
+  kind: 'filesystem',
+  dataPath: 'allo-matrix',
+  cachePath: 'allo-matrix',
+};
+
+/** An `IDBFactory` that records deletions instead of performing them. */
+class FakeIndexedDB {
+  readonly deleted: string[] = [];
+  readonly present: string[] = [];
+  /** Databases that answer with an error, as a private window's do. */
+  refuse = new Set<string>();
+  /** Whether this browser offers `databases()` at all. */
+  listable = true;
+
+  deleteDatabase(name: string): IDBOpenDBRequest {
+    const request: Record<string, unknown> = { error: new Error('refused') };
+    queueMicrotask(() => {
+      if (this.refuse.has(name)) {
+        callHandler(request.onerror);
+        return;
+      }
+      this.deleted.push(name);
+      callHandler(request.onsuccess);
+    });
+    return request as unknown as IDBOpenDBRequest;
+  }
+
+  databases(): Promise<IDBDatabaseInfo[]> {
+    return Promise.resolve(this.present.map((name) => ({ name, version: 1 })));
+  }
+
+  /** The shape of a browser without `databases()`. */
+  factory(): IDBFactory {
+    const self: Record<string, unknown> = {
+      deleteDatabase: (name: string) => this.deleteDatabase(name),
+    };
+    if (this.listable) {
+      self.databases = () => this.databases();
+    }
+    return self as unknown as IDBFactory;
+  }
+}
+
+function callHandler(handler: unknown): void {
+  if (typeof handler === 'function') {
+    handler(new Event('done'));
+  }
+}
+
+describe('the web store’s names', () => {
+  it('names the same database matrix-js-sdk will', () => {
+    // The SDK puts `matrix-js-sdk:` in front of the name it is given, and the
+    // eraser has to name the database rather than the store.
+    expect(syncDatabaseName('allo-matrix')).toBe('matrix-js-sdk:allo-matrix');
+  });
+
+  it('keys the crypto databases by device', () => {
+    // A crypto store belongs to exactly one device. A fresh install that
+    // inherited the last one would hold keys for an identity the homeserver has
+    // never heard of.
+    expect(cryptoDatabasePrefix('allo-matrix', 'DEVICE1')).toBe('allo-matrix:DEVICE1');
+    expect(cryptoDatabasePrefix('allo-matrix', 'DEVICE2')).not.toBe(
+      cryptoDatabasePrefix('allo-matrix', 'DEVICE1'),
+    );
+  });
+
+  it('resolves a store on disk, not one in memory', () => {
+    // A store in memory throws the device identity away when the tab closes,
+    // which is the every-launch-is-a-new-device behaviour this replaced.
+    expect(resolveAlloChatStore().kind).toBe('filesystem');
+  });
+});
+
+describe('eraseWebStore', () => {
+  it('deletes the synced state, which is the one a new session would inherit', async () => {
+    const indexedDB = new FakeIndexedDB();
+
+    await eraseWebStore(STORE, indexedDB.factory());
+
+    expect(indexedDB.deleted).toContain('matrix-js-sdk:allo-matrix');
+  });
+
+  it('deletes the crypto databases of every device that left one', async () => {
+    // Not correctness — a crypto database is named after its device and cannot
+    // be opened by the session that comes next — but storage that would
+    // otherwise never be reclaimed.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.present.push(
+      'allo-matrix:DEVICE1::matrix-sdk-crypto',
+      'allo-matrix:DEVICE1::matrix-sdk-crypto-meta',
+      'allo-matrix:DEVICE2::matrix-sdk-crypto',
+    );
+
+    await eraseWebStore(STORE, indexedDB.factory());
+
+    expect(indexedDB.deleted).toEqual(
+      expect.arrayContaining([
+        'allo-matrix:DEVICE1::matrix-sdk-crypto',
+        'allo-matrix:DEVICE1::matrix-sdk-crypto-meta',
+        'allo-matrix:DEVICE2::matrix-sdk-crypto',
+      ]),
+    );
+  });
+
+  it('leaves databases that are not this store’s alone', async () => {
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.present.push(
+      'someone-else:DEVICE1::matrix-sdk-crypto',
+      'allo-matrix:DEVICE1::something-else',
+      'matrix-js-sdk:another-store',
+    );
+
+    await eraseWebStore(STORE, indexedDB.factory());
+
+    expect(indexedDB.deleted).toEqual(['matrix-js-sdk:allo-matrix']);
+  });
+
+  it('still deletes the synced state in a browser with no databases()', async () => {
+    // Firefox before 126. The leftovers cannot be found, which costs storage —
+    // the one that matters for correctness is named without asking the browser
+    // anything.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.listable = false;
+    indexedDB.present.push('allo-matrix:DEVICE1::matrix-sdk-crypto');
+
+    await eraseWebStore(STORE, indexedDB.factory());
+
+    expect(indexedDB.deleted).toEqual(['matrix-js-sdk:allo-matrix']);
+  });
+
+  it('carries on past a database it is refused', async () => {
+    // A private window can have an `indexedDB` that refuses every mutation,
+    // including deleting a database that is not there. Stopping would leave the
+    // rest behind.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.present.push('allo-matrix:DEVICE1::matrix-sdk-crypto');
+    indexedDB.refuse.add('matrix-js-sdk:allo-matrix');
+
+    await eraseWebStore(STORE, indexedDB.factory());
+
+    expect(indexedDB.deleted).toEqual(['allo-matrix:DEVICE1::matrix-sdk-crypto']);
+  });
+
+  it('does nothing for a store that was never on disk', async () => {
+    const indexedDB = new FakeIndexedDB();
+
+    await eraseWebStore({ kind: 'in-memory' }, indexedDB.factory());
+
+    expect(indexedDB.deleted).toEqual([]);
+  });
+
+  it('refuses a browser with no IndexedDB rather than reporting an erased store', async () => {
+    // Reporting success would let the client open a store this could not have
+    // cleared.
+    await expect(eraseWebStore(STORE, undefined)).rejects.toThrow(MatrixPortError);
+  });
+});

--- a/packages/frontend/app/(chat)/settings/index.tsx
+++ b/packages/frontend/app/(chat)/settings/index.tsx
@@ -18,6 +18,7 @@ import { confirmDialog, alertDialog } from "@/utils/alerts";
 import { getData, storeData } from "@/utils/storage";
 // (already imported above)
 import { hasNotificationPermission, requestNotificationPermissions, getDevicePushToken } from "@/utils/notifications";
+import { signOutOfMatrix } from "@/hooks/useMatrixRuntime";
 import { useTheme } from "@/hooks/useTheme";
 import { getThemedBorder, getThemedShadow } from "@/utils/theme";
 import { useAppearanceStore } from "@/stores/appearanceStore";
@@ -255,7 +256,10 @@ export default function SettingsScreen() {
             destructive: true,
         });
         if (!confirmed) return;
-        // For now, just navigate back - the actual sign out would depend on your auth system
+        // Ends the Matrix session — on the homeserver, and everywhere it was kept
+        // on this device. Does nothing in a build talking to the Allo API, where
+        // the account is Oxy's and signing out of it is not this screen's to do.
+        await signOutOfMatrix();
         router.replace('/');
     };
 

--- a/packages/frontend/hooks/useMatrixRuntime.ts
+++ b/packages/frontend/hooks/useMatrixRuntime.ts
@@ -42,3 +42,23 @@ export function signInToMatrix(): void {
   // reads, so there is nothing for a caller to catch.
   void matrixRuntime.signIn();
 }
+
+/**
+ * Ends the session: on the homeserver, and everywhere it was kept on this
+ * device.
+ *
+ * Awaitable, unlike {@link signInToMatrix}, because a caller usually has
+ * something to do afterwards — navigating away from screens that were drawing a
+ * conversation the app no longer has. It does not reject: the runtime reports
+ * what went wrong through the state this module's hook reads, the same way a
+ * sign-in does.
+ *
+ * With the backend set to `allo-api` this resolves without doing anything, which
+ * is what lets a screen call it unconditionally.
+ */
+export async function signOutOfMatrix(): Promise<void> {
+  if (!enabled) {
+    return;
+  }
+  await matrixRuntime.signOut();
+}

--- a/packages/frontend/lib/chat/matrixConfig.ts
+++ b/packages/frontend/lib/chat/matrixConfig.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import * as Linking from 'expo-linking';
 
+import { resolveAlloChatStore } from '@/lib/matrix/store';
 import type { AlloChatClientConfig, AlloOidcClientMetadata } from '@/lib/matrix/types';
 
 /**
@@ -96,21 +97,21 @@ export function readOidcMetadata(
 /**
  * The configuration the port is built with.
  *
- * The store is in memory, and that is a decision rather than an oversight. A
- * filesystem store keeps a device's encryption keys across launches, which is
- * only worth anything if the *session* survives too — and it does not: the port
- * documents that a persisted session goes stale, because the SDK rotates its
- * tokens without telling the app (`lib/matrix/types.ts`, `AlloSession`). Until
- * that gap is closed, every launch is a new login and therefore a new Matrix
- * device, and a crypto store on disk would only accumulate the keys of devices
- * nothing will ever use again.
+ * The store is on disk, which is what makes an installation one Matrix device
+ * rather than one per launch. It only became worth having once the session
+ * survived too: a device's encryption keys are useless without the session that
+ * names the device, so before sessions were persisted a store on disk would have
+ * accumulated the keys of devices nothing would ever use again. Where "on disk"
+ * is — two directories, or an IndexedDB database — is `lib/matrix/store.*.ts`'s
+ * to decide, because it is the one thing here that is not the same question on
+ * both platforms.
  */
 export function readMatrixClientConfig(): AlloChatClientConfig {
   const homeserverUrl = readHomeserverUrl(process.env.EXPO_PUBLIC_MATRIX_HOMESERVER);
   const redirectUri = resolveRedirectUri(process.env.EXPO_PUBLIC_MATRIX_OIDC_REDIRECT_URI);
   return {
     homeserverUrl,
-    store: { kind: 'in-memory' },
+    store: resolveAlloChatStore(),
     oidc: readOidcMetadata(
       homeserverUrl,
       process.env.EXPO_PUBLIC_MATRIX_OIDC_CLIENT_ID,

--- a/packages/frontend/lib/chat/matrixRuntime.ts
+++ b/packages/frontend/lib/chat/matrixRuntime.ts
@@ -1,16 +1,21 @@
 import * as WebBrowser from 'expo-web-browser';
 
+import { eraseAlloChatStore } from '@/lib/matrix/store';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
   AlloChatClientFactory,
+  AlloChatStoreEraser,
   AlloOidcLoginRequest,
+  AlloSession,
   AlloSyncState,
   AlloUnsubscribe,
 } from '@/lib/matrix/types';
 import { logger } from '@/utils/logger';
 
 import { readMatrixClientConfig } from './matrixConfig';
+import { decodeStoredSession, encodeStoredSession } from './matrixSession';
+import { matrixSessionStorage, type MatrixSessionStorage } from './matrixSessionStorage';
 
 /**
  * The one Matrix client the app has, and its lifecycle.
@@ -25,13 +30,35 @@ import { readMatrixClientConfig } from './matrixConfig';
  * So the client is owned here, at module scope, and React reads it through
  * {@link MatrixRuntime.subscribe} and {@link MatrixRuntime.getState} — the shape
  * `useSyncExternalStore` wants. No Effect anywhere in the chain.
+ *
+ * ## One Matrix device per installation
+ *
+ * The rule this class exists to keep. A Matrix device is minted by a login and
+ * is what a set of encryption keys hangs off; an app that logs in on every launch
+ * fills the user's account with devices that can never be verified and can never
+ * read each other's history. So a session is written down and reinstated, and the
+ * two facts that make that work are both here:
+ *
+ * - **the stored session is the authority.** The client's store on disk belongs
+ *   to the session in storage and to no other. A launch that finds no session
+ *   erases the store before opening it, which is what makes every way of losing a
+ *   session — a sign-out, a crash halfway through one, a record from an older
+ *   Allo — end in the same clean state instead of in a client holding one
+ *   session's tokens and another one's keys.
+ * - **the session is not a snapshot.** The SDK rotates its tokens on its own, so
+ *   what was written at login is stale within the hour;
+ *   `AlloChatClient.observeSession` is subscribed to for exactly as long as the
+ *   client lives, and every version it reports is written down.
  */
 
 /** How far along the runtime is. */
 export type MatrixPhase =
   /** Nothing has asked for a client yet. */
   | 'idle'
-  /** Building the client: loading the SDK, opening its stores. */
+  /**
+   * Building the client: loading the SDK, opening its stores, and reinstating
+   * the session of a previous launch if there is one.
+   */
   | 'starting'
   /** There is a client, and nobody has signed in. */
   | 'signed-out'
@@ -70,6 +97,15 @@ export type AuthorizationOutcome =
 export interface MatrixRuntimeDependencies {
   readonly config: () => AlloChatClientConfig;
   readonly createClient: AlloChatClientFactory;
+  /**
+   * Deletes what a previous session left in the client's store.
+   *
+   * Separate from the client because it has to run when there is no client: a
+   * store that outlived its session has to go *before* the next one opens it.
+   */
+  readonly eraseStore: AlloChatStoreEraser;
+  /** Where the session is kept between launches. */
+  readonly sessionStorage: MatrixSessionStorage;
   /**
    * Opens the authorization page and reports the URL the browser was redirected
    * back to. The middle of OIDC's three steps, which the port deliberately does
@@ -123,7 +159,30 @@ export class MatrixRuntime implements MatrixRuntimeLike {
   #config: AlloChatClientConfig | undefined;
   #starting: Promise<AlloChatClient | undefined> | undefined;
   #signingIn: Promise<void> | undefined;
+  #signingOut: Promise<void> | undefined;
   #syncSubscription: AlloUnsubscribe | undefined;
+  #sessionSubscription: AlloUnsubscribe | undefined;
+  /**
+   * Whether a session has been installed in the current client, or the attempt
+   * has been made.
+   *
+   * "Or the attempt" is the point: a restore that failed halfway leaves a client
+   * whose state nobody here can describe, and the port refuses a second session
+   * on a client that already has one. Either way this client cannot be the one a
+   * new login goes through, so a sign-in from here starts over with a fresh one.
+   */
+  #clientHoldsSession = false;
+  /**
+   * The tail of the queue of storage operations.
+   *
+   * Storage is written from two directions that do not coordinate — a sign-in or
+   * sign-out the user asked for, and a token rotation the SDK did on its own —
+   * and a write is not one indivisible step. Two that overlap can finish in
+   * either order, and the loser leaves the older tokens behind. This is by
+   * construction a promise that never rejects, so a failed write cannot break the
+   * queue for the next one.
+   */
+  #storageQueue: Promise<void> = Promise.resolve();
 
   constructor(dependencies: MatrixRuntimeDependencies) {
     this.#dependencies = dependencies;
@@ -179,10 +238,35 @@ export class MatrixRuntime implements MatrixRuntimeLike {
     return this.#signingIn;
   }
 
+  /**
+   * Signs out: on the homeserver, from this device, and from storage.
+   *
+   * Concurrent calls share one attempt, for the same reason sign-ins do — the
+   * second would be working on a client the first has already taken apart.
+   */
+  signOut(): Promise<void> {
+    if (this.#signingOut === undefined) {
+      this.#signingOut = this.#signOut().finally(() => {
+        this.#signingOut = undefined;
+      });
+    }
+    return this.#signingOut;
+  }
+
   async #signIn(): Promise<void> {
-    const client = await this.#ensureClient();
+    let client = await this.#ensureClient();
     if (client === undefined || this.#state.phase === 'ready') {
       return;
+    }
+    if (this.#clientHoldsSession) {
+      // A client that has already had a session put into it — a restore that
+      // failed is the way this happens — cannot be given a second one. Starting
+      // over also erases the store, which is right: the session it belongs to is
+      // one this launch could not use.
+      client = await this.#startOver();
+      if (client === undefined) {
+        return;
+      }
     }
     const config = this.#config;
     if (config === undefined) {
@@ -219,14 +303,96 @@ export class MatrixRuntime implements MatrixRuntimeLike {
       return;
     }
 
+    let session: AlloSession;
     try {
       // The callback URL carries the authorization code, so it is never logged.
-      const session = await request.complete(outcome.callbackUrl);
+      session = await request.complete(outcome.callbackUrl);
+      this.#clientHoldsSession = true;
+    } catch (error) {
+      this.#fail('Allo could not finish the sign-in', error);
+      return;
+    }
+
+    try {
+      // Written down before sync starts, and before anything is drawn. The
+      // Matrix device exists on the homeserver the moment the line above
+      // returned; from here until the session is stored there is a device this
+      // installation would not recognise on its next launch, and the way to make
+      // that window not matter is to make it as short as the code allows.
+      await this.#remember(session);
+    } catch (error) {
+      // A sign-in that cannot be remembered is a device minted for one run of the
+      // app, and the next launch would mint another. Better to give the device
+      // back and say so than to accumulate them silently.
+      await this.#signOut();
+      this.#fail('Allo signed you in but could not remember it', error);
+      return;
+    }
+
+    try {
       await client.startSync();
       this.#publish({ phase: 'ready', userId: session.userId, error: undefined });
     } catch (error) {
       this.#fail('Allo could not finish the sign-in', error);
     }
+  }
+
+  async #signOut(): Promise<void> {
+    const client = this.#client;
+    if (client === undefined) {
+      return;
+    }
+
+    // The stored session goes first, and everything else is allowed to fail
+    // afterwards. The worst state this can be interrupted in is a store with no
+    // session, which the next launch erases before it opens anything — where the
+    // reverse order's worst state is a session pointing at a device the
+    // homeserver has already forgotten.
+    try {
+      await this.#forget();
+    } catch (error) {
+      // Refusing to go on is the honest answer: carrying on would report a
+      // sign-out while leaving the user's access token on the device.
+      this.#fail('Allo could not forget your session', error);
+      return;
+    }
+    this.#publish({ phase: 'starting', userId: undefined, error: undefined });
+
+    try {
+      await client.logout();
+    } catch (error) {
+      // The port's `logout` reports an unreachable homeserver by logging, so a
+      // throw here is local: the store did not go. Not fatal, because rebuilding
+      // erases it — there is no session left for it to belong to.
+      logger.error('[chat] a Matrix sign-out did not finish cleanly', error);
+    }
+
+    // Already closed by `logout`, but detaching is what drops the subscriptions
+    // and lets the next `#ensureClient` build rather than hand back this one.
+    this.#detach();
+    await this.#ensureClient();
+  }
+
+  /**
+   * Throws away the current client and everything it was working with, and comes
+   * back with a new one on an empty store.
+   *
+   * The homeserver is not told, which is what separates this from
+   * {@link signOut}: it is used when there is no usable session to end, only a
+   * client that cannot be reused.
+   */
+  async #startOver(): Promise<AlloChatClient | undefined> {
+    try {
+      await this.#forget();
+    } catch (error) {
+      this.#fail('Allo could not clear the session it could not reopen', error);
+      return undefined;
+    }
+    const previous = this.#detach();
+    // Closed before the rebuild, because the rebuild erases the store and the
+    // client that was holding it open is this one.
+    await previous?.close();
+    return this.#ensureClient();
   }
 
   async #ensureClient(): Promise<AlloChatClient | undefined> {
@@ -243,13 +409,34 @@ export class MatrixRuntime implements MatrixRuntimeLike {
   async #build(): Promise<AlloChatClient | undefined> {
     try {
       const config = this.#dependencies.config();
+      const stored = await this.#readStoredSession(config.homeserverUrl);
+
+      if (stored === undefined) {
+        // Nothing is being restored, so nothing on disk belongs to this launch.
+        // What may be there is the store of a session that is gone — a sign-out
+        // the app did not live long enough to finish, a record written by an
+        // Allo that stored them differently — and the SDKs' stores hold one user
+        // each. Erasing here is what makes every one of those endings look the
+        // same to the client that opens next.
+        await this.#dependencies.eraseStore(config.store);
+      }
+
       const client = await this.#dependencies.createClient(config);
       this.#config = config;
       this.#client = client;
       this.#syncSubscription = client.observeSyncState((sync) => {
         this.#publish({ sync });
       });
-      this.#publish({ phase: 'signed-out', error: undefined });
+      // Subscribed before anything can rotate: for as long as this client lives,
+      // every version of its session is written down. See the note at the top of
+      // this file.
+      this.#sessionSubscription = client.observeSession(this.#onSessionRotated);
+
+      if (stored === undefined) {
+        this.#publish({ phase: 'signed-out', error: undefined });
+      } else {
+        await this.#restore(client, stored);
+      }
       return client;
     } catch (error) {
       // Cleared so that the next attempt — a user pressing sign in again —
@@ -258,6 +445,103 @@ export class MatrixRuntime implements MatrixRuntimeLike {
       this.#fail('Allo could not start its Matrix client', error);
       return undefined;
     }
+  }
+
+  /**
+   * Puts a stored session back into a fresh client and starts syncing.
+   *
+   * A failure here is reported and the stored session is **kept**. The reasons a
+   * restore fails are not all permanent — a homeserver that is down, a phone with
+   * no network at the moment it was opened — and discarding on the first one
+   * would cost the user the device this whole mechanism exists to preserve. What
+   * discards it is the user asking to sign in again, which is an answer only they
+   * can give.
+   */
+  async #restore(client: AlloChatClient, session: AlloSession): Promise<void> {
+    this.#clientHoldsSession = true;
+    try {
+      await client.restoreSession(session);
+      await client.startSync();
+    } catch (error) {
+      this.#fail('Allo could not reopen your last session', error);
+      return;
+    }
+    this.#publish({ phase: 'ready', userId: session.userId, error: undefined });
+  }
+
+  /**
+   * The session of a previous launch, if there is one this build can use.
+   *
+   * A record that cannot be used is removed rather than left to be rediscovered
+   * and re-refused on every launch, and the reason is logged once — it names a
+   * device whose keys are being abandoned, which is worth knowing about.
+   */
+  async #readStoredSession(homeserverUrl: string): Promise<AlloSession | undefined> {
+    const stored = await this.#dependencies.sessionStorage.read();
+    const outcome = decodeStoredSession(stored, homeserverUrl);
+    if (outcome.kind === 'session') {
+      return outcome.session;
+    }
+    if (outcome.kind === 'unusable') {
+      logger.warn(`[chat] the stored Matrix session was not reinstated: ${outcome.reason}`);
+      await this.#forget();
+    }
+    return undefined;
+  }
+
+  /**
+   * The SDK has replaced the session's tokens.
+   *
+   * Not awaited, and that is not laziness: the port reports this from inside the
+   * SDK's own refresh, on native synchronously from Rust's thread, and anything
+   * that blocked here would block the refresh. A write that fails is logged and
+   * costs the next launch one extra refresh, because what is still stored is the
+   * previous session and the refresh token in it has not been used yet.
+   */
+  readonly #onSessionRotated = (session: AlloSession): void => {
+    void this.#remember(session).catch((error) => {
+      logger.error('[chat] a refreshed Matrix session could not be stored', error);
+    });
+  };
+
+  #remember(session: AlloSession): Promise<void> {
+    return this.#sequence(() =>
+      this.#dependencies.sessionStorage.write(encodeStoredSession(session)),
+    );
+  }
+
+  #forget(): Promise<void> {
+    return this.#sequence(() => this.#dependencies.sessionStorage.clear());
+  }
+
+  /** Runs one storage operation after the last, and reports its own failure. */
+  #sequence(operation: () => Promise<void>): Promise<void> {
+    const done = this.#storageQueue.then(operation);
+    // The queue itself must never reject: a failure belongs to the caller that
+    // asked for it, and the operation queued behind still has to run.
+    this.#storageQueue = done.then(ignoreOutcome, ignoreOutcome);
+    return done;
+  }
+
+  /**
+   * Lets go of the current client, and hands it back for the caller to close.
+   *
+   * Closing is the caller's because the two callers want it at different moments:
+   * a sign-out has already closed the client through `logout`, and starting over
+   * has to wait for the close before the store underneath can be erased.
+   */
+  #detach(): AlloChatClient | undefined {
+    this.#syncSubscription?.();
+    this.#syncSubscription = undefined;
+    this.#sessionSubscription?.();
+    this.#sessionSubscription = undefined;
+    this.#clientHoldsSession = false;
+
+    const client = this.#client;
+    this.#client = undefined;
+    this.#config = undefined;
+    this.#starting = undefined;
+    return client;
   }
 
   async #abort(request: AlloOidcLoginRequest): Promise<void> {
@@ -302,20 +586,21 @@ export class MatrixRuntime implements MatrixRuntimeLike {
   }
 
   /**
-   * Tears everything down. Tests use it; the app has no sign-out yet, which is
-   * the same missing piece as session persistence — see `matrixConfig.ts`.
+   * Tears everything down, leaving the stored session where it is.
+   *
+   * Not a sign-out and not a way to reach one: it releases the client and goes
+   * back to the state before anything asked for one, which is what a test wants
+   * between cases. {@link signOut} is what ends a session.
    */
   async close(): Promise<void> {
-    this.#syncSubscription?.();
-    this.#syncSubscription = undefined;
-    const client = this.#client;
-    this.#client = undefined;
-    this.#config = undefined;
-    this.#starting = undefined;
+    const client = this.#detach();
     this.#publish(IDLE_RUNTIME_STATE);
     await client?.close();
   }
 }
+
+/** Turns a settled promise into a settled promise with nothing in it. */
+const ignoreOutcome = (): void => {};
 
 /**
  * How the runtime reaches the world when it is not under test.
@@ -332,6 +617,10 @@ const defaultDependencies: MatrixRuntimeDependencies = {
     const { createAlloChatClient } = await import('@/lib/matrix/client');
     return createAlloChatClient(config);
   },
+  // Not behind the dynamic import, and it does not need to be: the store modules
+  // name directories and databases, and neither of them loads a Matrix SDK.
+  eraseStore: eraseAlloChatStore,
+  sessionStorage: matrixSessionStorage,
   authorize: async (authorizationUrl, redirectUri) => {
     const result = await WebBrowser.openAuthSessionAsync(authorizationUrl, redirectUri);
     return result.type === 'success'

--- a/packages/frontend/lib/chat/matrixSession.ts
+++ b/packages/frontend/lib/chat/matrixSession.ts
@@ -1,0 +1,169 @@
+import type { AlloSession } from '@/lib/matrix/types';
+
+/**
+ * The session as it is written down between launches.
+ *
+ * A record and not the bare {@link AlloSession} for two reasons, both of which
+ * are about reading something back that was written by a different Allo than the
+ * one reading it:
+ *
+ * - **a version**, so a shape that changes is refused rather than guessed at. The
+ *   cost of refusing is one sign-in; the cost of guessing is a client that
+ *   believes it has a session and cannot use it.
+ * - **the homeserver**, checked against the one this build talks to. A build
+ *   pointed at a different homeserver has a session for a server that never
+ *   issued it, and the device it names does not exist there.
+ *
+ * Nothing here parses `authData`: the port defines it as opaque and only the
+ * implementation that wrote it can read it. What this module checks is that it is
+ * a string, which is all it is allowed to know.
+ *
+ * **Everything this module returns is a credential.** The tokens must never reach
+ * a log, a crash report, or Allo's own backend; the reasons it gives for refusing
+ * a record are written so that they name what is wrong without quoting any of it.
+ */
+
+/**
+ * Bumped when {@link StoredSession} changes shape.
+ *
+ * Adding a field that older Allos will not have written is a version bump too: a
+ * record missing something the client needs restores into a session that cannot
+ * refresh itself, which is the failure this whole module exists to avoid.
+ */
+export const STORED_SESSION_VERSION = 1;
+
+interface StoredSession {
+  readonly version: typeof STORED_SESSION_VERSION;
+  readonly session: AlloSession;
+}
+
+/** What was found where the session is kept. */
+export type StoredSessionOutcome =
+  /** A session that can be restored. */
+  | { readonly kind: 'session'; readonly session: AlloSession }
+  /** Nothing was stored. The ordinary state of a fresh install. */
+  | { readonly kind: 'absent' }
+  /**
+   * Something was stored and cannot be used. Distinct from `absent` because the
+   * two are not the same event: this one is worth a log line, and it means a
+   * device's keys are being abandoned rather than never having existed.
+   */
+  | { readonly kind: 'unusable'; readonly reason: string };
+
+export function encodeStoredSession(session: AlloSession): string {
+  const record: StoredSession = { version: STORED_SESSION_VERSION, session };
+  return JSON.stringify(record);
+}
+
+/**
+ * Reads back what {@link encodeStoredSession} wrote, for the homeserver this
+ * build talks to.
+ *
+ * Every check is a refusal rather than a repair. A half-valid session is not a
+ * session that half works: it is one the SDK accepts and then cannot renew, and
+ * the user meets that as messages that stop arriving rather than as a sign-in
+ * screen.
+ */
+export function decodeStoredSession(
+  raw: string | undefined,
+  homeserverUrl: string,
+): StoredSessionOutcome {
+  if (raw === undefined || raw === '') {
+    return { kind: 'absent' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: 'unusable', reason: 'what was stored is not JSON' };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { kind: 'unusable', reason: 'what was stored is not an object' };
+  }
+
+  const record: Record<string, unknown> = { ...parsed };
+  if (record.version !== STORED_SESSION_VERSION) {
+    return {
+      kind: 'unusable',
+      reason:
+        `it is version ${String(record.version)}, and this Allo writes ` +
+        `version ${STORED_SESSION_VERSION}`,
+    };
+  }
+
+  const session = readSession(record.session);
+  if (typeof session === 'string') {
+    return { kind: 'unusable', reason: session };
+  }
+
+  if (session.homeserverUrl !== homeserverUrl) {
+    // Not a corrupt record: a build that was pointed somewhere else. Restoring
+    // it would hand this homeserver a device id it never issued.
+    return {
+      kind: 'unusable',
+      reason:
+        `it belongs to ${session.homeserverUrl} and this build talks to ` +
+        homeserverUrl,
+    };
+  }
+
+  return { kind: 'session', session };
+}
+
+/** The session, or a sentence saying what is missing from it. */
+function readSession(value: unknown): AlloSession | string {
+  if (typeof value !== 'object' || value === null) {
+    return 'it carries no session';
+  }
+
+  const fields: Record<string, unknown> = { ...value };
+  const userId = readRequired(fields.userId);
+  const deviceId = readRequired(fields.deviceId);
+  const homeserverUrl = readRequired(fields.homeserverUrl);
+  const accessToken = readRequired(fields.accessToken);
+  const refreshToken = readOptional(fields.refreshToken);
+  const authData = readOptional(fields.authData);
+
+  if (userId === undefined) {
+    return 'it names no user';
+  }
+  if (deviceId === undefined) {
+    // The device id is the installation's identity and what its encryption keys
+    // hang off. A session without one cannot be the same device twice.
+    return 'it names no device';
+  }
+  if (homeserverUrl === undefined) {
+    return 'it names no homeserver';
+  }
+  if (accessToken === undefined) {
+    return 'it carries no access token';
+  }
+  if (refreshToken === null) {
+    return 'its refresh token is not a string';
+  }
+  if (authData === null) {
+    return 'its authentication data is not a string';
+  }
+
+  return { userId, deviceId, homeserverUrl, accessToken, refreshToken, authData };
+}
+
+/** A non-empty string, or `undefined` if it is anything else. */
+function readRequired(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
+ * A string or nothing, or `null` for a value that is neither.
+ *
+ * The three-way answer is what separates "this session has no refresh token",
+ * which is a homeserver that does not issue them, from "this record is damaged".
+ */
+function readOptional(value: unknown): string | undefined | null {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return typeof value === 'string' ? value : null;
+}

--- a/packages/frontend/lib/chat/matrixSessionStorage.ts
+++ b/packages/frontend/lib/chat/matrixSessionStorage.ts
@@ -1,0 +1,114 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+import { MatrixStoreUnavailableError } from '@/lib/matrix/errors';
+
+/**
+ * Where the Matrix session is kept between launches.
+ *
+ * One value, one key, and a deliberately small interface: what is stored here is
+ * a set of credentials, and the fewer things that can be done to it the fewer
+ * ways it can leak. Reading and writing are the app's; interpreting the string is
+ * `matrixSession.ts`'s.
+ *
+ * `lib/secureStorage.ts` is not reused, and the reason is its fallback: it
+ * answers a SecureStore that refuses a write by writing to AsyncStorage instead,
+ * which on a phone means moving an access token out of the keychain and into
+ * plain application storage without telling anyone. That trade is right for the
+ * things it holds and wrong for this one, so a failure here is a failure.
+ */
+
+/**
+ * The one key. Only characters SecureStore accepts on both platforms: letters,
+ * digits, `.`, `-` and `_`.
+ */
+export const SESSION_KEY = 'allo.matrix.session';
+
+/**
+ * Keychain entries stay on the phone they were made on.
+ *
+ * `THIS_DEVICE_ONLY` is not caution for its own sake. A session is half of an
+ * installation's identity and the crypto store on disk is the other half; an
+ * encrypted iCloud backup restored onto a new phone would carry the session
+ * across and leave the keys behind, and the new phone would come up holding a
+ * device id whose encryption keys do not exist. `AFTER_FIRST_UNLOCK`, rather
+ * than `WHEN_UNLOCKED`, so that a launch into the background — a notification, a
+ * scheduled sync — can still restore the session on a locked phone.
+ */
+const KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+};
+
+/**
+ * The session's home, as little of it as the runtime needs.
+ *
+ * An interface rather than three functions because the runtime takes it as a
+ * dependency: the whole state machine around persisting and restoring sessions is
+ * then exercisable without a keychain, a browser, or either platform.
+ */
+export interface MatrixSessionStorage {
+  /** The stored session, or `undefined` if nothing has been stored. */
+  read(): Promise<string | undefined>;
+  /** Replaces the stored session. Throws if it could not be written. */
+  write(value: string): Promise<void>;
+  /** Removes it. Removing what is not there is not an error. */
+  clear(): Promise<void>;
+}
+
+/**
+ * The keychain, on iOS and Android.
+ *
+ * SecureStore's documented guidance is that values over 2048 bytes may fail on
+ * Android. A Matrix session is four short strings and the SDK's OIDC data, which
+ * is well inside that — but "well inside" is not "guaranteed", so a write that
+ * fails is raised rather than swallowed. The caller's answer is to tell the user
+ * their session will not survive the app closing, which is true and actionable;
+ * a swallowed failure would instead show up a day later as a device that appeared
+ * from nowhere.
+ */
+const keychainStorage: MatrixSessionStorage = {
+  read: async () => (await SecureStore.getItemAsync(SESSION_KEY, KEYCHAIN_OPTIONS)) ?? undefined,
+  write: (value) => SecureStore.setItemAsync(SESSION_KEY, value, KEYCHAIN_OPTIONS),
+  clear: () => SecureStore.deleteItemAsync(SESSION_KEY, KEYCHAIN_OPTIONS),
+};
+
+/**
+ * `localStorage`, on web.
+ *
+ * There is no keychain in a browser and nothing that behaves like one: anything
+ * the page can read, script running on the page can read. `localStorage` is what
+ * the session lives in, and the protection it has is the origin — the same
+ * protection the crypto store in IndexedDB already relies on, so this adds no
+ * exposure that Allo on web did not already have.
+ *
+ * A browser with no `localStorage` is refused at the first read rather than
+ * worked around. The alternative is an app that signs the user in on every
+ * launch and mints a Matrix device each time, which is the failure this whole
+ * change exists to remove — and it is the same answer the port already gives for
+ * a browser with no IndexedDB, for the same reason.
+ */
+const browserStorage: MatrixSessionStorage = {
+  read: async () => requireLocalStorage('read').getItem(SESSION_KEY) ?? undefined,
+  write: async (value) => {
+    requireLocalStorage('write').setItem(SESSION_KEY, value);
+  },
+  clear: async () => {
+    requireLocalStorage('clear').removeItem(SESSION_KEY);
+  },
+};
+
+function requireLocalStorage(operation: string): Storage {
+  const storage: Storage | undefined = globalThis.localStorage;
+  if (storage === undefined) {
+    throw new MatrixStoreUnavailableError(
+      `it cannot ${operation} the session because this browser exposes no ` +
+        'localStorage. Private browsing modes and some embedded webviews ' +
+        'refuse it.',
+    );
+  }
+  return storage;
+}
+
+/** The session storage for the platform this build runs on. */
+export const matrixSessionStorage: MatrixSessionStorage =
+  Platform.OS === 'web' ? browserStorage : keychainStorage;

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -320,6 +320,7 @@ class NativeAlloChatClient implements AlloChatClient {
       roomList.close();
     }
     this.#syncStateListeners.clear();
+    this.#sessions.releaseObservers();
     this.#syncStateHandle?.cancel();
     this.#syncStateHandle = undefined;
 

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -25,10 +25,16 @@ import type {
 } from '@unomed/react-native-matrix-sdk';
 
 import { MatrixRoomNotFoundError, MatrixSyncNotStartedError } from '@/lib/matrix/errors';
+// Named in full rather than as `@/lib/matrix/store`: this half of the port is
+// the native one and its store is the native one, and saying so leaves no
+// resolution rule to trust. The platform-resolved name is for the code above
+// the split, which must not care.
+import { eraseAlloChatStore } from '@/lib/matrix/store.native';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
   AlloChatClientFactory,
+  AlloClientStore,
   AlloEncryptionState,
   AlloOidcClientMetadata,
   AlloOidcLoginOptions,
@@ -49,7 +55,7 @@ import { applyListUpdate } from './native/listDiff';
 import { NativeOidcLoginRequest } from './native/oidcLogin';
 import { RoomSummaryCache } from './native/roomSummaries';
 import { TimelineProjection } from './native/timelineProjection';
-import { toAlloSession } from './native/session';
+import { NativeSessionDelegate, toAlloSession } from './native/session';
 import { toEncryptionState, toSyncState } from './native/translate';
 
 /**
@@ -99,15 +105,31 @@ function ensurePlatformInitialized(): void {
 
 export const createAlloChatClient: AlloChatClientFactory = async (config) => {
   ensurePlatformInitialized();
+  // Built before the client because that is the only order the binding offers:
+  // the delegate goes to the builder, and only afterwards is there a client for
+  // it to read. See `native/session.ts`.
+  const sessions = new NativeSessionDelegate();
+  const client = await buildClient(config, sessions);
+  sessions.bind(client);
   return new NativeAlloChatClient(
-    await buildClient(config),
+    client,
     toOidcConfiguration(config.oidc),
+    config.store,
+    sessions,
   );
 };
 
-async function buildClient(config: AlloChatClientConfig): Promise<ClientLike> {
+async function buildClient(
+  config: AlloChatClientConfig,
+  sessions: NativeSessionDelegate,
+): Promise<ClientLike> {
   const builder = new ClientBuilder()
     .homeserverUrl(config.homeserverUrl)
+    // The binding's one way of reporting that it has rotated the session's
+    // tokens. Without it a persisted session is a snapshot that goes stale the
+    // first time the SDK refreshes, and every launch after that is a new login
+    // and a new Matrix device.
+    .setSessionDelegate(sessions)
     // The binding's only sliding sync options are "none" and "native": there is
     // no proxy fallback, so a homeserver that does not serve native sliding sync
     // makes `build()` fail with `ClientBuildError.SlidingSyncVersion` instead of
@@ -149,6 +171,8 @@ function toOidcConfiguration(metadata: AlloOidcClientMetadata): OidcConfiguratio
 class NativeAlloChatClient implements AlloChatClient {
   readonly #client: ClientLike;
   readonly #oidc: OidcConfiguration;
+  readonly #store: AlloClientStore;
+  readonly #sessions: NativeSessionDelegate;
   readonly #syncStateListeners = new Set<(state: AlloSyncState) => void>();
   readonly #roomLists = new Set<NativeRoomListHandle>();
   readonly #timelines = new Set<NativeTimelineHandle>();
@@ -157,9 +181,16 @@ class NativeAlloChatClient implements AlloChatClient {
   #syncStateHandle: TaskHandleLike | undefined;
   #syncState: AlloSyncState = 'idle';
 
-  constructor(client: ClientLike, oidc: OidcConfiguration) {
+  constructor(
+    client: ClientLike,
+    oidc: OidcConfiguration,
+    store: AlloClientStore,
+    sessions: NativeSessionDelegate,
+  ) {
     this.#client = client;
     this.#oidc = oidc;
+    this.#store = store;
+    this.#sessions = sessions;
   }
 
   async beginOidcLogin(options: AlloOidcLoginOptions = {}): Promise<AlloOidcLoginRequest> {
@@ -181,6 +212,37 @@ class NativeAlloChatClient implements AlloChatClient {
 
   session(): AlloSession {
     return toAlloSession(this.#client.session());
+  }
+
+  observeSession(onChange: (session: AlloSession) => void): AlloUnsubscribe {
+    return this.#sessions.observe(onChange);
+  }
+
+  /**
+   * Logs out on the homeserver, then takes the store with it.
+   *
+   * The order is not interchangeable. `logout()` needs a working client and a
+   * live access token, so it goes first; the local state goes afterwards and goes
+   * whatever the homeserver said, because a sign-out that leaves this device's
+   * keys on the phone is not a sign-out. A homeserver that could not be reached
+   * is a warning and not a failure — see {@link AlloChatClient.logout} for why
+   * this cannot be reported by throwing.
+   */
+  async logout(): Promise<void> {
+    try {
+      await this.#client.logout();
+    } catch (error) {
+      logger.warn(
+        `${LOG_TAG} the homeserver was not told about this sign-out; the session ` +
+          'is gone from this device either way',
+        error,
+      );
+    }
+    // Before erasing, not after: closing stops the sync loop, and a sync loop
+    // still running against a store that is being deleted writes into a
+    // directory nothing leads to.
+    await this.close();
+    await eraseAlloChatStore(this.#store);
   }
 
   async startSync(): Promise<void> {

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -34,6 +34,11 @@ import {
   MatrixStoreUnavailableError,
   MatrixSyncNotStartedError,
 } from '@/lib/matrix/errors';
+// Named in full rather than as `@/lib/matrix/store`: this half of the port is
+// the web one and its store is the web one, and saying so leaves no resolution
+// rule to trust. The platform-resolved name is for the code above the split,
+// which must not care.
+import { cryptoDatabasePrefix } from '@/lib/matrix/store.web';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
@@ -127,6 +132,7 @@ class WebAlloChatClient implements AlloChatClient {
    */
   readonly #wasm = new CryptoWasmLoader(initAsync);
   readonly #syncStateListeners = new Set<(state: AlloSyncState) => void>();
+  readonly #sessionListeners = new Set<(session: AlloSession) => void>();
   readonly #roomLists = new Set<WebRoomListHandle>();
   readonly #timelines = new Set<WebTimelineHandle>();
 
@@ -190,6 +196,56 @@ class WebAlloChatClient implements AlloChatClient {
       throw new MatrixNotLoggedInError('Reading the session');
     }
     return this.#session;
+  }
+
+  observeSession(onChange: (session: AlloSession) => void): AlloUnsubscribe {
+    this.#sessionListeners.add(onChange);
+    return () => {
+      this.#sessionListeners.delete(onChange);
+    };
+  }
+
+  /**
+   * Logs out on the homeserver, then deletes every database this session used.
+   *
+   * `clearStores` is the SDK's own answer and covers both halves — the synced
+   * state and the Rust crypto machine's two databases — but only if it is given
+   * the same `cryptoDatabasePrefix` the client was started with. Given the wrong
+   * one it deletes nothing, reports success, and leaves this device's keys in the
+   * browser, which is why the prefix is built in one place by
+   * {@link cryptoDatabasePrefix} rather than spelled out at each end.
+   *
+   * It also refuses to run while the client is running, which is why closing
+   * comes in between rather than being left to `logout(true)`: a homeserver call
+   * that threw would otherwise stop nothing and the stores would survive the
+   * sign-out.
+   */
+  async logout(): Promise<void> {
+    const client = this.#requireClient('Signing out');
+    const session = this.#session;
+
+    try {
+      await client.logout(true);
+    } catch (error) {
+      logger.warn(
+        `${LOG_TAG} the homeserver was not told about this sign-out; the session ` +
+          'is gone from this browser either way',
+        error,
+      );
+    }
+
+    await this.close();
+    await client.clearStores(
+      this.#config.store.kind === 'in-memory' || session === undefined
+        ? {}
+        : {
+            cryptoDatabasePrefix: cryptoDatabasePrefix(
+              this.#config.store.dataPath,
+              session.deviceId,
+            ),
+          },
+    );
+    this.#session = undefined;
   }
 
   async startSync(): Promise<void> {
@@ -287,6 +343,7 @@ class WebAlloChatClient implements AlloChatClient {
       roomList.close();
     }
     this.#syncStateListeners.clear();
+    this.#sessionListeners.clear();
 
     const client = this.#client;
     if (client !== undefined && this.#watchingSyncState) {
@@ -429,8 +486,8 @@ class WebAlloChatClient implements AlloChatClient {
 
     // The crypto store is keyed by device: a second device on this browser is a
     // second set of keys, and letting them share a store makes the SDK refuse to
-    // open it at all. Nothing deletes the store of a device that is no longer
-    // used — that belongs with a logout flow, which this port does not have.
+    // open it at all. The store of a device that is no longer used is deleted by
+    // {@link logout}, which builds the same name through the same function.
     //
     // This is also the call the SDK's multi-tab warning is attached to; see the
     // note at the top of this file for what is not being done about it.
@@ -439,7 +496,10 @@ class WebAlloChatClient implements AlloChatClient {
         ? { useIndexedDB: false }
         : {
             useIndexedDB: true,
-            cryptoDatabasePrefix: `${this.#config.store.dataPath}:${session.deviceId}`,
+            cryptoDatabasePrefix: cryptoDatabasePrefix(
+              this.#config.store.dataPath,
+              session.deviceId,
+            ),
           },
     );
 
@@ -474,23 +534,36 @@ class WebAlloChatClient implements AlloChatClient {
 
   /**
    * The SDK rotates the session's tokens on its own, and under OIDC it does so
-   * often. The port has no way to tell the app that it happened — the same gap
-   * the native half has, documented on {@link AlloSession} — so the best that can
-   * be done here is keep {@link session} answering with the current tokens, so an
-   * app that reads it again gets something worth persisting.
+   * often.
+   *
+   * Two things follow, and both matter. {@link session} has to start answering
+   * with the new tokens, and whoever is persisting the session has to be told —
+   * a copy written at login is correct for minutes and then permanently stale,
+   * which is a session that looks persisted and stops restoring. A listener that
+   * throws is logged rather than allowed to propagate: this is the SDK's refresh
+   * path, and a failed persist must not become a failed refresh.
    */
   #onTokensRefreshed(tokens: AccessTokens): void {
     const session = this.#session;
     if (session === undefined) {
       return;
     }
-    this.#session = {
+    const refreshed: AlloSession = {
       ...session,
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
     };
+    this.#session = refreshed;
     // Never the tokens themselves: they are credentials.
     logger.info(`${LOG_TAG} the session's tokens were refreshed`);
+
+    for (const listener of this.#sessionListeners) {
+      try {
+        listener(refreshed);
+      } catch (error) {
+        logger.error(`${LOG_TAG} a refreshed session could not be handled`, error);
+      }
+    }
   }
 
   #watchSyncState(client: MatrixClient): void {

--- a/packages/frontend/lib/matrix/native/session.ts
+++ b/packages/frontend/lib/matrix/native/session.ts
@@ -89,6 +89,17 @@ export class NativeSessionDelegate implements ClientSessionDelegate {
   }
 
   /**
+   * Drops every listener, for a client that is being closed.
+   *
+   * The delegate outlives the client it was built for — Rust holds it — so
+   * without this a closed client would keep reporting rotations to whoever was
+   * watching the session it no longer has.
+   */
+  releaseObservers(): void {
+    this.#listeners.clear();
+  }
+
+  /**
    * The session as the SDK last left it.
    *
    * Answered from the client rather than from storage, which is not what the name

--- a/packages/frontend/lib/matrix/native/session.ts
+++ b/packages/frontend/lib/matrix/native/session.ts
@@ -1,16 +1,21 @@
-import type { Session } from '@unomed/react-native-matrix-sdk';
+import type { ClientSessionDelegate, Session } from '@unomed/react-native-matrix-sdk';
 
-import type { AlloSession } from '@/lib/matrix/types';
+import { MatrixNotLoggedInError, MatrixSessionRestoreError } from '@/lib/matrix/errors';
+import type { AlloSession, AlloUnsubscribe } from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
 
 /**
- * The session, translated.
+ * The session: translated, and watched for the moment the SDK replaces it.
  *
- * Its own module rather than part of `translate.ts` because it is the one
- * translation that needs nothing from the SDK at runtime — only the shape of its
- * `Session` record, which is a type and disappears at compile time. Keeping it
- * apart is what lets the authentication path, which depends on this and on
- * nothing else of the binding's, be exercised without loading the native module.
+ * Its own module rather than part of `translate.ts` because none of it needs the
+ * SDK at runtime — only the shape of its `Session` record and the shape of the
+ * delegate it calls back on, both of which are types and disappear at compile
+ * time. Keeping it apart is what lets the authentication path, which depends on
+ * this and on nothing else of the binding's, be exercised without loading the
+ * native module.
  */
+
+const LOG_TAG = '[matrix]';
 
 /** The fields of the SDK's session the port carries. */
 export type SessionFields = Pick<
@@ -32,4 +37,96 @@ export function toAlloSession(session: SessionFields): AlloSession {
     refreshToken: session.refreshToken,
     authData: session.oidcData,
   };
+}
+
+/** What the delegate needs of the client it belongs to. */
+export interface SessionReader {
+  session(): Session;
+}
+
+/**
+ * How the app finds out that the SDK has replaced the session.
+ *
+ * This is the binding's only answer to that question, and it is not shaped like
+ * an observer: it is a *delegate*, handed to the builder before the client
+ * exists, and the SDK calls it "keychain" because it expects the app to keep the
+ * session where a phone keeps secrets. Allo does — see
+ * `lib/chat/matrixSessionStorage.ts` — but not from here: this object turns two
+ * synchronous callbacks into the port's `observeSession`, and where the bytes go
+ * is a decision the app gets to make once, above the platform split.
+ *
+ * Why it matters at all: under OIDC the access token is short-lived and the SDK
+ * refreshes it on its own. A session written down at login and never updated is
+ * correct for minutes and then permanently stale, which is a session that looks
+ * persisted and silently stops restoring — and every launch that fails to restore
+ * is a new Matrix device on the user's account.
+ *
+ * **Callbacks come from Rust, on Rust's thread, and are synchronous.** Nothing
+ * here may block, and nothing here may throw where the SDK did not ask a
+ * question: a listener that fails must not become a token refresh that fails.
+ */
+export class NativeSessionDelegate implements ClientSessionDelegate {
+  readonly #listeners = new Set<(session: AlloSession) => void>();
+
+  #reader: SessionReader | undefined;
+
+  /**
+   * Points the delegate at the client it was built with.
+   *
+   * Two-phase because the order is forced: `ClientBuilder.setSessionDelegate`
+   * takes the delegate, and only then is there a client for it to read.
+   */
+  bind(reader: SessionReader): void {
+    this.#reader = reader;
+  }
+
+  /** Reports every session the SDK saves from now on. */
+  observe(onChange: (session: AlloSession) => void): AlloUnsubscribe {
+    this.#listeners.add(onChange);
+    return () => {
+      this.#listeners.delete(onChange);
+    };
+  }
+
+  /**
+   * The session as the SDK last left it.
+   *
+   * Answered from the client rather than from storage, which is not what the name
+   * suggests and is the right thing here. The call exists for a second process —
+   * a notification extension — that may have refreshed the tokens while this one
+   * slept, and Allo has no such process: it does not enable the SDK's
+   * cross-process refresh lock, so the only party that ever changes this
+   * session is the client being asked. Reading a copy out of the keychain would
+   * risk answering with something older than what the client already has.
+   */
+  retrieveSessionFromKeychain(userId: string): Session {
+    if (this.#reader === undefined) {
+      throw new MatrixNotLoggedInError('Reading the session the SDK asked for');
+    }
+    const session = this.#reader.session();
+    if (session.userId !== userId) {
+      // The client holds one user's session; being asked for another one means
+      // the SDK and this delegate disagree about which client this is.
+      throw new MatrixSessionRestoreError(
+        `the SDK asked for ${userId}'s session and this client holds ${session.userId}'s`,
+      );
+    }
+    return session;
+  }
+
+  /** The SDK has new tokens. Everything downstream of here is a persist. */
+  saveSessionInKeychain(session: Session): void {
+    const translated = toAlloSession(session);
+    for (const listener of this.#listeners) {
+      try {
+        listener(translated);
+      } catch (error) {
+        // Never the session itself: it is a credential. A listener that failed
+        // means this rotation was not written down, so the next launch restores
+        // the previous one and the SDK refreshes again — recoverable, and worth
+        // saying out loud.
+        logger.error(`${LOG_TAG} a refreshed session could not be handled`, error);
+      }
+    }
+  }
 }

--- a/packages/frontend/lib/matrix/store.native.ts
+++ b/packages/frontend/lib/matrix/store.native.ts
@@ -1,0 +1,102 @@
+import { Directory, Paths } from 'expo-file-system';
+
+import { MatrixStoreUnavailableError } from '@/lib/matrix/errors';
+import type { AlloChatStoreEraser, AlloClientStore } from '@/lib/matrix/types';
+
+/**
+ * Where the native client keeps its data, and how to get rid of it.
+ *
+ * Metro serves this file on iOS and Android and `store.web.ts` on web; both
+ * answer the same two names, and everything above them is written against those
+ * rather than against a filesystem.
+ *
+ * The Rust SDK's own words on the paths it is given are that they "**must** be
+ * unique per session as the SDK stores aren't capable of handling multiple
+ * users". Allo has one session at a time, so one pair of paths is enough — but
+ * only if a session's store never outlives the session. That is what
+ * {@link eraseAlloChatStore} is for, and why the runtime erases before it builds
+ * a client it has no session for.
+ */
+
+/** The directory, inside the app's own document and cache directories. */
+const STORE_DIRECTORY = 'matrix';
+
+const FILE_SCHEME = 'file://';
+
+/**
+ * The state store and the event cache.
+ *
+ * Two directories and not one, in the two places the platform means them to be:
+ * the state store holds the device's encryption keys and belongs where the system
+ * will not reclaim it, and the event cache is a cache — losing it costs a
+ * re-sync, and a phone running out of space should be allowed to take it.
+ */
+export function resolveAlloChatStore(): AlloClientStore {
+  return {
+    kind: 'filesystem',
+    dataPath: toFilesystemPath(new Directory(Paths.document, STORE_DIRECTORY)),
+    cachePath: toFilesystemPath(new Directory(Paths.cache, STORE_DIRECTORY)),
+  };
+}
+
+/**
+ * Deletes both directories, and everything the SDK put in them.
+ *
+ * The SQLite files may still be open when this runs — the client that owns them
+ * is closed first, but the Rust object behind it is released by a garbage
+ * collector nothing here can wait for. Deleting them anyway is safe and is the
+ * point: on both platforms unlinking a file that is open removes it from the
+ * filesystem immediately, and whatever still holds it writes to something no path
+ * leads to. What must not happen is the directory surviving, because a client
+ * built afterwards would open it.
+ */
+export const eraseAlloChatStore: AlloChatStoreEraser = async (store) => {
+  if (store.kind === 'in-memory') {
+    return;
+  }
+  // A set, because a deployment is free to point both at one directory: the SDK
+  // allows it, and deleting the same directory twice would throw on the second.
+  for (const path of new Set([store.dataPath, store.cachePath])) {
+    const directory = new Directory(toDirectoryUri(path));
+    if (directory.exists) {
+      directory.delete();
+    }
+  }
+};
+
+/**
+ * The plain path the Rust SDK speaks, from the URI expo-file-system speaks.
+ *
+ * The SDK takes an operating system path — it hands it to SQLite — and
+ * expo-file-system answers in `file://` URIs, so the percent-encoding a URI
+ * carries has to come off.
+ */
+function toFilesystemPath(directory: Directory): string {
+  const { uri } = directory;
+  if (!uri.startsWith(FILE_SCHEME)) {
+    throw new MatrixStoreUnavailableError(
+      `this platform put the app's storage at "${uri}", which is not a local ` +
+        'file and cannot be given to the SDK as a path',
+    );
+  }
+  return decodeURIComponent(uri.slice(FILE_SCHEME.length));
+}
+
+/**
+ * The reverse, for the one call that takes a URI rather than a path.
+ *
+ * `encodeURI` and not `encodeURIComponent`: the separators have to survive. What
+ * it leaves alone is `#` and `?`, which a URI would read as the start of a
+ * fragment or a query — so a path containing either is refused here rather than
+ * silently naming a different directory, which is the one mistake this function
+ * could make that ends in deleting nothing and reporting success.
+ */
+function toDirectoryUri(path: string): string {
+  if (path.includes('#') || path.includes('?')) {
+    throw new MatrixStoreUnavailableError(
+      `"${path}" cannot be addressed as a file URI, because "#" and "?" mean ` +
+        'something else in one',
+    );
+  }
+  return `${FILE_SCHEME}${encodeURI(path)}`;
+}

--- a/packages/frontend/lib/matrix/store.web.ts
+++ b/packages/frontend/lib/matrix/store.web.ts
@@ -1,0 +1,163 @@
+import { MatrixStoreUnavailableError } from '@/lib/matrix/errors';
+import type { AlloChatStoreEraser, AlloClientStore } from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
+
+/**
+ * Where the web client keeps its data, and how to get rid of it.
+ *
+ * Metro serves this file on web and `store.native.ts` on iOS and Android; both
+ * answer the same two names. What differs is what a store *is*: a browser has no
+ * filesystem, so the port's `dataPath` names an IndexedDB database rather than a
+ * directory, and `cachePath` has nothing to name.
+ *
+ * Two databases hang off that name and they are not symmetrical:
+ *
+ * - **the synced state**, named after the store and nothing else, so a client
+ *   built with the same configuration opens the same one whichever session it is
+ *   for. That is what makes erasing before a new session necessary here.
+ * - **the crypto store**, named after the store *and the device*, so it can only
+ *   ever be opened by the device that wrote it. A leftover cannot be inherited by
+ *   a new session — it can only take up space, which is why erasing it is
+ *   housekeeping rather than correctness.
+ *
+ * Both are deleted here, and neither is deleted while a client is using it. Allo
+ * on web is safe in one tab and untested in two (`client.web.ts`), and a second
+ * tab holding a live session is one of the things that is untested.
+ */
+
+const LOG_TAG = '[matrix]';
+
+/** The IndexedDB database name. Also the crypto databases' first component. */
+const STORE_NAME = 'allo-matrix';
+
+/** What `matrix-js-sdk` puts in front of the name it is given. */
+const SYNC_DATABASE_PREFIX = 'matrix-js-sdk:';
+
+/** What the Rust crypto machine puts after the prefix it is given. */
+const CRYPTO_DATABASE_SUFFIXES = ['::matrix-sdk-crypto', '::matrix-sdk-crypto-meta'];
+
+export function resolveAlloChatStore(): AlloClientStore {
+  // The same string twice: `cachePath` exists for the native SDK, which keeps its
+  // event cache in a second directory. There is no second database here.
+  return { kind: 'filesystem', dataPath: STORE_NAME, cachePath: STORE_NAME };
+}
+
+/**
+ * What `matrix-js-sdk` will call the database holding the synced state.
+ *
+ * Its own function because the eraser has to name the same database the store
+ * did, and the SDK's prefix is not something either end can be trusted to
+ * remember separately.
+ */
+export function syncDatabaseName(dataPath: string): string {
+  return `${SYNC_DATABASE_PREFIX}${dataPath}`;
+}
+
+/**
+ * What the crypto databases are named after, for one device.
+ *
+ * Keyed by device because a crypto store belongs to exactly one: the SDK refuses
+ * to open one written by a different device, and a fresh install that inherited
+ * the last one would be holding keys for an identity the homeserver has never
+ * heard of.
+ */
+export function cryptoDatabasePrefix(dataPath: string, deviceId: string): string {
+  return `${dataPath}:${deviceId}`;
+}
+
+export const eraseAlloChatStore: AlloChatStoreEraser = (store) =>
+  eraseWebStore(store, globalThis.indexedDB);
+
+/**
+ * The eraser, with the browser's IndexedDB handed in.
+ *
+ * Injected rather than read from `globalThis` so that the deletion — which
+ * databases, in what order, and what a refusal does — can be exercised without a
+ * browser.
+ */
+export async function eraseWebStore(
+  store: AlloClientStore,
+  indexedDB: IDBFactory | undefined,
+): Promise<void> {
+  if (store.kind === 'in-memory') {
+    return;
+  }
+  if (indexedDB === undefined) {
+    throw new MatrixStoreUnavailableError(
+      'this browser exposes no IndexedDB, so the databases a previous session ' +
+        'may have left cannot be deleted',
+    );
+  }
+
+  const names = new Set([syncDatabaseName(store.dataPath)]);
+  for (const name of await cryptoDatabaseNames(store.dataPath, indexedDB)) {
+    names.add(name);
+  }
+
+  for (const name of names) {
+    await deleteDatabase(name, indexedDB);
+  }
+}
+
+/**
+ * The crypto databases this store has left behind, whichever devices wrote them.
+ *
+ * `databases()` is what makes this possible and not every browser has it —
+ * Firefox only from 126. Without it the leftovers are not found, which costs
+ * storage and nothing else: a crypto database is named after the device that
+ * wrote it, so one that is still there cannot be opened by the session that comes
+ * next. The one that matters for correctness is the synced state, and that one is
+ * named without asking the browser anything.
+ */
+async function cryptoDatabaseNames(
+  dataPath: string,
+  indexedDB: IDBFactory,
+): Promise<readonly string[]> {
+  if (typeof indexedDB.databases !== 'function') {
+    return [];
+  }
+
+  const found: string[] = [];
+  const existing = await indexedDB.databases();
+  for (const { name } of existing) {
+    if (name === undefined) {
+      continue;
+    }
+    for (const suffix of CRYPTO_DATABASE_SUFFIXES) {
+      if (name.startsWith(`${dataPath}:`) && name.endsWith(suffix)) {
+        found.push(name);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Deletes one database, and does not let a refusal stop the others.
+ *
+ * A deletion can be *blocked* rather than refused, which is a connection
+ * somewhere else still holding the database open — another tab. It is reported
+ * and waited out rather than treated as an error, because the request stays
+ * pending and completes when the other connection closes.
+ */
+function deleteDatabase(name: string, indexedDB: IDBFactory): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => {
+      resolve();
+    };
+    request.onerror = () => {
+      // Firefox in a private window has an `indexedDB` that refuses every
+      // mutation, including deleting a database that does not exist. There is
+      // nothing to do about it and nothing the user can do about it.
+      logger.warn(`${LOG_TAG} the database ${name} could not be deleted`, request.error);
+      resolve();
+    };
+    request.onblocked = () => {
+      logger.warn(
+        `${LOG_TAG} the database ${name} is still open somewhere else; it will ` +
+          'be deleted when that connection closes',
+      );
+    };
+  });
+}

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -187,9 +187,11 @@ export interface AlloOidcLoginRequest {
  * device keychain.
  *
  * A warning that matters more under OIDC than it did under a password: **these
- * tokens rotate**. The SDK refreshes them on its own, and this port does not yet
- * report when it does, so a session stored once and never refreshed goes stale
- * and stops restoring. Persisting sessions needs that gap closed first.
+ * tokens rotate**. The SDK refreshes them on its own, without being asked, and a
+ * copy taken at login is correct for minutes and stale for good afterwards — a
+ * session that looks persisted and quietly stops restoring.
+ * {@link AlloChatClient.observeSession} is how an app hears about it, and
+ * anything that stores a session has to subscribe to it.
  */
 export interface AlloSession {
   readonly userId: string;
@@ -215,6 +217,20 @@ export interface AlloSession {
 export type AlloClientStore =
   | { readonly kind: 'in-memory' }
   | { readonly kind: 'filesystem'; readonly dataPath: string; readonly cachePath: string };
+
+/**
+ * Deletes what a client built on a store would otherwise inherit.
+ *
+ * Separate from {@link AlloChatClient.logout} because it has to be callable when
+ * there is no client: a store left behind by a session that is gone has to be
+ * erased *before* the next client opens it, and the SDKs' own stores hold one
+ * user each — the native one says so outright, that its paths "must be unique per
+ * session". Handing a new session a store that belongs to an older one is the
+ * failure that does not look like its cause.
+ *
+ * Erasing a store nothing has written is not an error.
+ */
+export type AlloChatStoreEraser = (store: AlloClientStore) => Promise<void>;
 
 export interface AlloChatClientConfig {
   readonly homeserverUrl: string;
@@ -264,6 +280,8 @@ export interface AlloTimelineHandle {
  * - {@link startSync} must happen before {@link observeRooms} or
  *   {@link openTimeline}: both are views over the sync loop's state, and there is
  *   nothing to view before it runs.
+ * - {@link logout} is terminal. A client that has logged out holds neither a
+ *   session nor a store; signing in again means building a new one.
  *
  * There is no password login and there will not be one. Allo's homeserver issues
  * sessions through Matrix Authentication Service with Oxy upstream, so the user
@@ -279,6 +297,39 @@ export interface AlloChatClient {
   restoreSession(session: AlloSession): Promise<void>;
   /** The current session. Throws if nobody has logged in. */
   session(): AlloSession;
+  /**
+   * Reports the session every time the SDK replaces it.
+   *
+   * Changes only. The session a login or a restore produced is that call's own
+   * result; this is what happens to it afterwards, which under OIDC is a token
+   * rotation the app never asked for. See {@link AlloSession} for why an app that
+   * persists sessions cannot skip this.
+   *
+   * Both SDKs report it through a callback the client is built with, so
+   * subscribing late does not miss a rotation that has already been applied —
+   * what it misses is being *told* about it, and {@link session} still answers
+   * with the current one.
+   */
+  observeSession(onChange: (session: AlloSession) => void): AlloUnsubscribe;
+
+  /**
+   * Ends the session, and destroys everything it left on this device.
+   *
+   * Two halves that fail independently, and the order is the point. The
+   * homeserver is asked to forget the device first, so that the tokens stop
+   * working; the local stores go afterwards and go *regardless*, because a user
+   * signing out on a train has still signed out. A homeserver that could not be
+   * reached is reported by the implementation's logs, not by throwing: a caller
+   * that saw this throw would have no way to tell "you are still signed in" from
+   * "you are signed out and the server does not know yet", and only the second
+   * one is true.
+   *
+   * What must not survive: the access and refresh tokens, the state store, and
+   * the crypto store with this device's keys. Half of that is worse than none —
+   * the next login opens a crypto store belonging to a device that no longer
+   * exists, and fails in ways that look nothing like their cause.
+   */
+  logout(): Promise<void>;
 
   /** Starts, or restarts after {@link stopSync}, the background sync loop. */
   startSync(): Promise<void>;

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -184,7 +184,9 @@ export interface AlloOidcLoginRequest {
  *
  * `accessToken`, `refreshToken` and `authData` are credentials: they must never
  * be logged, never sent to Allo's backend, and never written anywhere but the
- * device keychain.
+ * best storage the platform has — the device keychain on a phone, and on web the
+ * origin's own, which is all a browser offers and is the same protection the
+ * crypto store already relies on.
  *
  * A warning that matters more under OIDC than it did under a password: **these
  * tokens rotate**. The SDK refreshes them on its own, without being asked, and a

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -78,6 +78,7 @@
     "expo-constants": "~57.0.5",
     "expo-contacts": "~57.0.1",
     "expo-crypto": "~57.0.1",
+    "expo-file-system": "~57.0.1",
     "expo-font": "~57.0.1",
     "expo-haptics": "~57.0.1",
     "expo-image": "~57.0.1",


### PR DESCRIPTION
## Qué resuelve

El hueco número uno del camino de Matrix: **la sesión no se persistía**. Cada arranque era un login nuevo y, por tanto, **un dispositivo Matrix nuevo** — cuentas llenándose de dispositivos fantasma, cada uno con sus claves y ninguno verificable.

No era un olvido. El código lo documentaba: el SDK rota los tokens sin avisar a la app, así que una sesión guardada se queda rancia y deja de restaurarse. Ése era el problema real, y es lo que se resuelve aquí.

Con la sesión persistida, el almacén de cripto pasa de memoria a disco — antes no tenía sentido acumular claves de dispositivos irrepetibles.

Y **se puede cerrar sesión**: hasta ahora el único camino de vuelta era reiniciar la app.

## Plan de pruebas

- Typecheck del frontend en verde en condiciones de CI.
- **370 tests en 32 suites**, frente a 319 en 29.
- Conflicto con el trabajo de recuperación de claves resuelto a mano en `types.ts` y en el mock del SDK: los dos ampliaban el puerto, y ambas ampliaciones conviven.
- Cero `as any`, cero `@ts-ignore`, cero `useEffect` nuevos.

## Un hueco de cobertura, dicho en voz alta

`matrixRuntime.test.ts` cubre la secuencia de cierre de sesión —leer, borrar, escribir, limpiar— contra un almacén falso. Lo que **no** está cubierto es que las implementaciones concretas de `clear` (SecureStore en nativo, `localStorage` en web) borren de verdad.

El riesgo es bajo por construcción: `read`, `write` y `clear` usan la misma constante `SESSION_KEY`, así que una discordancia de clave es imposible. Intenté añadir la cobertura y se me fue en pelear con la resolución de plataforma de jest, así que lo dejo escrito en lugar de meter un test a medias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)