### PR TITLE
La lista de conversaciones dice qué se dijo y cuándo

### DIFF
--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -73,6 +73,7 @@ lib/chat/
   timelineSource.ts      un timeline por sala, ídem, más paginar y enviar
   matrixViewModel.ts     AlloRoomSummary → Conversation, AlloTimelineItem → Message
 lib/matrix/
+  directMessage.ts       cuándo crear una conversación es reutilizar una
   store.native.ts        dos directorios, y cómo borrarlos
   store.web.ts           una base de IndexedDB, y cómo borrarla
 hooks/
@@ -101,9 +102,10 @@ el historial de los demás. Lo que lo evita son dos hechos, ambos en
 
 **Ningún componente de presentación cambió.** `MessageBubble`, `MessageBlock`,
 `DaySeparator`, las filas de la lista, el layout de tres paneles y los temas por
-conversación siguen recibiendo `Conversation` y `Message`. Lo único que cambia es
-de dónde salen, y en cada punto de conexión la rama vieja es la expresión que ya
-estaba:
+conversación siguen recibiendo `Conversation` y `Message`. `Conversation` ganó un
+campo opcional —`isInvitation`, que sólo el camino de Matrix rellena— y ningún
+componente lo lee todavía. Lo único que cambia es de dónde salen los datos, y en
+cada punto de conexión la rama vieja es la expresión que ya estaba:
 
 ```ts
 const conversations = roomConversations ?? storedConversations;
@@ -123,9 +125,18 @@ encenderlo.
 
 ## 4. Qué llega a la pantalla hoy
 
-- Lista de conversaciones, en el orden que da el puerto (no se reordena aquí).
+- Lista de conversaciones, en el orden que da el puerto (no se reordena aquí),
+  **con vista previa del último mensaje y su hora**. La hora sale del mensaje y
+  no de un campo aparte: son el mismo hecho visto dos veces, y una fila no puede
+  enseñar honestamente una sin la otra. Una sala cuyo último mensaje este
+  dispositivo no conoce se queda sin texto y sin hora, que es lo que el
+  formateador dibuja como nada.
 - Timeline de una conversación, con paginación hacia atrás al llegar arriba.
 - Envío de texto.
+- **Crear una conversación**, en el puerto (`createRoom`). Siempre privada, sólo
+  por invitación y cifrada; un mensaje directo con un solo invitado reutiliza la
+  sala que ya existe con esa persona en vez de acuñar una segunda. Ninguna
+  pantalla lo llama todavía.
 - Login OIDC en tres pasos, con `expo-web-browser`.
 - **Sesión persistida**: el segundo arranque no pasa por el navegador. Se guarda
   en el llavero del móvil (`AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`, para que una
@@ -134,26 +145,30 @@ encenderlo.
 - **Cerrar sesión**, desde Ajustes. Avisa al homeserver, y borre o no borre el
   homeserver, se lleva la sesión guardada, el almacén de estado y el de cripto.
 - Estados propios para los eventos sin texto: no descifrable, redactado, y
-  «Allo no sabe dibujar esto todavía». Ninguno se pinta como una burbuja vacía.
+  «Allo no sabe dibujar esto todavía». Ninguno se pinta como una burbuja vacía,
+  y la vista previa de la lista usa las mismas palabras: una conversación cuyo
+  último mensaje no se puede leer aquí lo dice, en vez de quedarse en blanco y
+  parecer una conversación en la que nadie ha escrito.
+- **Una invitación se distingue de una conversación** (`membership` en el
+  resumen, `Conversation.isInvitation` en la pantalla). Qué hacer con el dato es
+  de la UI, y hoy no hace nada distinto: ver §5.
 
 ## 5. Qué no llega, y por qué
 
 Por orden de cuánto se nota:
 
-1. **La fila de la lista no tiene ni vista previa ni hora.** `AlloRoomSummary` no
-   lleva último evento ni marca de actividad. El orden no se pierde —lo da el
-   puerto— pero el texto y la hora se quedan vacíos, que es lo que el formateador
-   dibuja como nada. Inventar `Date.now()` pondría «ahora» al lado de cada
-   conversación de la app.
-2. **El tamaño de letra por mensaje no viaja.** `AlloTimelineHandle.sendText`
+1. **El tamaño de letra por mensaje no viaja.** `AlloTimelineHandle.sendText`
    manda un cuerpo y nada más; `so.oxy.allo.font_size` (§4.2 de
    `data-model.md`) necesita una llamada que el puerto no tiene.
-3. **Un envío fallido dibuja el reloj, no un error.** `MessageMetadata` sólo
+2. **Un envío fallido dibuja el reloj, no un error.** `MessageMetadata` sólo
    conoce pendiente / enviado / entregado / leído. El reloj es cierto en móvil,
    donde la cola del SDK sigue reintentando, y optimista en web, donde no.
-4. **Sin reacciones, sin edición, sin borrado, sin adjuntos, sin recibos de
-   lectura, sin indicador de escribiendo, sin crear conversaciones.** El puerto
-   no expone ninguna de esas operaciones todavía.
+3. **Sin reacciones, sin edición, sin borrado, sin adjuntos, sin recibos de
+   lectura, sin indicador de escribiendo.** El puerto no expone ninguna de esas
+   operaciones todavía.
+4. **Nadie llama a `createRoom`.** El puerto sabe crear una conversación; no hay
+   pantalla que lo pida, así que en la app sigue sin poder empezarse un chat
+   nuevo por el camino de Matrix.
 5. **Una sesión revocada desde fuera no se nota hasta el siguiente arranque.** Si
    el usuario borra este dispositivo desde otro cliente, el sync empieza a fallar
    y la app lo dibuja como un error de sincronización, no como «te han cerrado la
@@ -161,10 +176,11 @@ Por orden de cuánto se nota:
    `matrix-js-sdk` también (`HttpApiEvent.SessionLoggedOut`); el puerto no expone
    ninguno de los dos todavía. El camino de vuelta existe —cerrar sesión desde
    Ajustes— pero hay que saber que hace falta.
-6. **Las invitaciones aparecen como filas normales.** El puerto las incluye
-   («todo lo que el usuario no ha abandonado»), y abrir una probablemente no dé
-   timeline. No se filtran aquí: la definición de qué es una conversación es del
-   puerto, no de este mapeo.
+6. **Una invitación se distingue pero se pinta igual.** El resumen dice cuál lo
+   es (`membership`) y `Conversation.isInvitation` lo lleva hasta la pantalla,
+   que todavía no hace nada distinto con él: la fila se dibuja como cualquier
+   otra y abrirla no da timeline. Aceptar o rechazar tampoco existe — el puerto
+   no expone ninguna de las dos.
 
 ## 6. Web
 

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -247,6 +247,10 @@ class FakeChatClient implements AlloChatClient {
     throw new Error('not used by these tests');
   }
 
+  async createRoom(): Promise<string> {
+    throw new Error('not used by these tests');
+  }
+
   async roomEncryption(): Promise<AlloEncryptionState> {
     return 'encrypted';
   }

--- a/packages/frontend/__tests__/chat/matrixViewModel.test.ts
+++ b/packages/frontend/__tests__/chat/matrixViewModel.test.ts
@@ -1,5 +1,6 @@
 import { toConversation, toMessage, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
-import type { AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
+import type { AlloRoomPreview, AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
+import { formatConversationTimestamp } from '@/utils/dateUtils';
 
 /**
  * The translation from what the port reports to what Allo's chat components
@@ -22,6 +23,18 @@ function room(overrides: Partial<AlloRoomSummary> = {}): AlloRoomSummary {
     membership: 'joined',
     encryption: 'encrypted',
     unreadCount: 0,
+    latestMessage: undefined,
+    ...overrides,
+  };
+}
+
+function preview(overrides: Partial<AlloRoomPreview> = {}): AlloRoomPreview {
+  return {
+    sentAt: 1_700_000_000_000,
+    sender: '@alice:allo.you',
+    senderDisplayName: 'Alice',
+    isOwn: false,
+    content: { kind: 'text', body: 'see you there', isEdited: false },
     ...overrides,
   };
 }
@@ -42,7 +55,7 @@ function event(overrides: Partial<AlloTimelineItem> = {}): AlloTimelineItem {
 
 describe('toConversation', () => {
   it('carries the room across as a direct conversation', () => {
-    const conversation = toConversation(room({ unreadCount: 3, avatarUrl: 'mxc://a' }));
+    const conversation = toConversation(room({ unreadCount: 3, avatarUrl: 'mxc://a' }), LABELS);
 
     expect(conversation).toMatchObject({
       id: '!room:allo.you',
@@ -54,33 +67,96 @@ describe('toConversation', () => {
   });
 
   it('calls a room that is not a direct message a group', () => {
-    expect(toConversation(room({ isDirect: false })).type).toBe('group');
+    expect(toConversation(room({ isDirect: false }), LABELS).type).toBe('group');
   });
 
   it('falls back to the room id while the name has not synced', () => {
     // A blank row is worse than an ugly one: the user can still tell two
     // unnamed conversations apart by their ids, and cannot tell two blanks apart.
-    expect(toConversation(room({ displayName: undefined })).name).toBe('!room:allo.you');
+    expect(toConversation(room({ displayName: undefined }), LABELS).name).toBe('!room:allo.you');
   });
 
-  it('leaves the last message empty rather than inventing one', () => {
-    // The port's room summary carries no latest event. Reading one would mean a
-    // timeline open per room in the list.
-    expect(toConversation(room()).lastMessage).toBe('');
+  it('shows the last message and the time it was sent', () => {
+    const conversation = toConversation(
+      room({ latestMessage: preview({ sentAt: 1_700_000_000_000 }) }),
+      LABELS,
+    );
+
+    expect(conversation.lastMessage).toBe('see you there');
+    expect(new Date(conversation.timestamp).getTime()).toBe(1_700_000_000_000);
   });
 
   it('leaves the timestamp empty rather than saying "now"', () => {
-    // This is the mistake this test exists to prevent. `AlloRoomSummary` has no
-    // activity time, and `new Date().toISOString()` would put the current time
-    // beside every conversation in the app — including one nobody has touched in
-    // a year. An empty string is what the formatter renders as nothing.
-    expect(toConversation(room()).timestamp).toBe('');
+    // This is the mistake this test exists to prevent. A room whose latest
+    // message this device does not know has no activity time, and the current
+    // time would put "now" beside every conversation in the app — including one
+    // nobody has touched in a year. An empty string is what the formatter
+    // renders as nothing.
+    const conversation = toConversation(room({ latestMessage: undefined }), LABELS);
+
+    expect(conversation.timestamp).toBe('');
+    expect(formatConversationTimestamp(conversation.timestamp)).toBe('');
+  });
+
+  it('leaves the preview empty when there is no message, rather than inventing one', () => {
+    expect(toConversation(room({ latestMessage: undefined }), LABELS).lastMessage).toBe('');
+  });
+
+  it('says so when the last message cannot be read on this device', () => {
+    // A row that went blank would read as a conversation nobody has written in.
+    // A device set up today sees this for every conversation it joins.
+    const conversation = toConversation(
+      room({ latestMessage: preview({ content: { kind: 'undecryptable' } }) }),
+      LABELS,
+    );
+
+    expect(conversation.lastMessage).toBe('cannot be read on this device');
+    expect(conversation.lastMessage).not.toBe('');
+  });
+
+  it('still shows a time for a message it cannot read', () => {
+    // The time comes from the event, which arrived; only its content did not.
+    const conversation = toConversation(
+      room({
+        latestMessage: preview({ content: { kind: 'undecryptable' }, sentAt: 1_600_000_000_000 }),
+      }),
+      LABELS,
+    );
+
+    expect(new Date(conversation.timestamp).getTime()).toBe(1_600_000_000_000);
+  });
+
+  it('says so when the last message was deleted, and when it cannot be drawn', () => {
+    expect(
+      toConversation(room({ latestMessage: preview({ content: { kind: 'redacted' } }) }), LABELS)
+        .lastMessage,
+    ).toBe('was deleted');
+    expect(
+      toConversation(
+        room({
+          latestMessage: preview({ content: { kind: 'unsupported', description: 'm.image' } }),
+        }),
+        LABELS,
+      ).lastMessage,
+    ).toBe('cannot show this yet (m.image)');
+  });
+
+  it('marks an invitation as one', () => {
+    // An invitation is in the list because the port's definition of a
+    // conversation is everything the viewer has not left. It is not a
+    // conversation yet — there is nothing to read in it until it is accepted —
+    // and the screen cannot tell unless this says so.
+    expect(toConversation(room({ membership: 'invited' }), LABELS).isInvitation).toBe(true);
+  });
+
+  it('does not mark a conversation the viewer has joined as an invitation', () => {
+    expect(toConversation(room({ membership: 'joined' }), LABELS).isInvitation).toBe(false);
   });
 
   it('leaves the conversation theme unset', () => {
     // Themes are to travel as an encrypted timeline event and nothing writes one
     // yet, so a Matrix conversation uses the app's theme.
-    expect(toConversation(room()).theme).toBeUndefined();
+    expect(toConversation(room(), LABELS).theme).toBeUndefined();
   });
 });
 

--- a/packages/frontend/__tests__/chat/roomListSource.test.ts
+++ b/packages/frontend/__tests__/chat/roomListSource.test.ts
@@ -130,6 +130,10 @@ class FakeChatClient implements AlloChatClient {
     throw new Error('not used by these tests');
   }
 
+  async createRoom(): Promise<string> {
+    throw new Error('not used by these tests');
+  }
+
   async roomEncryption(): Promise<AlloEncryptionState> {
     throw new Error('not used by these tests');
   }

--- a/packages/frontend/__tests__/chat/roomListSource.test.ts
+++ b/packages/frontend/__tests__/chat/roomListSource.test.ts
@@ -35,6 +35,7 @@ function summary(roomId: string): AlloRoomSummary {
     membership: 'joined',
     encryption: 'encrypted',
     unreadCount: 0,
+    latestMessage: undefined,
   };
 }
 

--- a/packages/frontend/__tests__/chat/timelineSource.test.ts
+++ b/packages/frontend/__tests__/chat/timelineSource.test.ts
@@ -161,6 +161,10 @@ class FakeChatClient implements AlloChatClient {
     throw new Error('not used by these tests');
   }
 
+  async createRoom(): Promise<string> {
+    throw new Error('not used by these tests');
+  }
+
   async roomEncryption(): Promise<AlloEncryptionState> {
     throw new Error('not used by these tests');
   }

--- a/packages/frontend/__tests__/matrix/directMessage.test.ts
+++ b/packages/frontend/__tests__/matrix/directMessage.test.ts
@@ -1,0 +1,46 @@
+import { soleDirectInvitee } from '@/lib/matrix/directMessage';
+import type { AlloCreateRoomRequest } from '@/lib/matrix/types';
+
+/**
+ * When creating a conversation means reusing one.
+ *
+ * The rule is above the platform split because the two halves look the existing
+ * room up in completely different ways and must still agree on *when* to look. If
+ * they drift, the same tap opens the conversation the user already had on one
+ * platform and starts a second one on the other — two threads of history that
+ * neither person can see from the other.
+ */
+
+function request(overrides: Partial<AlloCreateRoomRequest> = {}): AlloCreateRoomRequest {
+  return {
+    invite: ['@alice:allo.you'],
+    name: undefined,
+    isDirect: true,
+    ...overrides,
+  };
+}
+
+describe('soleDirectInvitee', () => {
+  it('names the person a direct message is with', () => {
+    expect(soleDirectInvitee(request())).toBe('@alice:allo.you');
+  });
+
+  it('has nobody to look up for a group', () => {
+    // A group is a new room every time it is asked for. Two groups with the same
+    // members are two different conversations, and the user meant the new one.
+    expect(soleDirectInvitee(request({ isDirect: false }))).toBe(undefined);
+  });
+
+  it('has nobody to look up for a room with two people invited', () => {
+    // `m.direct` records one room per person. Three people cannot share a
+    // conversation that every client resolves to a pair, so there is no room to
+    // find however the caller labelled the request.
+    expect(
+      soleDirectInvitee(request({ invite: ['@alice:allo.you', '@bob:allo.you'] })),
+    ).toBe(undefined);
+  });
+
+  it('has nobody to look up for a room the user is alone in', () => {
+    expect(soleDirectInvitee(request({ invite: [] }))).toBe(undefined);
+  });
+});

--- a/packages/frontend/__tests__/matrix/roomSummaries.test.ts
+++ b/packages/frontend/__tests__/matrix/roomSummaries.test.ts
@@ -1,22 +1,63 @@
-import { EncryptionState, Membership } from '@unomed/react-native-matrix-sdk';
+import {
+  EncryptionState,
+  Membership,
+  MessageType,
+  MsgLikeKind,
+  ProfileDetails,
+  TimelineItemContent,
+} from '@unomed/react-native-matrix-sdk';
 
 import { RoomSummaryCache, type RoomEntry } from '@/lib/matrix/native/roomSummaries';
-import type { RoomSummaryFields } from '@/lib/matrix/native/translate';
+import type { RoomPreviewFields, RoomSummaryFields } from '@/lib/matrix/native/translate';
 
 jest.mock('@unomed/react-native-matrix-sdk');
 
 /**
- * A room, unlike a timeline row, does not carry its summary: reading one is an
- * async call across the FFI boundary. The room list stream emits a batch whenever
- * any conversation changes, so re-reading every room per batch would cost one
- * round trip per conversation per message received by anyone.
+ * A room, unlike a timeline row, does not carry its summary: reading one is two
+ * async calls across the FFI boundary. The room list stream emits a batch
+ * whenever any conversation changes, so re-reading every room per batch would
+ * cost two round trips per conversation per message received by anyone.
  */
 
 interface CountedRoom extends RoomEntry {
   readonly reads: () => number;
 }
 
-function room(id: string, overrides: Partial<RoomSummaryFields> = {}): CountedRoom {
+function message(body: string): RoomPreviewFields['content'] {
+  return new TimelineItemContent.MsgLike({
+    content: {
+      kind: new MsgLikeKind.Message({
+        content: {
+          msgType: new MessageType.Text({ content: { body } }),
+          body,
+          isEdited: false,
+        },
+      }),
+      reactions: [],
+    },
+  });
+}
+
+function latestEvent(overrides: Partial<RoomPreviewFields> = {}): RoomPreviewFields {
+  return {
+    sender: '@alice:allo.you',
+    senderProfile: new ProfileDetails.Unavailable(),
+    content: message('hello'),
+    timestamp: 1_700_000_000_000n,
+    isOwn: false,
+    ...overrides,
+  };
+}
+
+interface RoomOptions {
+  readonly info?: Partial<RoomSummaryFields>;
+  /** The room's latest event: absent by default, as an untouched room's is. */
+  readonly latest?: RoomPreviewFields;
+  /** Makes `latestEvent()` reject, as it does for a room the store cannot read. */
+  readonly latestFails?: boolean;
+}
+
+function room(id: string, options: RoomOptions = {}): CountedRoom {
   let reads = 0;
   return {
     roomInfo: async () => {
@@ -29,8 +70,14 @@ function room(id: string, overrides: Partial<RoomSummaryFields> = {}): CountedRo
         membership: Membership.Joined,
         encryptionState: EncryptionState.Encrypted,
         numUnreadMessages: 0n,
-        ...overrides,
+        ...options.info,
       };
+    },
+    latestEvent: async () => {
+      if (options.latestFails === true) {
+        throw new Error('the event cache has nothing for this room');
+      }
+      return options.latest;
     },
     reads: () => reads,
   };
@@ -63,8 +110,8 @@ describe('RoomSummaryCache', () => {
     // unread count has to be read again — serving the cached one is how a badge
     // gets stuck.
     const cache = new RoomSummaryCache();
-    const before = room('!room', { numUnreadMessages: 0n });
-    const after = room('!room', { numUnreadMessages: 2n });
+    const before = room('!room', { info: { numUnreadMessages: 0n } });
+    const after = room('!room', { info: { numUnreadMessages: 2n } });
 
     expect((await cache.project([before]))[0]?.unreadCount).toBe(0);
     expect((await cache.project([after]))[0]?.unreadCount).toBe(2);
@@ -90,10 +137,12 @@ describe('RoomSummaryCache', () => {
 
     const summaries = await cache.project([
       room('!room', {
-        displayName: 'Bea',
-        encryptionState: EncryptionState.Unknown,
-        numUnreadMessages: 5n,
-        membership: Membership.Invited,
+        info: {
+          displayName: 'Bea',
+          encryptionState: EncryptionState.Unknown,
+          numUnreadMessages: 5n,
+          membership: Membership.Invited,
+        },
       }),
     ]);
 
@@ -105,6 +154,47 @@ describe('RoomSummaryCache', () => {
       membership: 'invited',
       encryption: 'unknown',
       unreadCount: 5,
+      latestMessage: undefined,
     });
+  });
+
+  it("carries the room's latest message and the time it was sent", async () => {
+    const cache = new RoomSummaryCache();
+
+    const summaries = await cache.project([
+      room('!room', {
+        latest: latestEvent({ content: message('see you there'), timestamp: 1_600_000_000_000n }),
+      }),
+    ]);
+
+    expect(summaries[0]?.latestMessage).toEqual({
+      sentAt: 1_600_000_000_000,
+      sender: '@alice:allo.you',
+      senderDisplayName: undefined,
+      isOwn: false,
+      content: { kind: 'text', body: 'see you there', isEdited: false },
+    });
+  });
+
+  it('gives a room nobody has written in no preview and no time', async () => {
+    // An invitation, and a room created a second ago. `undefined` is the answer
+    // that lets the row say nothing; anything else would be a time invented here.
+    const summaries = await new RoomSummaryCache().project([room('!fresh')]);
+
+    expect(summaries[0]?.latestMessage).toBe(undefined);
+  });
+
+  it('keeps a room whose latest message could not be read', async () => {
+    // The row still has a name, an avatar and an unread count. Losing the whole
+    // conversation list because one room's last message could not be fetched
+    // would be a far worse answer than one row without a preview.
+    const summaries = await new RoomSummaryCache().project([
+      room('!broken', { latestFails: true }),
+      room('!fine', { latest: latestEvent() }),
+    ]);
+
+    expect(summaries.map((summary) => summary.roomId)).toEqual(['!broken', '!fine']);
+    expect(summaries[0]?.latestMessage).toBe(undefined);
+    expect(summaries[1]?.latestMessage).toBeDefined();
   });
 });

--- a/packages/frontend/__tests__/matrix/translate.test.ts
+++ b/packages/frontend/__tests__/matrix/translate.test.ts
@@ -16,9 +16,11 @@ import type { EventTimelineItem, TimelineItemContent as SdkTimelineItemContent }
 
 import {
   toEncryptionState,
+  toRoomPreview,
   toRoomSummary,
   toSyncState,
   toTimelineItem,
+  type RoomPreviewFields,
   type RoomSummaryFields,
   type TimelineEventFields,
 } from '@/lib/matrix/native/translate';
@@ -62,6 +64,18 @@ function event(overrides: Partial<TimelineEventFields> = {}): TimelineEventField
   };
 }
 
+/** A room's latest event, described by the members the row's preview reads. */
+function preview(overrides: Partial<RoomPreviewFields> = {}): RoomPreviewFields {
+  return {
+    sender: '@alice:allo.you',
+    senderProfile: new ProfileDetails.Unavailable(),
+    content: textContent('hello'),
+    timestamp: 1_700_000_000_000n,
+    isOwn: false,
+    ...overrides,
+  };
+}
+
 function roomInfo(overrides: Partial<RoomSummaryFields> = {}): RoomSummaryFields {
   return {
     id: '!room:allo.you',
@@ -99,7 +113,7 @@ describe('toSyncState', () => {
 
 describe('toRoomSummary', () => {
   it('carries the fields the conversation list draws', () => {
-    expect(toRoomSummary(roomInfo({ numUnreadMessages: 3n }))).toEqual({
+    expect(toRoomSummary(roomInfo({ numUnreadMessages: 3n }), undefined)).toEqual({
       roomId: '!room:allo.you',
       displayName: 'Bea',
       avatarUrl: 'mxc://allo.you/avatar',
@@ -107,18 +121,19 @@ describe('toRoomSummary', () => {
       membership: 'joined',
       encryption: 'encrypted',
       unreadCount: 3,
+      latestMessage: undefined,
     });
   });
 
   it('passes an undetermined encryption state through instead of guessing', () => {
     expect(
-      toRoomSummary(roomInfo({ encryptionState: EncryptionState.Unknown })).encryption,
+      toRoomSummary(roomInfo({ encryptionState: EncryptionState.Unknown }), undefined).encryption,
     ).toBe('unknown');
   });
 
   it('names every membership', () => {
     const membershipOf = (membership: Membership): string =>
-      toRoomSummary(roomInfo({ membership })).membership;
+      toRoomSummary(roomInfo({ membership }), undefined).membership;
 
     expect(membershipOf(Membership.Invited)).toBe('invited');
     expect(membershipOf(Membership.Joined)).toBe('joined');
@@ -128,7 +143,67 @@ describe('toRoomSummary', () => {
   });
 
   it('reads an unread count that arrives as a bigint', () => {
-    expect(toRoomSummary(roomInfo({ numUnreadMessages: 42n })).unreadCount).toBe(42);
+    expect(toRoomSummary(roomInfo({ numUnreadMessages: 42n }), undefined).unreadCount).toBe(42);
+  });
+
+  it('leaves a room with no latest event without a preview, and so without a time', () => {
+    // The mistake this shape exists to prevent. An invitation and a room created
+    // a second ago both have no latest event, and the row for one has to be able
+    // to say nothing — a substituted time would read as "now" beside every
+    // conversation in the app.
+    expect(toRoomSummary(roomInfo(), undefined).latestMessage).toBe(undefined);
+  });
+
+  it('carries the room’s latest message and the time it was sent', () => {
+    const summary = toRoomSummary(roomInfo(), preview({ timestamp: 1_600_000_000_000n }));
+
+    expect(summary.latestMessage).toEqual({
+      sentAt: 1_600_000_000_000,
+      sender: '@alice:allo.you',
+      senderDisplayName: undefined,
+      isOwn: false,
+      content: { kind: 'text', body: 'hello', isEdited: false },
+    });
+  });
+});
+
+describe('toRoomPreview', () => {
+  it('reads a timestamp that arrives as a bigint', () => {
+    expect(toRoomPreview(preview({ timestamp: 1_700_000_000_000n })).sentAt).toBe(
+      1_700_000_000_000,
+    );
+  });
+
+  it('names the sender once their profile has been resolved', () => {
+    const named = preview({
+      senderProfile: new ProfileDetails.Ready({
+        displayName: 'Alice',
+        displayNameAmbiguous: false,
+        avatarUrl: undefined,
+      }),
+    });
+
+    expect(toRoomPreview(named).senderDisplayName).toBe('Alice');
+  });
+
+  it("marks the viewer's own message as theirs", () => {
+    expect(toRoomPreview(preview({ isOwn: true })).isOwn).toBe(true);
+  });
+
+  it('previews a message that cannot be decrypted as exactly that', () => {
+    // Not an empty preview. A device set up today cannot read the last message of
+    // every conversation it joins, and a blank row there reads as a conversation
+    // nobody has written in.
+    const undecryptable = preview({
+      content: new TimelineItemContent.MsgLike({
+        content: {
+          kind: new MsgLikeKind.UnableToDecrypt({ msg: new EncryptedMessage.Unknown() }),
+          reactions: [],
+        },
+      }),
+    });
+
+    expect(toRoomPreview(undecryptable).content).toEqual({ kind: 'undecryptable' });
   });
 });
 

--- a/packages/frontend/__tests__/matrix/web/roomList.test.ts
+++ b/packages/frontend/__tests__/matrix/web/roomList.test.ts
@@ -1,14 +1,22 @@
-import { directRoomIds, orderRoomList, type RoomListEntry } from '@/lib/matrix/web/roomList';
+import {
+  directRoomIds,
+  orderRoomList,
+  selectRoomPreview,
+  type RoomListEntry,
+} from '@/lib/matrix/web/roomList';
 import type { AlloRoomSummary } from '@/lib/matrix/types';
+import type { TimelineEventFields } from '@/lib/matrix/web/translate';
 
 /**
- * The order of the conversation list, and the account data that decides which of
- * its rows are direct messages.
+ * The order of the conversation list, the message each row previews, and the
+ * account data that decides which of its rows are direct messages.
  *
- * `matrix-js-sdk` hands over an unordered set of rooms where the Rust SDK hands
- * over a sorted list, so this is the code that has to produce the same list the
- * native half gets for free.
+ * `matrix-js-sdk` hands over an unordered set of rooms and no notion of a room's
+ * latest message, where the Rust SDK hands over both, so this is the code that
+ * has to produce the list the native half gets for free.
  */
+
+const VIEWER = '@viewer:allo.you';
 
 function summary(roomId: string): AlloRoomSummary {
   return {
@@ -19,11 +27,35 @@ function summary(roomId: string): AlloRoomSummary {
     membership: 'joined',
     encryption: 'encrypted',
     unreadCount: 0,
+    latestMessage: undefined,
   };
 }
 
 function entry(roomId: string, activityTimestamp: number): RoomListEntry {
   return { summary: summary(roomId), activityTimestamp };
+}
+
+/** A timeline event, described by the members the preview reads. */
+function event(type: string, body: string, sentAt = 1_700_000_000_000): TimelineEventFields {
+  return {
+    getId: () => `$${body}`,
+    getTxnId: () => undefined,
+    getSender: () => '@alice:allo.you',
+    getType: () => type,
+    getContent: () => ({ msgtype: 'm.text', body }),
+    getTs: () => sentAt,
+    isRedacted: () => false,
+    replacingEvent: () => null,
+    status: null,
+    sender: { name: 'Alice' },
+  };
+}
+
+/** `count` events of a type no row can preview. */
+function noise(count: number): TimelineEventFields[] {
+  return Array.from({ length: count }, (_unused, index) =>
+    event('m.room.member', `joined-${index}`),
+  );
 }
 
 describe('orderRoomList', () => {
@@ -68,6 +100,64 @@ describe('orderRoomList', () => {
     orderRoomList(entries);
 
     expect(entries.map((item) => item.summary.roomId)).toEqual(['!a:allo.you', '!b:allo.you']);
+  });
+});
+
+describe('selectRoomPreview', () => {
+  it('previews the newest message in the room', () => {
+    const preview = selectRoomPreview(
+      [event('m.room.message', 'older'), event('m.room.message', 'newest')],
+      VIEWER,
+    );
+
+    expect(preview?.content).toEqual({ kind: 'text', body: 'newest', isEdited: false });
+  });
+
+  it('walks past events that are not messages to the last one that is', () => {
+    // The reason this function exists rather than a call to getLastLiveEvent().
+    // Someone joining a room is not the room's latest message, and a list that
+    // said so would lose every preview the moment anybody came or went.
+    const preview = selectRoomPreview(
+      [event('m.room.message', 'the real last message'), ...noise(3)],
+      VIEWER,
+    );
+
+    expect(preview?.content).toEqual({
+      kind: 'text',
+      body: 'the real last message',
+      isEdited: false,
+    });
+  });
+
+  it('has no preview for a room whose timeline this device holds nothing of', () => {
+    // An invitation, and a room created a second ago. Not an empty preview and
+    // above all not a time: `undefined` is what stops a row inventing one.
+    expect(selectRoomPreview([], VIEWER)).toBe(undefined);
+  });
+
+  it('has no preview for a room that holds no messages at all', () => {
+    expect(selectRoomPreview(noise(5), VIEWER)).toBe(undefined);
+  });
+
+  it('gives up rather than walking a long history of events it cannot preview', () => {
+    // The list is rebuilt on every sync response and this search is per room, so
+    // it is bounded. Giving up costs a row its preview; not bounding it costs
+    // every room's whole loaded history, several times a minute.
+    const deep = [event('m.room.message', 'buried'), ...noise(40)];
+
+    expect(selectRoomPreview(deep, VIEWER)).toBe(undefined);
+  });
+
+  it('reads the time from the message it previews and not from any other event', () => {
+    const preview = selectRoomPreview(
+      [
+        event('m.room.message', 'the message', 1_600_000_000_000),
+        event('m.room.member', 'joined', 1_700_000_000_000),
+      ],
+      VIEWER,
+    );
+
+    expect(preview?.sentAt).toBe(1_600_000_000_000);
   });
 });
 

--- a/packages/frontend/__tests__/matrix/web/roomList.test.ts
+++ b/packages/frontend/__tests__/matrix/web/roomList.test.ts
@@ -1,7 +1,9 @@
 import {
   directRoomIds,
+  directRoomsWith,
   orderRoomList,
   selectRoomPreview,
+  withDirectRoom,
   type RoomListEntry,
 } from '@/lib/matrix/web/roomList';
 import type { AlloRoomSummary } from '@/lib/matrix/types';
@@ -158,6 +160,88 @@ describe('selectRoomPreview', () => {
     );
 
     expect(preview?.sentAt).toBe(1_600_000_000_000);
+  });
+});
+
+describe('directRoomsWith', () => {
+  it('answers with the rooms recorded against one person', () => {
+    const rooms = directRoomsWith(
+      { '@alice:allo.you': ['!one:allo.you', '!two:allo.you'], '@bob:allo.you': ['!three'] },
+      '@alice:allo.you',
+    );
+
+    expect(rooms).toEqual(['!one:allo.you', '!two:allo.you']);
+  });
+
+  it('answers with nothing for a person who has none, and for no account data', () => {
+    expect(directRoomsWith({}, '@alice:allo.you')).toEqual([]);
+    expect(directRoomsWith(undefined, '@alice:allo.you')).toEqual([]);
+  });
+
+  it('ignores an entry that is not a list of room ids', () => {
+    expect(directRoomsWith({ '@alice:allo.you': '!not-a-list' }, '@alice:allo.you')).toEqual([]);
+    expect(directRoomsWith({ '@alice:allo.you': [42, '!real'] }, '@alice:allo.you')).toEqual([
+      '!real',
+    ]);
+  });
+});
+
+describe('withDirectRoom', () => {
+  it('records the new room against the person it is shared with', () => {
+    expect(withDirectRoom(undefined, '@alice:allo.you', '!new:allo.you')).toEqual({
+      '@alice:allo.you': ['!new:allo.you'],
+    });
+  });
+
+  it('keeps the conversations the user already had with everybody else', () => {
+    // Account data is replaced whole. A write that sent only the pair it cared
+    // about would strip the "direct" flag off every other conversation the user
+    // has, with every client that ever set one.
+    const next = withDirectRoom(
+      { '@bob:allo.you': ['!bob-room'], '@carol:allo.you': ['!carol-room'] },
+      '@alice:allo.you',
+      '!new:allo.you',
+    );
+
+    expect(next).toEqual({
+      '@bob:allo.you': ['!bob-room'],
+      '@carol:allo.you': ['!carol-room'],
+      '@alice:allo.you': ['!new:allo.you'],
+    });
+  });
+
+  it('adds to the rooms already shared with that person rather than replacing them', () => {
+    const next = withDirectRoom(
+      { '@alice:allo.you': ['!old:allo.you'] },
+      '@alice:allo.you',
+      '!new:allo.you',
+    );
+
+    expect(next['@alice:allo.you']).toEqual(['!old:allo.you', '!new:allo.you']);
+  });
+
+  it('does not record the same room twice', () => {
+    const next = withDirectRoom(
+      { '@alice:allo.you': ['!room:allo.you'] },
+      '@alice:allo.you',
+      '!room:allo.you',
+    );
+
+    expect(next['@alice:allo.you']).toEqual(['!room:allo.you']);
+  });
+
+  it('writes back content the next reader can trust', () => {
+    // What it declines to carry over is what is not `m.direct` content at all.
+    const next = withDirectRoom(
+      { '@bob:allo.you': 'not-a-list', '@carol:allo.you': [7, '!carol-room'] },
+      '@alice:allo.you',
+      '!new:allo.you',
+    );
+
+    expect(next).toEqual({
+      '@carol:allo.you': ['!carol-room'],
+      '@alice:allo.you': ['!new:allo.you'],
+    });
   });
 });
 

--- a/packages/frontend/__tests__/matrix/web/translate.test.ts
+++ b/packages/frontend/__tests__/matrix/web/translate.test.ts
@@ -1,5 +1,6 @@
 import {
   toEncryptionState,
+  toRoomPreview,
   toRoomSummary,
   toSyncState,
   toTimelineItem,
@@ -107,7 +108,7 @@ describe('toEncryptionState', () => {
 
 describe('toRoomSummary', () => {
   it('reads a room the way the conversation list draws it', () => {
-    expect(toRoomSummary(room(), roomState(['m.room.create']), true)).toEqual({
+    expect(toRoomSummary(room(), roomState(['m.room.create']), true, undefined)).toEqual({
       roomId: '!room:allo.you',
       displayName: 'Kitchen',
       avatarUrl: 'mxc://allo.you/avatar',
@@ -115,6 +116,7 @@ describe('toRoomSummary', () => {
       membership: 'joined',
       encryption: 'encrypted',
       unreadCount: 3,
+      latestMessage: undefined,
     });
   });
 
@@ -122,7 +124,8 @@ describe('toRoomSummary', () => {
     const memberships = ['join', 'invite', 'leave', 'knock', 'ban'];
     const mapped = memberships.map(
       (membership) =>
-        toRoomSummary(room({ getMyMembership: () => membership }), undefined, false)?.membership,
+        toRoomSummary(room({ getMyMembership: () => membership }), undefined, false, undefined)
+          ?.membership,
     );
 
     expect(mapped).toEqual(['joined', 'invited', 'left', 'knocked', 'banned']);
@@ -131,9 +134,9 @@ describe('toRoomSummary', () => {
   it('drops a room whose membership this version of Allo has no name for', () => {
     // `Membership` is an open string type. Reporting an unknown one as joined
     // would put a room the user is not in at the top of their conversations.
-    expect(toRoomSummary(room({ getMyMembership: () => 'm.future.state' }), undefined, false)).toBe(
-      undefined,
-    );
+    expect(
+      toRoomSummary(room({ getMyMembership: () => 'm.future.state' }), undefined, false, undefined),
+    ).toBe(undefined);
   });
 
   it('treats a room with no name and no avatar as having neither', () => {
@@ -141,6 +144,7 @@ describe('toRoomSummary', () => {
       room({ name: '', getMxcAvatarUrl: () => null }),
       undefined,
       false,
+      undefined,
     );
 
     expect(summary?.displayName).toBe(undefined);
@@ -151,11 +155,86 @@ describe('toRoomSummary', () => {
     const counts = [-1, Number.NaN, 1.5];
     const mapped = counts.map(
       (count) =>
-        toRoomSummary(room({ getUnreadNotificationCount: () => count }), undefined, false)
+        toRoomSummary(room({ getUnreadNotificationCount: () => count }), undefined, false, undefined)
           ?.unreadCount,
     );
 
     expect(mapped).toEqual([0, 0, 0]);
+  });
+});
+
+describe('toRoomPreview', () => {
+  it('reads the message a conversation row shows', () => {
+    expect(toRoomPreview(event(), VIEWER)).toEqual({
+      sentAt: 1_700_000_000_000,
+      sender: '@alice:allo.you',
+      senderDisplayName: 'Alice',
+      isOwn: false,
+      content: { kind: 'text', body: 'hello', isEdited: false },
+    });
+  });
+
+  it('carries the time the message was sent and never the time it was read', () => {
+    // The field this whole change exists for. A row's time is the message's, and
+    // the only way to have one is to have a message.
+    expect(toRoomPreview(event({ getTs: () => 1_600_000_000_000 }), VIEWER)?.sentAt).toBe(
+      1_600_000_000_000,
+    );
+  });
+
+  it("marks the viewer's own message as theirs", () => {
+    expect(toRoomPreview(event({ getSender: () => VIEWER }), VIEWER)?.isOwn).toBe(true);
+  });
+
+  it('previews a message that cannot be decrypted as exactly that', () => {
+    // Not an empty preview. A device set up today cannot read the last message of
+    // every conversation it joins, and a blank row there reads as a conversation
+    // nobody has written in.
+    const preview = toRoomPreview(event({ getType: () => 'm.room.encrypted' }), VIEWER);
+
+    expect(preview?.content).toEqual({ kind: 'undecryptable' });
+  });
+
+  it('previews a redacted message as redacted', () => {
+    expect(toRoomPreview(event({ isRedacted: () => true }), VIEWER)?.content).toEqual({
+      kind: 'redacted',
+    });
+  });
+
+  it('previews a message it cannot draw as a message it cannot draw', () => {
+    // An image is a message. The row has to say something about it, and naming
+    // the kind is better than showing the filename its body carries.
+    const preview = toRoomPreview(
+      event({ getContent: () => ({ msgtype: 'm.image', body: 'IMG_0042.jpg' }) }),
+      VIEWER,
+    );
+
+    expect(preview?.content).toEqual({
+      kind: 'unsupported',
+      description: 'm.room.message:m.image',
+    });
+  });
+
+  it('does not preview an event that is not one of the room’s messages', () => {
+    // The case the whole filter exists for: without it, every conversation's
+    // preview becomes "someone joined" the moment someone does.
+    const memberships = ['m.room.member', 'm.room.name', 'm.room.avatar', 'm.reaction'];
+
+    expect(memberships.map((type) => toRoomPreview(event({ getType: () => type }), VIEWER))).toEqual(
+      [undefined, undefined, undefined, undefined],
+    );
+  });
+
+  it('previews stickers and polls, in both spellings a poll has', () => {
+    const types = ['m.sticker', 'm.poll.start', 'org.matrix.msc3381.poll.start'];
+
+    for (const type of types) {
+      expect(toRoomPreview(event({ getType: () => type }), VIEWER)).toBeDefined();
+    }
+  });
+
+  it('does not preview an event with no sender', () => {
+    expect(toRoomPreview(event({ getSender: () => undefined }), VIEWER)).toBe(undefined);
   });
 });
 

--- a/packages/frontend/app/(chat)/index.tsx
+++ b/packages/frontend/app/(chat)/index.tsx
@@ -93,6 +93,13 @@ export interface Conversation {
     unreadCount: number;
     avatar?: string; // For direct: contact avatar, for group: group avatar or first participant avatar
     isArchived?: boolean;
+    /**
+     * The viewer has been invited and has not joined. There is nothing to read in
+     * the conversation until they do, and opening it yields no messages.
+     *
+     * Only the Matrix backend produces this: the Express API has no invitations.
+     */
+    isInvitation?: boolean;
     theme?: string; // Color theme ID (shared with all participants)
     // Group-specific fields
     participants?: ConversationParticipant[]; // All participants (including current user for groups)

--- a/packages/frontend/hooks/useMatrixConversations.ts
+++ b/packages/frontend/hooks/useMatrixConversations.ts
@@ -1,8 +1,9 @@
 import { useMemo, useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { Conversation } from '@/app/(chat)/index';
 import { CHAT_BACKEND } from '@/lib/chat/backend';
-import { toConversation } from '@/lib/chat/matrixViewModel';
+import { toConversation, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
 import { roomListSource } from '@/lib/chat/roomListSource';
 import type { AlloRoomSummary, AlloUnsubscribe } from '@/lib/matrix/types';
 
@@ -25,14 +26,34 @@ const noRooms = (): readonly AlloRoomSummary[] => NO_ROOMS;
 const enabled = CHAT_BACKEND === 'matrix';
 
 export function useMatrixConversations(): readonly Conversation[] | undefined {
+  const { t } = useTranslation();
+
   const rooms = useSyncExternalStore(
     enabled ? roomListSource.subscribe : subscribeToNothing,
     enabled ? roomListSource.getSnapshot : noRooms,
     noRooms,
   );
 
+  /**
+   * The same words the timeline uses for the same three facts. A conversation
+   * whose last message cannot be read on this device says so in the list too:
+   * an empty preview there reads as a conversation nobody has written in.
+   */
+  const labels = useMemo<UnreadableEventLabels>(
+    () => ({
+      undecryptable: t('This message cannot be read on this device.'),
+      redacted: t('This message was deleted.'),
+      unsupported: (description) =>
+        t('Allo cannot show this yet ({{kind}}).', { kind: description }),
+    }),
+    [t],
+  );
+
   // Derived during render, as a mapping of the snapshot should be. An Effect that
   // mirrored this into state would render one frame of the previous list every
   // time a message arrived.
-  return useMemo(() => (enabled ? rooms.map(toConversation) : undefined), [rooms]);
+  return useMemo(
+    () => (enabled ? rooms.map((room) => toConversation(room, labels)) : undefined),
+    [rooms, labels],
+  );
 }

--- a/packages/frontend/lib/chat/matrixViewModel.ts
+++ b/packages/frontend/lib/chat/matrixViewModel.ts
@@ -1,5 +1,5 @@
 import type { Conversation } from '@/app/(chat)/index';
-import type { AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
+import type { AlloEventContent, AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
 import type { Message } from '@/stores/messagesStore';
 
 /**
@@ -34,24 +34,29 @@ export interface UnreadableEventLabels {
 /**
  * A room, as a row of the conversation list.
  *
- * Two of `Conversation`'s fields cannot be filled from what the port reports, and
- * they are left empty rather than invented:
+ * **A row with no known time says nothing, and must be able to.** A room whose
+ * latest message this device does not know — an invitation, a conversation
+ * created a moment ago, one whose history has not arrived — has no preview and no
+ * time, and both come out empty. `formatConversationTimestamp` renders an empty
+ * string as nothing, which is the honest answer; the current time would put "now"
+ * beside every conversation in the app, including one nobody has touched in a
+ * year. That is the mistake this mapping is shaped to make impossible: the time
+ * is read from the message, so there is no time to invent when there is no
+ * message.
  *
- * - `lastMessage`. {@link AlloRoomSummary} carries no latest event. Reading one
- *   would mean opening a timeline per room, which for a list of hundreds is a
- *   timeline per room open at once.
- * - `timestamp`. Nor does it carry an activity time. The *order* of the list is
- *   not lost — the port hands it back already ordered, and this mapping never
- *   re-sorts — but the time shown next to each row is. An empty string is what
- *   `formatConversationTimestamp` renders as nothing, which is the honest answer;
- *   `Date.now()` would put "now" beside every conversation in the app.
+ * The *order* of the list is not this mapping's business either way. The port
+ * hands it back already ordered and nothing here re-sorts.
  *
- * `theme` is absent for the same kind of reason and is not a gap in the port: a
- * conversation's theme is to be an encrypted timeline event
- * (`docs/matrix/data-model.md` §4.1) and no code writes or reads one yet, so
- * every Matrix conversation falls back to the app's theme.
+ * `theme` is absent, and is not a gap in the port: a conversation's theme is to
+ * be an encrypted timeline event (`docs/matrix/data-model.md` §4.1) and no code
+ * writes or reads one yet, so every Matrix conversation falls back to the app's
+ * theme.
  */
-export function toConversation(summary: AlloRoomSummary): Conversation {
+export function toConversation(
+  summary: AlloRoomSummary,
+  labels: UnreadableEventLabels,
+): Conversation {
+  const latest = summary.latestMessage;
   return {
     id: summary.roomId,
     type: summary.isDirect ? 'direct' : 'group',
@@ -59,10 +64,15 @@ export function toConversation(summary: AlloRoomSummary): Conversation {
     // user sees while sync has not yet delivered the room's name or enough
     // members to compute one.
     name: summary.displayName ?? summary.roomId,
-    lastMessage: '',
-    timestamp: '',
+    lastMessage: latest === undefined ? '' : bodyOf(latest.content, labels),
+    timestamp: latest === undefined ? '' : new Date(latest.sentAt).toISOString(),
     unreadCount: summary.unreadCount,
     avatar: summary.avatarUrl,
+    // An invitation is in the list because the port's definition of a
+    // conversation is everything the viewer has not left, and it is not a
+    // conversation yet: there is nothing to read in it and accepting comes first.
+    // What to do about that is the screen's decision, not this mapping's.
+    isInvitation: summary.membership === 'invited',
   };
 }
 
@@ -80,7 +90,7 @@ export function toMessage(
 ): Message {
   return {
     id: item.key,
-    text: bodyOf(item, labels),
+    text: bodyOf(item.content, labels),
     senderId: item.sender,
     senderName: item.senderDisplayName,
     timestamp: new Date(item.sentAt),
@@ -92,16 +102,24 @@ export function toMessage(
   };
 }
 
-function bodyOf(item: AlloTimelineItem, labels: UnreadableEventLabels): string {
-  switch (item.content.kind) {
+/**
+ * What an event says, in words, whether it is a bubble or a row's preview.
+ *
+ * One function for both because the three states that carry no text mean exactly
+ * the same thing in each place. A conversation whose last message this device
+ * cannot decrypt has to say so in the list as well as in the timeline: an empty
+ * preview there reads as a conversation nobody has written in.
+ */
+function bodyOf(content: AlloEventContent, labels: UnreadableEventLabels): string {
+  switch (content.kind) {
     case 'text':
-      return item.content.body;
+      return content.body;
     case 'undecryptable':
       return labels.undecryptable;
     case 'redacted':
       return labels.redacted;
     case 'unsupported':
-      return labels.unsupported(item.content.description);
+      return labels.unsupported(content.description);
   }
 }
 

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -1,9 +1,12 @@
 import {
   ClientBuilder,
   LogLevel,
+  Membership,
   MessageType,
   OidcPrompt,
   RoomListEntriesDynamicFilterKind,
+  RoomPreset,
+  RoomVisibility,
   SlidingSyncVersion,
   SlidingSyncVersionBuilder,
   initPlatform,
@@ -26,6 +29,7 @@ import type {
   TimelineLike,
 } from '@unomed/react-native-matrix-sdk';
 
+import { soleDirectInvitee } from '@/lib/matrix/directMessage';
 import { MatrixRoomNotFoundError, MatrixSyncNotStartedError } from '@/lib/matrix/errors';
 // Named in full rather than as `@/lib/matrix/store`: this half of the port is
 // the native one and its store is the native one, and saying so leaves no
@@ -37,6 +41,7 @@ import type {
   AlloChatClientConfig,
   AlloChatClientFactory,
   AlloClientStore,
+  AlloCreateRoomRequest,
   AlloEncryptionState,
   AlloOidcClientMetadata,
   AlloOidcLoginOptions,
@@ -81,6 +86,19 @@ const LOG_TAG = '[matrix]';
  * conversations would be missing.
  */
 const ROOM_LIST_PAGE_SIZE = 500;
+
+/**
+ * The memberships that make an existing direct message worth reopening.
+ *
+ * A room the user was invited to is one: accepting the invitation is how the
+ * conversation continues, and inviting them to a second room instead leaves two.
+ * A room they left, were kicked from or were banned from is not — `m.direct`
+ * still names it, and the way back in is not to send another message into it.
+ */
+const REUSABLE_MEMBERSHIPS: ReadonlySet<Membership> = new Set([
+  Membership.Joined,
+  Membership.Invited,
+]);
 
 /**
  * Rust's logging and callback machinery is process-global and has to be set up
@@ -291,6 +309,49 @@ class NativeAlloChatClient implements AlloChatClient {
     handle.attach(roomList.entriesWithDynamicAdapters(ROOM_LIST_PAGE_SIZE, handle.listener));
     this.#roomLists.add(handle);
     return handle;
+  }
+
+  /**
+   * Creates a conversation, or hands back the one that already exists.
+   *
+   * `getDmRoom` is the binding's own index of `m.direct`, and it answers for
+   * rooms the user has left as well as ones they are in — a conversation somebody
+   * walked out of is not one to reopen, so the membership is checked rather than
+   * assumed.
+   *
+   * The parameters that are not the caller's: the room is private, invite-only
+   * and encrypted, which is what Allo is. `TrustedPrivateChat` for a direct
+   * message gives both people the same power level, because a conversation
+   * between two people has no moderator; a group keeps `PrivateChat`, where the
+   * creator can name it and invite.
+   */
+  async createRoom(request: AlloCreateRoomRequest): Promise<string> {
+    const invitee = soleDirectInvitee(request);
+    if (invitee !== undefined) {
+      const existing = this.#client.getDmRoom(invitee);
+      if (existing !== undefined && REUSABLE_MEMBERSHIPS.has(existing.membership())) {
+        return existing.id();
+      }
+    }
+
+    const room = await this.#client.createRoom({
+      name: request.name,
+      topic: undefined,
+      isEncrypted: true,
+      isDirect: request.isDirect,
+      visibility: new RoomVisibility.Private(),
+      preset: request.isDirect ? RoomPreset.TrustedPrivateChat : RoomPreset.PrivateChat,
+      invite: [...request.invite],
+      avatar: undefined,
+      powerLevelContentOverride: undefined,
+      joinRuleOverride: undefined,
+      historyVisibilityOverride: undefined,
+      canonicalAlias: undefined,
+    });
+    // The binding writes `m.direct` itself for a direct message with one invitee,
+    // which is the same rule {@link soleDirectInvitee} states; the web half has to
+    // do it by hand.
+    return room;
   }
 
   async roomEncryption(roomId: string): Promise<AlloEncryptionState> {

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -4,14 +4,17 @@ import {
   EventTimeline,
   EventType,
   IndexedDBStore,
+  KnownMembership,
   MatrixError,
   MatrixEventEvent,
   MemoryStore,
   MsgType,
   OAuth2,
+  Preset,
   RoomEvent,
   RoomStateEvent,
   TokenRefresher,
+  Visibility,
   createClient,
   isValidAuthMetadata,
 } from 'matrix-js-sdk';
@@ -46,11 +49,13 @@ import {
 // the web one and its store is the web one, and saying so leaves no resolution
 // rule to trust. The platform-resolved name is for the code above the split,
 // which must not care.
+import { soleDirectInvitee } from '@/lib/matrix/directMessage';
 import { cryptoDatabasePrefix } from '@/lib/matrix/store.web';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
   AlloChatClientFactory,
+  AlloCreateRoomRequest,
   AlloEncryptionState,
   AlloOidcLoginOptions,
   AlloOidcLoginRequest,
@@ -76,8 +81,10 @@ import {
 import { planKeyBackup, toRecoveryState } from './web/recovery';
 import {
   directRoomIds,
+  directRoomsWith,
   orderRoomList,
   selectRoomPreview,
+  withDirectRoom,
   type RoomListEntry,
 } from './web/roomList';
 import { createSecretStorageKeyCallback } from './web/secretStorage';
@@ -135,6 +142,12 @@ const INITIAL_SYNC_LIMIT = 20;
 
 /** `m.room.encryption` is room state with an empty state key. */
 const ENCRYPTION_STATE_KEY = '';
+
+/**
+ * The only encryption algorithm Matrix defines for rooms, spelled out because
+ * `matrix-js-sdk@42` does not export a constant for it from its root.
+ */
+const MEGOLM_ALGORITHM = 'm.megolm.v1.aes-sha2';
 
 /**
  * The SDK's crypto surface. Taken off the client rather than imported, because
@@ -324,6 +337,89 @@ class WebAlloChatClient implements AlloChatClient {
     this.#roomLists.add(handle);
     handle.attach();
     return handle;
+  }
+
+  /**
+   * Creates a conversation, or hands back the one that already exists.
+   *
+   * Two things the native binding does on its own have to be done by hand here.
+   * There is no index of direct messages, so the existing room is looked for in
+   * `m.direct` itself; and nothing writes `m.direct` after a room is created, so
+   * a direct message that is not recorded there would come back from sync as an
+   * ordinary group with a generated name.
+   *
+   * The account data write comes after the room exists, and a failure is reported
+   * rather than allowed to lose the room: the conversation has been created and
+   * the invitation sent, and throwing here would tell the caller nothing had
+   * happened. What the user sees instead is a conversation drawn as a group,
+   * which the next client to mark it fixes.
+   *
+   * The parameters that are not the caller's: private, invite-only, encrypted.
+   * `TrustedPrivateChat` for a direct message gives both people the same power
+   * level, because a conversation between two people has no moderator.
+   */
+  async createRoom(request: AlloCreateRoomRequest): Promise<string> {
+    const client = this.#requireClient('Creating a conversation');
+    const invitee = soleDirectInvitee(request);
+
+    if (invitee !== undefined) {
+      const existing = this.#existingDirectRoom(client, invitee);
+      if (existing !== undefined) {
+        return existing;
+      }
+    }
+
+    const created = await client.createRoom({
+      name: request.name,
+      visibility: Visibility.Private,
+      preset: request.isDirect ? Preset.TrustedPrivateChat : Preset.PrivateChat,
+      is_direct: request.isDirect,
+      invite: [...request.invite],
+      initial_state: [
+        {
+          type: EventType.RoomEncryption,
+          state_key: ENCRYPTION_STATE_KEY,
+          content: { algorithm: MEGOLM_ALGORITHM },
+        },
+      ],
+    });
+
+    if (invitee !== undefined) {
+      await this.#recordDirectRoom(client, invitee, created.room_id);
+    }
+    return created.room_id;
+  }
+
+  /**
+   * The direct message this browser already knows of with one person, if there is
+   * one it makes sense to reopen.
+   *
+   * `m.direct` outlives the rooms it names — leaving a conversation does not
+   * remove it — so the membership decides, and a room sync has not delivered is
+   * one this client cannot vouch for and does not reuse.
+   */
+  #existingDirectRoom(client: MatrixClient, userId: string): string | undefined {
+    const content = client.getAccountData(EventType.Direct)?.getContent();
+    for (const roomId of directRoomsWith(content, userId)) {
+      const membership = client.getRoom(roomId)?.getMyMembership();
+      if (membership === KnownMembership.Join || membership === KnownMembership.Invite) {
+        return roomId;
+      }
+    }
+    return undefined;
+  }
+
+  async #recordDirectRoom(client: MatrixClient, userId: string, roomId: string): Promise<void> {
+    try {
+      const content = client.getAccountData(EventType.Direct)?.getContent();
+      await client.setAccountData(EventType.Direct, withDirectRoom(content, userId, roomId));
+    } catch (error) {
+      logger.error(
+        `${LOG_TAG} room ${roomId} was created but could not be marked as a direct ` +
+          'message; it will be drawn as a group until some client marks it',
+        error,
+      );
+    }
   }
 
   async roomEncryption(roomId: string): Promise<AlloEncryptionState> {

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -74,7 +74,12 @@ import {
   type OidcGrant,
 } from './web/oidcLogin';
 import { planKeyBackup, toRecoveryState } from './web/recovery';
-import { directRoomIds, orderRoomList, type RoomListEntry } from './web/roomList';
+import {
+  directRoomIds,
+  orderRoomList,
+  selectRoomPreview,
+  type RoomListEntry,
+} from './web/roomList';
 import { createSecretStorageKeyCallback } from './web/secretStorage';
 import { decodeAuthData, encodeAuthData } from './web/session';
 import { toEncryptionState, toRoomSummary, toSyncState, toTimelineItem } from './web/translate';
@@ -841,16 +846,22 @@ class WebRoomListHandle implements AlloRoomListHandle {
     }
 
     const direct = directRoomIds(this.#client.getAccountData(EventType.Direct)?.getContent());
+    const viewerUserId = this.#client.getSafeUserId();
     const entries: RoomListEntry[] = [];
 
     // `getVisibleRooms` and not `getRooms`: it drops the old versions of rooms
     // that have been upgraded, which are rooms the user has already been moved
     // out of.
     for (const room of this.#client.getVisibleRooms()) {
+      const timeline = room.getLiveTimeline();
       const summary = toRoomSummary(
         room,
-        room.getLiveTimeline().getState(EventTimeline.FORWARDS),
+        timeline.getState(EventTimeline.FORWARDS),
         direct.has(room.roomId),
+        // The live timeline and not `getLastLiveEvent()`: the row previews the
+        // room's last *message*, and the last event of all is as likely to be
+        // somebody joining. See `selectRoomPreview`.
+        selectRoomPreview(timeline.getEvents(), viewerUserId),
       );
       if (summary === undefined) {
         logger.warn(

--- a/packages/frontend/lib/matrix/directMessage.ts
+++ b/packages/frontend/lib/matrix/directMessage.ts
@@ -1,0 +1,24 @@
+import type { AlloCreateRoomRequest } from '@/lib/matrix/types';
+
+/**
+ * When creating a conversation means reusing one.
+ *
+ * This lives above the platform split, and is imported by both halves, because it
+ * is a statement about {@link AlloChatClient.createRoom}'s contract rather than
+ * about either SDK. The two implementations look up the existing room in
+ * completely different ways — the binding keeps an index, `matrix-js-sdk` has
+ * `m.direct` and nothing else — but they must agree on *when* to look, or the
+ * same tap creates a second conversation on one platform and not the other.
+ *
+ * Two invitees are not a direct message however the caller labels it: `m.direct`
+ * records one room per person, three people cannot share a conversation that
+ * every client resolves to a pair, and there is no room to find. A request with
+ * no invitees is a room the user is alone in, which is theirs and never anyone
+ * else's.
+ */
+export function soleDirectInvitee(request: AlloCreateRoomRequest): string | undefined {
+  if (!request.isDirect || request.invite.length !== 1) {
+    return undefined;
+  }
+  return request.invite[0];
+}

--- a/packages/frontend/lib/matrix/native/roomSummaries.ts
+++ b/packages/frontend/lib/matrix/native/roomSummaries.ts
@@ -1,6 +1,7 @@
 import type { AlloRoomSummary } from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
 
-import { toRoomSummary, type RoomSummaryFields } from './translate';
+import { toRoomSummary, type RoomPreviewFields, type RoomSummaryFields } from './translate';
 
 /**
  * What this module needs of a room handle, rather than the whole `RoomLike`: the
@@ -10,17 +11,21 @@ import { toRoomSummary, type RoomSummaryFields } from './translate';
  */
 export interface RoomEntry {
   roomInfo(): Promise<RoomSummaryFields>;
+  /** The room's most recent message-like event, if the binding cached one. */
+  latestEvent(): Promise<RoomPreviewFields | undefined>;
 }
+
+const LOG_TAG = '[matrix]';
 
 /**
  * Turns the mirrored room list into the array the conversation list draws.
  *
- * Unlike a timeline row, a room does not carry its own summary: `roomInfo()` is
- * an async call across the FFI boundary. Doing it for every room on every batch
- * would mean one round trip per conversation every time any conversation
- * receives a message, so summaries are cached by object identity — the binding
- * hands over a fresh room object whenever the entry changes, which is exactly
- * when the summary needs recomputing.
+ * Unlike a timeline row, a room does not carry its own summary: `roomInfo()` and
+ * `latestEvent()` are async calls across the FFI boundary. Doing them for every
+ * room on every batch would mean two round trips per conversation every time any
+ * conversation receives a message, so summaries are cached by object identity —
+ * the binding hands over a fresh room object whenever the entry changes, which is
+ * exactly when the summary needs recomputing.
  */
 export class RoomSummaryCache {
   #cache = new Map<RoomEntry, AlloRoomSummary>();
@@ -30,7 +35,7 @@ export class RoomSummaryCache {
     const projected = await Promise.all(
       rooms.map(async (room) => ({
         room,
-        summary: previous.get(room) ?? toRoomSummary(await room.roomInfo()),
+        summary: previous.get(room) ?? (await this.#read(room)),
       })),
     );
 
@@ -41,5 +46,35 @@ export class RoomSummaryCache {
     this.#cache = next;
 
     return projected.map(({ summary }) => summary);
+  }
+
+  /**
+   * Both halves of a summary, read together.
+   *
+   * The two calls go out at once because they are independent and each is a round
+   * trip; awaiting them in sequence would double the latency of a batch.
+   */
+  async #read(room: RoomEntry): Promise<AlloRoomSummary> {
+    const [info, preview] = await Promise.all([room.roomInfo(), this.#latestEvent(room)]);
+    return toRoomSummary(info, preview);
+  }
+
+  /**
+   * The room's latest event, or nothing.
+   *
+   * A preview that cannot be read is not a reason to lose the room: the row still
+   * has a name, an avatar and an unread count, and a list that vanished because
+   * one conversation's last message could not be fetched would be a worse answer
+   * than a row with no preview. The failure is reported rather than swallowed,
+   * and costs one line per room rather than one per batch because the summary it
+   * belongs to is cached either way.
+   */
+  async #latestEvent(room: RoomEntry): Promise<RoomPreviewFields | undefined> {
+    try {
+      return await room.latestEvent();
+    } catch (error) {
+      logger.warn(`${LOG_TAG} a room's latest message could not be read`, error);
+      return undefined;
+    }
   }
 }

--- a/packages/frontend/lib/matrix/native/translate.ts
+++ b/packages/frontend/lib/matrix/native/translate.ts
@@ -20,6 +20,7 @@ import type {
   AlloEventContent,
   AlloEventKey,
   AlloRoomMembership,
+  AlloRoomPreview,
   AlloRoomSummary,
   AlloSendState,
   AlloSyncState,
@@ -79,7 +80,40 @@ export type RoomSummaryFields = Pick<
   | 'numUnreadMessages'
 >;
 
-export function toRoomSummary(info: RoomSummaryFields): AlloRoomSummary {
+/** The fields of `EventTimelineItem` a conversation *row* reads. */
+export type RoomPreviewFields = Pick<
+  EventTimelineItem,
+  'sender' | 'senderProfile' | 'content' | 'timestamp' | 'isOwn'
+>;
+
+/**
+ * The row's preview, from the room's latest event.
+ *
+ * Nothing is filtered here because the binding has already done it: what
+ * `Room.latestEvent()` answers with comes from the Rust SDK's latest-event cache,
+ * which only ever holds message-like events — a member joining never becomes a
+ * room's latest event. The web half has no such cache and has to make the same
+ * choice by hand.
+ *
+ * @param preview the room's latest event, or `undefined` when it has none. A
+ * room this device has seen no message in is not a room whose preview is empty.
+ */
+export function toRoomPreview(preview: RoomPreviewFields): AlloRoomPreview {
+  return {
+    // `Timestamp` is milliseconds since the epoch as a bigint, exact as a number
+    // for another 285 000 years.
+    sentAt: Number(preview.timestamp),
+    sender: preview.sender,
+    senderDisplayName: toSenderDisplayName(preview.senderProfile),
+    isOwn: preview.isOwn,
+    content: toEventContent(preview.content),
+  };
+}
+
+export function toRoomSummary(
+  info: RoomSummaryFields,
+  preview: RoomPreviewFields | undefined,
+): AlloRoomSummary {
   return {
     roomId: info.id,
     displayName: info.displayName,
@@ -88,6 +122,7 @@ export function toRoomSummary(info: RoomSummaryFields): AlloRoomSummary {
     membership: MEMBERSHIPS[info.membership],
     encryption: toEncryptionState(info.encryptionState),
     unreadCount: Number(info.numUnreadMessages),
+    latestMessage: preview === undefined ? undefined : toRoomPreview(preview),
   };
 }
 

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -47,6 +47,12 @@ export type AlloUnsubscribe = () => void;
  * `encryption` here is whatever sync has told us so far and may well be
  * `'unknown'`; {@link AlloChatClient.roomEncryption} is the call that resolves
  * that against the server.
+ *
+ * `membership` is also what tells an **invitation** apart from a conversation.
+ * The list holds everything the viewer has not left, invitations included, and
+ * an invited room is not a conversation yet: it has no readable timeline, so its
+ * {@link latestMessage} is absent, and opening it yields nothing to draw. What
+ * the port owes the UI is the fact; what to do with it is the UI's.
  */
 export interface AlloRoomSummary {
   readonly roomId: string;
@@ -58,6 +64,52 @@ export interface AlloRoomSummary {
   readonly encryption: AlloEncryptionState;
   /** Messages the viewer has not read, independent of notification settings. */
   readonly unreadCount: number;
+  /**
+   * The room's most recent message, or `undefined` when this device knows of
+   * none.
+   *
+   * `undefined` is a real answer and not a placeholder: an invitation, a room
+   * created a second ago, and a room whose messages have not reached this device
+   * all have no latest message, and the row for one has no preview and no time.
+   * Substituting the current time is the mistake this shape exists to prevent —
+   * it puts "now" beside every conversation in the app, including one nobody has
+   * touched in a year.
+   */
+  readonly latestMessage: AlloRoomPreview | undefined;
+}
+
+/**
+ * The one message a conversation row previews.
+ *
+ * It carries {@link AlloEventContent} rather than a string because a preview is
+ * subject to every state a timeline row is: the latest message of an encrypted
+ * room may not be decryptable on this device yet, which is a state of its own and
+ * not an empty preview, and it stops being true the moment the room key arrives.
+ *
+ * `sentAt` is the row's activity time, and there is deliberately no separate
+ * field for it. A time and a preview are the same fact seen twice — a row cannot
+ * honestly show one without the other — and one field cannot go stale against
+ * the other.
+ *
+ * The sender travels with it because a group conversation's row says who spoke,
+ * and both SDKs hand the sender over inside the very object this is read from.
+ * Asking for it later would mean a timeline open per room in the list.
+ *
+ * **What counts as "the latest message".** Message-like events only: text,
+ * stickers, polls, media, an event that failed to decrypt, and a message that has
+ * been redacted. Someone joining a room is not the room's latest message, and a
+ * list that said so would replace every preview with a membership change every
+ * time anyone came or went.
+ */
+export interface AlloRoomPreview {
+  /** Milliseconds since the Unix epoch. */
+  readonly sentAt: number;
+  /** Matrix user id of the sender. */
+  readonly sender: string;
+  /** Undefined while the sender's profile has not been resolved. */
+  readonly senderDisplayName: string | undefined;
+  readonly isOwn: boolean;
+  readonly content: AlloEventContent;
 }
 
 /**

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -113,6 +113,27 @@ export interface AlloRoomPreview {
 }
 
 /**
+ * A conversation to be created.
+ *
+ * There is no "encrypted" option, and that is a decision rather than an omission:
+ * Allo is an encrypted messenger, and encryption in Matrix is one-way — a room
+ * created without it can never be given it. An option here would let a mistake
+ * become a conversation that is permanently in the clear.
+ */
+export interface AlloCreateRoomRequest {
+  /** Matrix user ids to invite. A conversation with nobody in it is allowed. */
+  readonly invite: readonly string[];
+  /** Absent for a direct message, whose name is computed from its members. */
+  readonly name: string | undefined;
+  /**
+   * Whether this is a one-to-one conversation, which is a claim about the room
+   * and not a count of its invitees: it decides `m.direct`, and through it the
+   * name and avatar the room is drawn with.
+   */
+  readonly isDirect: boolean;
+}
+
+/**
  * How an event addresses itself.
  *
  * A message the viewer just sent exists in the timeline before the homeserver
@@ -439,6 +460,27 @@ export interface AlloChatClient {
   observeRooms(
     onChange: (rooms: readonly AlloRoomSummary[]) => void,
   ): Promise<AlloRoomListHandle>;
+
+  /**
+   * Creates a conversation, and answers with its room id.
+   *
+   * Every room Allo creates is private, invite-only and encrypted; see
+   * {@link AlloCreateRoomRequest} for why none of that is a parameter.
+   *
+   * **A direct message with one invitee reuses the room that already exists with
+   * that person, if there is one.** Two people have one conversation, and the
+   * homeserver will happily mint a second room between the same pair every time
+   * it is asked — which is a second thread of history that neither of them can
+   * see from the other. What "already exists" means is what `m.direct` says and
+   * what sync has delivered, so a client that has just started may not know about
+   * a room it will know about a moment later; the alternative is refusing to
+   * create anything until sync settles.
+   *
+   * The room id comes back before sync has delivered the room, so it will not be
+   * in {@link observeRooms}'s list yet and {@link openTimeline} on it may still
+   * throw.
+   */
+  createRoom(request: AlloCreateRoomRequest): Promise<string>;
 
   /**
    * The authoritative encryption state of a room, asking the server when sync

--- a/packages/frontend/lib/matrix/web/roomList.ts
+++ b/packages/frontend/lib/matrix/web/roomList.ts
@@ -1,14 +1,17 @@
-import type { AlloRoomSummary } from '@/lib/matrix/types';
+import type { AlloRoomPreview, AlloRoomSummary } from '@/lib/matrix/types';
+
+import { toRoomPreview, type TimelineEventFields } from './translate';
 
 /**
- * The order of the conversation list, and the one piece of account data it
- * depends on.
+ * The order of the conversation list, the preview each row shows, and the one
+ * piece of account data both depend on.
  *
- * Ordering is here rather than in `client.web.ts` because it is the part of the
+ * All of it is here rather than in `client.web.ts` because it is the part of the
  * room list that is a pure function and the part most likely to be wrong in a way
- * only a test would catch. `matrix-js-sdk` hands over an unordered set of rooms —
- * there is no equivalent of the Rust SDK's already-sorted room list — so this is
- * where the web half earns the same output as the native one.
+ * only a test would catch. `matrix-js-sdk` hands over an unordered set of rooms
+ * and no notion of a room's latest message — there is no equivalent of the Rust
+ * SDK's already-sorted room list or of its latest-event cache — so this is where
+ * the web half earns the same output as the native one.
  */
 
 export interface RoomListEntry {
@@ -39,6 +42,47 @@ export function orderRoomList(entries: readonly RoomListEntry[]): readonly AlloR
       return left.summary.roomId < right.summary.roomId ? -1 : 1;
     })
     .map((entry) => entry.summary);
+}
+
+/**
+ * How far back a room's loaded timeline is searched for something to preview.
+ *
+ * There is a limit at all because the search is per room and the list is rebuilt
+ * on every sync response: a room whose loaded history is nothing but membership
+ * changes would otherwise be walked end to end, for every room, several times a
+ * minute. Twenty is the size of the first sync's slice per room, so in the case
+ * this is really guarding against — a quiet room full of people coming and going
+ * — the walk ends where the loaded history does.
+ *
+ * Giving up leaves the row with no preview, which is a row that says less than it
+ * could. It is not a row that says something false.
+ */
+const PREVIEW_SEARCH_LIMIT = 20;
+
+/**
+ * The most recent event of a room that a conversation row can preview.
+ *
+ * Not simply the last one. `getLastLiveEvent()` answers with the latest event of
+ * any type, so a room's preview would become "someone joined" every time someone
+ * did, and the message that was there a second ago would be gone. Walking
+ * backwards to the last *message* is what the Rust SDK's latest-event cache does
+ * for the native half without being asked.
+ *
+ * @param events one room's loaded timeline, oldest first, as the SDK holds it.
+ */
+export function selectRoomPreview(
+  events: readonly TimelineEventFields[],
+  viewerUserId: string,
+): AlloRoomPreview | undefined {
+  const oldestToConsider = Math.max(0, events.length - PREVIEW_SEARCH_LIMIT);
+  for (let index = events.length - 1; index >= oldestToConsider; index -= 1) {
+    const event = events[index];
+    const preview = event === undefined ? undefined : toRoomPreview(event, viewerUserId);
+    if (preview !== undefined) {
+      return preview;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/frontend/lib/matrix/web/roomList.ts
+++ b/packages/frontend/lib/matrix/web/roomList.ts
@@ -112,3 +112,53 @@ export function directRoomIds(content: Record<string, unknown> | undefined): Rea
   }
   return roomIds;
 }
+
+/**
+ * The rooms `m.direct` records as shared with one person, oldest entry first.
+ *
+ * Read with the same suspicion as {@link directRoomIds}, and for the same reason:
+ * every client the user has ever used has written to this event.
+ */
+export function directRoomsWith(
+  content: Record<string, unknown> | undefined,
+  userId: string,
+): readonly string[] {
+  const rooms = content?.[userId];
+  if (!Array.isArray(rooms)) {
+    return [];
+  }
+  return rooms.filter((roomId): roomId is string => typeof roomId === 'string');
+}
+
+/**
+ * `m.direct` with one more room recorded against one person.
+ *
+ * **Every other person's conversations are carried over.** Account data is
+ * replaced whole, so a write that only sent the pair it cared about would delete
+ * the "direct" flag from every conversation the user has ever had — with every
+ * other client that ever set one.
+ *
+ * What it does not carry over is anything in the event that is not a list of room
+ * ids, because that is not `m.direct` content and the write has to produce
+ * content the next reader can trust. The same suspicion as {@link directRoomIds},
+ * applied to a write instead of a read.
+ *
+ * A room already recorded is not recorded twice, so this is safe to apply to what
+ * the server already holds.
+ */
+export function withDirectRoom(
+  content: Record<string, unknown> | undefined,
+  userId: string,
+  roomId: string,
+): Record<string, string[]> {
+  const next: Record<string, string[]> = {};
+  for (const otherUserId of Object.keys(content ?? {})) {
+    const rooms = directRoomsWith(content, otherUserId);
+    if (rooms.length > 0) {
+      next[otherUserId] = [...rooms];
+    }
+  }
+  const existing = next[userId] ?? [];
+  next[userId] = existing.includes(roomId) ? existing : [...existing, roomId];
+  return next;
+}

--- a/packages/frontend/lib/matrix/web/translate.ts
+++ b/packages/frontend/lib/matrix/web/translate.ts
@@ -5,6 +5,7 @@ import type {
   AlloEventContent,
   AlloEventKey,
   AlloRoomMembership,
+  AlloRoomPreview,
   AlloRoomSummary,
   AlloSendState,
   AlloSyncState,
@@ -34,6 +35,28 @@ const ROOM_CREATE_EVENT_TYPE = 'm.room.create';
 const ROOM_MESSAGE_EVENT_TYPE = 'm.room.message';
 const ROOM_ENCRYPTED_EVENT_TYPE = 'm.room.encrypted';
 const TEXT_MESSAGE_TYPE = 'm.text';
+
+/**
+ * The event types a conversation row previews.
+ *
+ * This list is the web half's copy of a decision the native half gets for free:
+ * the Rust SDK keeps a latest-event cache that only ever holds message-like
+ * events, and `matrix-js-sdk` keeps no such thing — `getLastLiveEvent()` answers
+ * with the last event of any type at all. Without this filter a room's preview
+ * would be replaced by a membership change every time anyone joined or left.
+ *
+ * Both spellings of a poll are here because the stable type was only assigned
+ * after clients had shipped the unstable one, and rooms hold events from both.
+ */
+const PREVIEWABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  ROOM_MESSAGE_EVENT_TYPE,
+  // An event that has not been decrypted still reports this type, and it is a
+  // message: "arrived and cannot be read" is a preview, not the absence of one.
+  ROOM_ENCRYPTED_EVENT_TYPE,
+  'm.sticker',
+  'm.poll.start',
+  'org.matrix.msc3381.poll.start',
+]);
 
 /**
  * The SDK's `SyncState` and `EventStatus`, written as the values of their
@@ -162,6 +185,7 @@ export function toRoomSummary(
   room: RoomSummaryFields,
   state: RoomStateFields | undefined,
   isDirect: boolean,
+  latestMessage: AlloRoomPreview | undefined,
 ): AlloRoomSummary | undefined {
   const membership = MEMBERSHIP_LOOKUP[room.getMyMembership()];
   if (membership === undefined) {
@@ -177,6 +201,7 @@ export function toRoomSummary(
     membership,
     encryption: toEncryptionState(room, state),
     unreadCount: toUnreadCount(room.getUnreadNotificationCount()),
+    latestMessage,
   };
 }
 
@@ -189,6 +214,37 @@ export function toRoomSummary(
  */
 function toUnreadCount(count: number): number {
   return Number.isInteger(count) && count > 0 ? count : 0;
+}
+
+/**
+ * A conversation row's preview, or `undefined` for an event that is not one of
+ * the room's messages.
+ *
+ * Being undrawable and not being a message are different answers, and only the
+ * second one is `undefined` here. An image is a message Allo cannot draw yet, so
+ * it comes back as `unsupported` and the row says as much; someone changing their
+ * avatar is not a message at all, and a caller looking for the room's latest one
+ * has to keep looking.
+ *
+ * A sender is required for the same reason a timeline row needs one. The SDK only
+ * ever omits it on events it built locally without one, which is not something a
+ * room's history contains.
+ */
+export function toRoomPreview(
+  event: TimelineEventFields,
+  viewerUserId: string,
+): AlloRoomPreview | undefined {
+  const sender = event.getSender();
+  if (sender === undefined || !PREVIEWABLE_EVENT_TYPES.has(event.getType())) {
+    return undefined;
+  }
+  return {
+    sentAt: event.getTs(),
+    sender,
+    senderDisplayName: event.sender?.name,
+    isOwn: sender === viewerUserId,
+    content: toEventContent(event),
+  };
 }
 
 /** What a conversation row needs of a `MatrixEvent`. */

--- a/packages/frontend/utils/dateUtils.ts
+++ b/packages/frontend/utils/dateUtils.ts
@@ -59,10 +59,18 @@ function getShortDateFormatter(): Intl.DateTimeFormat {
  *  - Yesterday:  "Yesterday"
  *  - This week:  "Monday"
  *  - Older:      "1/15/25"
+ *  - Unknown:    "" — a row whose time nobody knows shows no time
+ *
+ * The last case is a real one and not a defensive flourish. A conversation this
+ * device has seen no message in has no activity time, and the alternative to
+ * saying nothing is saying "now" beside a conversation nobody has touched.
  */
 export const formatConversationTimestamp = (input: string | Date): string => {
   try {
     const date = typeof input === 'string' ? new Date(input) : input;
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
     const now = new Date();
 
     // Start of today (midnight)


### PR DESCRIPTION
## Qué resuelve

Por el camino de Matrix, las filas de la lista salían **sin vista previa y sin hora** — el hueco más visible de todos, porque es lo primero que se ve al abrir la app.

Ahora el resumen de sala lleva último mensaje y hora de actividad, el puerto sabe **crear una conversación** (sin lo cual no se podía empezar un chat nuevo), y las invitaciones se distinguen de las conversaciones normales en el dato, dejando a la UI decidir cómo se pintan.

## La trampa que no se pisó

Una sala en la que nadie ha escrito **no tiene** hora, y rellenarla con `Date.now()` pondría «ahora» al lado de cada conversación vacía. Está protegido por un test que se llama justo eso:

> *"gives a room nobody has written in no preview and no time"*

Fabricar la marca de tiempo hace fallar seis tests, ése incluido. Y el último mensaje de una sala cifrada puede no ser descifrable todavía: eso tiene su propio estado, no es una cadena vacía.

## Plan de pruebas

- Typecheck del frontend en verde en condiciones de CI.
- **412 tests en 33 suites**, frente a 370 en 32.
- Verificado por mutación, no sólo por estar verde.
- Cero `as any`, cero `@ts-ignore`, cero `useEffect` nuevos, y cero `Date.now()` en las rutas de resumen.

`docs/matrix/ui-wiring.md` §5 deja de listar como pendiente lo que este cambio resuelve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/allo/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->