### PR TITLE
ci: only deploy to AWS from main

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -57,6 +57,9 @@ env:
 
 jobs:
   deploy:
+    # workflow_dispatch can be run against arbitrary refs; only deploys from the
+    # protected main branch may assume the AWS deploy role.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
`workflow_dispatch` accepts any ref, so a manual run could assume the AWS deploy role and ship an arbitrary branch to production. One line gating the `deploy` job on `github.ref`.

Same form already on OxyHQServices `main`, so the repos sharing this workflow converge on one spelling instead of each growing its own. Landed in Syra as part of OxyHQ/Syra#71, which came out of reviewing the stale `codex/*` security branches.

**Scope, checked per repo rather than applied in bulk — two of the six do NOT get this:**

- **Homiio** is a deliberate exception. Its `workflow_dispatch` from any ref is a documented escape hatch: `workflow_run` was tried there and concluded `action_required` with zero jobs created, twice, so manual dispatch is the fallback when CI itself breaks. Adding the guard would remove it and contradict an explicit "do not restore" note in the file.
- **Mention** needs nothing. It triggers on `workflow_run` alone — no `workflow_dispatch` at all — and already requires `head_branch == 'main'`, a same-repository check, `event == 'push'` and a success conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/allo/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->