### PR TITLE
Reacciones, edición, borrado, recibos y escribiendo

### DIFF
--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -75,6 +75,7 @@ lib/chat/
 lib/matrix/
   store.native.ts        dos directorios, y cómo borrarlos
   store.web.ts           una base de IndexedDB, y cómo borrarla
+  readReceipts.ts        de «quién tiene recibo aquí» a «alguien ha leído esto»
 hooks/
   useMatrixRuntime.ts       useSyncExternalStore sobre el runtime
   useMatrixConversations.ts → Conversation[] | undefined
@@ -135,6 +136,22 @@ encenderlo.
   homeserver, se lleva la sesión guardada, el almacén de estado y el de cripto.
 - Estados propios para los eventos sin texto: no descifrable, redactado, y
   «Allo no sabe dibujar esto todavía». Ninguno se pinta como una burbuja vacía.
+- **Reacciones**, poner y quitar, desde la barra de emoji del menú de acciones.
+  Una sola llamada para los dos sentidos: cuál de los dos es depende de si esta
+  cuenta ya anotó el evento, y eso lo sabe el SDK y no un snapshot de la
+  pantalla.
+- **Edición y borrado** de los mensajes propios. El borrado es una redacción, y
+  una redacción no borra la fila: deja el esqueleto —quién y cuándo— en pie aquí
+  y en todos los demás clientes, y la fila se pone a dibujarse como borrada. El
+  compositor tiene un segundo modo, con una barra encima para cancelarlo.
+- **Recibos de lectura**, en las dos direcciones: se envían mientras la
+  conversación está en pantalla y el segundo tick aparece cuando alguien que no
+  es quien lo envió ha leído. Un recibo de Matrix nombra un evento y cubre todos
+  los anteriores, así que la respuesta por fila sale de recorrer el timeline
+  hacia atrás (`lib/matrix/readReceipts.ts`) y no de preguntar por cada mensaje.
+- **Indicador de escribiendo**, también en las dos direcciones, y por el
+  homeserver: a diferencia del camino viejo, existe fuera de la web.
+- **Un envío fallido se dibuja como error** y no como el reloj.
 
 ## 5. Qué no llega, y por qué
 
@@ -148,20 +165,24 @@ Por orden de cuánto se nota:
 2. **El tamaño de letra por mensaje no viaja.** `AlloTimelineHandle.sendText`
    manda un cuerpo y nada más; `so.oxy.allo.font_size` (§4.2 de
    `data-model.md`) necesita una llamada que el puerto no tiene.
-3. **Un envío fallido dibuja el reloj, no un error.** `MessageMetadata` sólo
-   conoce pendiente / enviado / entregado / leído. El reloj es cierto en móvil,
-   donde la cola del SDK sigue reintentando, y optimista en web, donde no.
-4. **Sin reacciones, sin edición, sin borrado, sin adjuntos, sin recibos de
-   lectura, sin indicador de escribiendo, sin crear conversaciones.** El puerto
-   no expone ninguna de esas operaciones todavía.
-5. **Una sesión revocada desde fuera no se nota hasta el siguiente arranque.** Si
+3. **Las reacciones no se ven en la burbuja.** Se pueden poner y quitar, y el
+   toggle sabe cuáles son las tuyas, pero nada las dibuja debajo del mensaje.
+   No es un hueco del puerto: `Message.reactions` existe desde antes que él y
+   ningún backend de Allo las ha pintado nunca. Hacerlo es UI nueva para los dos
+   caminos, no cableado de éste.
+4. **Sin adjuntos y sin crear conversaciones.** El puerto no expone ninguna de
+   las dos operaciones todavía.
+5. **Nada reintenta un envío fallido.** Se ve que falló, y no hay forma de
+   volver a intentarlo desde la burbuja; en móvil la cola del SDK ya no lo está
+   intentando y en web nunca hubo cola. Reenviarlo es escribirlo otra vez.
+6. **Una sesión revocada desde fuera no se nota hasta el siguiente arranque.** Si
    el usuario borra este dispositivo desde otro cliente, el sync empieza a fallar
    y la app lo dibuja como un error de sincronización, no como «te han cerrado la
    sesión». El binding lo cuenta (`ClientDelegate.didReceiveAuthError`) y
    `matrix-js-sdk` también (`HttpApiEvent.SessionLoggedOut`); el puerto no expone
    ninguno de los dos todavía. El camino de vuelta existe —cerrar sesión desde
    Ajustes— pero hay que saber que hace falta.
-6. **Las invitaciones aparecen como filas normales.** El puerto las incluye
+7. **Las invitaciones aparecen como filas normales.** El puerto las incluye
    («todo lo que el usuario no ha abandonado»), y abrir una probablemente no dé
    timeline. No se filtran aquí: la definición de qué es una conversación es del
    puerto, no de este mapeo.

--- a/packages/frontend/__tests__/chat/matrixViewModel.test.ts
+++ b/packages/frontend/__tests__/chat/matrixViewModel.test.ts
@@ -36,6 +36,8 @@ function event(overrides: Partial<AlloTimelineItem> = {}): AlloTimelineItem {
     isOwn: false,
     sendState: 'sent',
     content: { kind: 'text', body: 'hello', isEdited: false },
+    reactions: [],
+    isReadByOthers: false,
     ...overrides,
   };
 }
@@ -172,17 +174,90 @@ describe('toMessage', () => {
     expect(message.readStatus).toBe('sent');
   });
 
-  it('does not claim a failed send reached the homeserver', () => {
-    // The bubble has no failed state, so this settles for the clock. What it
-    // must never do is report `sent`, which draws the tick that tells the user
-    // the message arrived.
+  it('draws a failed send as an error and not as the clock', () => {
+    // The mistake this holds down. `failed` and `pending` look the same to a
+    // switch that only tests for `sent`, and the two mean opposite things: the
+    // clock says "still going", and nothing is still going. On the web nothing
+    // retries at all, so a clock there is a message the user believes is on its
+    // way and which no longer exists.
     const message = toMessage(
       event({ isOwn: true, sendState: 'failed' }),
       '!room:allo.you',
       LABELS,
     );
 
+    expect(message.readStatus).toBe('failed');
+    expect(message.readStatus).not.toBe('pending');
     expect(message.readStatus).not.toBe('sent');
-    expect(message.readStatus).toBe('pending');
+  });
+
+  it('shows two ticks once somebody else has read the message', () => {
+    const message = toMessage(
+      event({ isOwn: true, sendState: 'sent', isReadByOthers: true }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.readStatus).toBe('read');
+  });
+
+  it('never reports a message as delivered', () => {
+    // Matrix has no delivery receipt: there is no event for "it reached their
+    // device". `delivered` draws a tick that would mean something Allo cannot
+    // know, so no combination of states may reach it.
+    const states = (['pending', 'sent', 'failed'] as const).flatMap((sendState) =>
+      [false, true].map(
+        (isReadByOthers) =>
+          toMessage(event({ isOwn: true, sendState, isReadByOthers }), '!room:allo.you', LABELS)
+            .readStatus,
+      ),
+    );
+
+    expect(states).not.toContain('delivered');
+  });
+
+  it('reports an edited message as edited', () => {
+    const message = toMessage(
+      event({ content: { kind: 'text', body: 'fixed', isEdited: true } }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.isEdited).toBe(true);
+    expect(message.text).toBe('fixed');
+  });
+
+  it('does not call a redacted message an edited one', () => {
+    // Both arrive as "the body you had is not the body now", and only one of them
+    // is a correction the sender made.
+    const message = toMessage(
+      event({ content: { kind: 'redacted' } }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.isEdited).toBe(false);
+  });
+
+  it('carries reactions across as emoji to senders', () => {
+    const message = toMessage(
+      event({
+        reactions: [
+          { key: '👍', senders: ['@alice:allo.you', '@bob:allo.you'] },
+          { key: '❤️', senders: ['@bob:allo.you'] },
+        ],
+      }),
+      '!room:allo.you',
+      LABELS,
+    );
+
+    expect(message.reactions).toEqual({
+      '👍': ['@alice:allo.you', '@bob:allo.you'],
+      '❤️': ['@bob:allo.you'],
+    });
+  });
+
+  it('leaves reactions unset when nobody has reacted', () => {
+    expect(toMessage(event(), '!room:allo.you', LABELS).reactions).toBeUndefined();
   });
 });

--- a/packages/frontend/__tests__/chat/timelineSource.test.ts
+++ b/packages/frontend/__tests__/chat/timelineSource.test.ts
@@ -30,7 +30,7 @@ import type {
 
 const ROOM = '!room:allo.you';
 
-function event(key: string): AlloTimelineItem {
+function event(key: string, overrides: Partial<AlloTimelineItem> = {}): AlloTimelineItem {
   return {
     key,
     id: { kind: 'remote', eventId: `$${key}` },
@@ -40,18 +40,37 @@ function event(key: string): AlloTimelineItem {
     isOwn: false,
     sendState: 'sent',
     content: { kind: 'text', body: key, isEdited: false },
+    reactions: [],
+    isReadByOthers: false,
+    ...overrides,
   };
+}
+
+/** A row the homeserver has not accepted yet: addressable only by transaction id. */
+function localEcho(key: string): AlloTimelineItem {
+  return event(key, {
+    id: { kind: 'local', transactionId: `txn-${key}` },
+    sendState: 'pending',
+    isOwn: true,
+  });
 }
 
 class FakeTimeline implements AlloTimelineHandle {
   closes = 0;
   paginateCalls: number[] = [];
   sent: string[] = [];
+  reacted: { eventId: string; key: string }[] = [];
+  edited: { eventId: string; body: string }[] = [];
+  redacted: { eventId: string; reason: string | undefined }[] = [];
+  receipted: string[] = [];
+  typingNotices: boolean[] = [];
+  typingUnsubscribes = 0;
   outcome: AlloPaginationOutcome = 'more-available';
   /** When set, `paginateBackwards` waits for {@link releasePagination}. */
   #pendingPagination: (() => void) | undefined;
   #holdPagination = false;
   #items: readonly AlloTimelineItem[] = [];
+  #typingListeners = new Set<(userIds: readonly string[]) => void>();
 
   constructor(private readonly onChange: (items: readonly AlloTimelineItem[]) => void) {}
 
@@ -62,6 +81,12 @@ class FakeTimeline implements AlloTimelineHandle {
   publish(items: readonly AlloTimelineItem[]): void {
     this.#items = items;
     this.onChange(items);
+  }
+
+  publishTyping(userIds: readonly string[]): void {
+    for (const listener of this.#typingListeners) {
+      listener(userIds);
+    }
   }
 
   holdPagination(): void {
@@ -86,6 +111,34 @@ class FakeTimeline implements AlloTimelineHandle {
 
   async sendText(body: string): Promise<void> {
     this.sent.push(body);
+  }
+
+  async toggleReaction(eventId: string, key: string): Promise<void> {
+    this.reacted.push({ eventId, key });
+  }
+
+  async edit(eventId: string, body: string): Promise<void> {
+    this.edited.push({ eventId, body });
+  }
+
+  async redact(eventId: string, reason: string | undefined): Promise<void> {
+    this.redacted.push({ eventId, reason });
+  }
+
+  async sendReadReceipt(eventId: string): Promise<void> {
+    this.receipted.push(eventId);
+  }
+
+  async sendTypingNotice(isTyping: boolean): Promise<void> {
+    this.typingNotices.push(isTyping);
+  }
+
+  observeTyping(onChange: (userIds: readonly string[]) => void): AlloUnsubscribe {
+    this.#typingListeners.add(onChange);
+    return () => {
+      this.#typingListeners.delete(onChange);
+      this.typingUnsubscribes += 1;
+    };
   }
 
   close(): void {
@@ -441,6 +494,239 @@ describe('TimelineSource sending', () => {
     const { source } = readyTimeline();
 
     await expect(source.sendText('hello')).rejects.toThrow(ROOM);
+  });
+});
+
+describe('TimelineSource message operations', () => {
+  async function watching(): Promise<{ runtime: FakeRuntime; source: TimelineSource }> {
+    const ready = readyTimeline();
+    ready.source.subscribe(() => {});
+    await settle();
+    return ready;
+  }
+
+  it('resolves the key the UI draws with into the event id the port wants', async () => {
+    // The UI holds `Message.id`, which is the row key. Handing that to the
+    // homeserver would address an event that does not exist.
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1')]);
+
+    await source.toggleReaction('row-1', '👍');
+
+    expect(runtime.chatClient.timelines[0].reacted).toEqual([{ eventId: '$row-1', key: '👍' }]);
+  });
+
+  it('edits by event id', async () => {
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1')]);
+
+    await source.edit('row-1', 'fixed');
+
+    expect(runtime.chatClient.timelines[0].edited).toEqual([
+      { eventId: '$row-1', body: 'fixed' },
+    ]);
+  });
+
+  it('redacts by event id, with no reason unless one is given', async () => {
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1')]);
+
+    await source.redact('row-1');
+
+    expect(runtime.chatClient.timelines[0].redacted).toEqual([
+      { eventId: '$row-1', reason: undefined },
+    ]);
+  });
+
+  it('leaves the redacted row in the timeline', async () => {
+    // The mistake this holds down. A redaction is not a deletion: the event keeps
+    // its place, its sender and its time on every client in the room, and the
+    // port reports it with a `redacted` content kind. Dropping the row here would
+    // renumber the conversation under the reader and disagree with every other
+    // device until the next sync — and then disagree with itself.
+    const { runtime, source } = await watching();
+    const rows = [event('row-1'), event('row-2')];
+    runtime.chatClient.timelines[0].publish(rows);
+
+    await source.redact('row-1');
+
+    expect(source.getSnapshot().items).toBe(rows);
+    expect(source.getSnapshot().items.map((item) => item.key)).toEqual(['row-1', 'row-2']);
+  });
+
+  it('refuses to act on a message the homeserver has not accepted', async () => {
+    // A local echo has no event id at all. Sending its transaction id would
+    // address nothing, and the native SDK's ability to do slightly better is not
+    // worth two platforms disagreeing about which taps work.
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([localEcho('row-1')]);
+
+    await expect(source.toggleReaction('row-1', '👍')).rejects.toThrow('has not been accepted');
+    expect(runtime.chatClient.timelines[0].reacted).toEqual([]);
+  });
+
+  it('says which message it could not find when the row is gone', async () => {
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1')]);
+
+    await expect(source.edit('row-9', 'fixed')).rejects.toThrow('row-9');
+  });
+});
+
+describe('TimelineSource read receipts', () => {
+  async function watching(): Promise<{ runtime: FakeRuntime; source: TimelineSource }> {
+    const ready = readyTimeline();
+    ready.source.subscribe(() => {});
+    await settle();
+    return ready;
+  }
+
+  it('receipts the newest row', async () => {
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1'), event('row-2')]);
+
+    await source.markRead();
+
+    expect(runtime.chatClient.timelines[0].receipted).toEqual(['$row-2']);
+  });
+
+  it('does not send the same receipt twice', async () => {
+    // Called from a render, so it runs whenever anything about the conversation
+    // changes: a reaction, a scroll, a redraw. Every one of those would otherwise
+    // be a request to the homeserver.
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1')]);
+
+    await source.markRead();
+    await source.markRead();
+    await source.markRead();
+
+    expect(runtime.chatClient.timelines[0].receipted).toEqual(['$row-1']);
+  });
+
+  it('receipts again once a newer message arrives', async () => {
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1')]);
+    await source.markRead();
+
+    runtime.chatClient.timelines[0].publish([event('row-1'), event('row-2')]);
+    await source.markRead();
+
+    expect(runtime.chatClient.timelines[0].receipted).toEqual(['$row-1', '$row-2']);
+  });
+
+  it('skips over a message of the viewer’s own that has not been sent', async () => {
+    // The newest row right after sending is a local echo with no event id.
+    // Receipting the newest *remote* one keeps the mark moving.
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([event('row-1'), localEcho('row-2')]);
+
+    await source.markRead();
+
+    expect(runtime.chatClient.timelines[0].receipted).toEqual(['$row-1']);
+  });
+
+  it('sends nothing for a conversation with no remote messages', async () => {
+    const { runtime, source } = await watching();
+    runtime.chatClient.timelines[0].publish([localEcho('row-1')]);
+
+    await source.markRead();
+
+    expect(runtime.chatClient.timelines[0].receipted).toEqual([]);
+  });
+
+  it('tries again after a receipt that failed to go out', async () => {
+    // Otherwise one refusal from the homeserver leaves the sender's bubble one
+    // tick short for the rest of the conversation.
+    const { runtime, source } = await watching();
+    const timeline = runtime.chatClient.timelines[0];
+    timeline.publish([event('row-1')]);
+    timeline.sendReadReceipt = async () => {
+      throw new Error('the homeserver said no');
+    };
+
+    await expect(source.markRead()).rejects.toThrow('the homeserver said no');
+
+    timeline.sendReadReceipt = async (eventId: string) => {
+      timeline.receipted.push(eventId);
+    };
+    await source.markRead();
+
+    expect(timeline.receipted).toEqual(['$row-1']);
+  });
+
+  it('sends nothing for a conversation nothing is watching', async () => {
+    // Not an error: a screen that unmounted while a render was in flight is
+    // ordinary, and there is nothing a reader could do about it either way.
+    const { source } = readyTimeline();
+
+    await expect(source.markRead()).resolves.toBeUndefined();
+  });
+});
+
+describe('TimelineSource typing', () => {
+  it('reports who else is typing', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    runtime.chatClient.timelines[0].publishTyping(['@bea:allo.you']);
+
+    expect(source.getSnapshot().typingUserIds).toEqual(['@bea:allo.you']);
+  });
+
+  it('notifies its watchers when typing changes', async () => {
+    const { runtime, source } = readyTimeline();
+    let notifications = 0;
+    source.subscribe(() => {
+      notifications += 1;
+    });
+    await settle();
+    notifications = 0;
+
+    runtime.chatClient.timelines[0].publishTyping(['@bea:allo.you']);
+
+    expect(notifications).toBe(1);
+  });
+
+  it('says nobody is typing in a conversation that has just been opened', async () => {
+    const { source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    expect(source.getSnapshot().typingUserIds).toEqual([]);
+  });
+
+  it('forgets who was typing when the session goes away', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+    runtime.chatClient.timelines[0].publishTyping(['@bea:allo.you']);
+
+    runtime.become('signed-out');
+
+    expect(source.getSnapshot().typingUserIds).toEqual([]);
+  });
+
+  it('stops listening for typing when the timeline closes', async () => {
+    const { runtime, source } = readyTimeline();
+    const unsubscribe = source.subscribe(() => {});
+    await settle();
+
+    unsubscribe();
+
+    expect(runtime.chatClient.timelines[0].typingUnsubscribes).toBe(1);
+  });
+
+  it('passes the viewer’s own typing through to the port', async () => {
+    const { runtime, source } = readyTimeline();
+    source.subscribe(() => {});
+    await settle();
+
+    await source.sendTypingNotice(true);
+    await source.sendTypingNotice(false);
+
+    expect(runtime.chatClient.timelines[0].typingNotices).toEqual([true, false]);
   });
 });
 

--- a/packages/frontend/__tests__/matrix/readReceipts.test.ts
+++ b/packages/frontend/__tests__/matrix/readReceipts.test.ts
@@ -1,0 +1,85 @@
+import { markReadByOthers, type AlloReadRow } from '@/lib/matrix/readReceipts';
+
+/**
+ * Turning "whose receipt names this event" into "has anybody seen this message".
+ *
+ * The whole reason this function exists is that the two are not the same
+ * question. A Matrix receipt is a high-water mark: it names the newest event a
+ * user has read and covers everything before it, so in any conversation somebody
+ * has actually read, exactly one event carries a receipt and every earlier one
+ * carries none. Answering per row is answering the wrong question.
+ */
+
+const ALICE = '@alice:allo.you';
+const BEA = '@bea:allo.you';
+const CARLA = '@carla:allo.you';
+
+function row(sender: string, readers: readonly string[] = []): AlloReadRow {
+  return { sender, readers };
+}
+
+describe('markReadByOthers', () => {
+  it('marks every row before the one the receipt names', () => {
+    // The case the whole function exists for. Bea's receipt sits on the last
+    // message, and it says she has read the two before it as well.
+    const flags = markReadByOthers([
+      row(ALICE),
+      row(ALICE),
+      row(ALICE, [BEA]),
+    ]);
+
+    expect(flags).toEqual([true, true, true]);
+  });
+
+  it('leaves the rows after the receipt unread', () => {
+    const flags = markReadByOthers([
+      row(ALICE, [BEA]),
+      row(ALICE),
+      row(ALICE),
+    ]);
+
+    expect(flags).toEqual([true, false, false]);
+  });
+
+  it('does not count a sender reading their own message', () => {
+    // Clients send a receipt for the message they have just sent. Counting it
+    // would put the read mark on every outgoing message the moment it came back
+    // down sync, which is a mark that means nothing at all.
+    expect(markReadByOthers([row(ALICE, [ALICE])])).toEqual([false]);
+  });
+
+  it('counts a reader who is not the sender even when the sender is there too', () => {
+    expect(markReadByOthers([row(ALICE, [ALICE, BEA])])).toEqual([true]);
+  });
+
+  it('answers each row against its own sender', () => {
+    // A group conversation, where consecutive rows have different senders and
+    // the same receipt means different things to each of them.
+    const flags = markReadByOthers([
+      row(BEA),
+      row(ALICE),
+      row(BEA, [BEA]),
+    ]);
+
+    // Bea's own two messages are not read by anybody but Bea; Alice's is.
+    expect(flags).toEqual([false, true, false]);
+  });
+
+  it('keeps counting receipts met further along', () => {
+    const flags = markReadByOthers([
+      row(ALICE),
+      row(ALICE, [BEA]),
+      row(ALICE, [CARLA]),
+    ]);
+
+    expect(flags).toEqual([true, true, true]);
+  });
+
+  it('reports nothing read when nobody has a receipt', () => {
+    expect(markReadByOthers([row(ALICE), row(ALICE)])).toEqual([false, false]);
+  });
+
+  it('answers an empty timeline with an empty list', () => {
+    expect(markReadByOthers([])).toEqual([]);
+  });
+});

--- a/packages/frontend/__tests__/matrix/timelineProjection.test.ts
+++ b/packages/frontend/__tests__/matrix/timelineProjection.test.ts
@@ -18,10 +18,15 @@ jest.mock('@unomed/react-native-matrix-sdk');
  *   every event received, so rows already read must not be read again.
  */
 
-function eventFields(body: string): TimelineEventFields {
+interface EventOptions {
+  readonly sender?: string;
+  readonly readers?: readonly string[];
+}
+
+function eventFields(body: string, options: EventOptions = {}): TimelineEventFields {
   return {
     eventOrTransactionId: new EventOrTransactionId.EventId({ eventId: `$${body}` }),
-    sender: '@alice:allo.you',
+    sender: options.sender ?? '@alice:allo.you',
     senderProfile: new ProfileDetails.Unavailable(),
     content: new TimelineItemContent.MsgLike({
       content: {
@@ -38,6 +43,9 @@ function eventFields(body: string): TimelineEventFields {
     timestamp: 1_700_000_000_000n,
     isOwn: false,
     localSendState: undefined,
+    readReceipts: new Map(
+      (options.readers ?? []).map((userId) => [userId, { timestamp: 1_700_000_000_000n }]),
+    ),
   };
 }
 
@@ -45,13 +53,13 @@ interface CountedRow extends TimelineRow {
   readonly reads: () => number;
 }
 
-function eventRow(id: string, body: string): CountedRow {
+function eventRow(id: string, body: string, options: EventOptions = {}): CountedRow {
   let reads = 0;
   return {
     uniqueId: () => ({ id }),
     asEvent: () => {
       reads += 1;
-      return eventFields(body);
+      return eventFields(body, options);
     },
     reads: () => reads,
   };
@@ -165,5 +173,89 @@ describe('TimelineProjection', () => {
 
   it('reports an empty timeline as an empty list', () => {
     expect(new TimelineProjection().project([])).toEqual([]);
+  });
+});
+
+describe('TimelineProjection read receipts', () => {
+  const BEA = '@bea:allo.you';
+
+  it('marks the rows before the one a receipt names', () => {
+    // The binding attaches a receipt to the single event it names. Reading each
+    // row on its own would report every message but the last as unread.
+    const projection = new TimelineProjection();
+
+    const items = projection.project([
+      eventRow('row-1', 'first'),
+      eventRow('row-2', 'second', { readers: [BEA] }),
+    ]);
+
+    expect(items.map((item) => item.isReadByOthers)).toEqual([true, true]);
+  });
+
+  it('leaves the rows after the receipt unread', () => {
+    const projection = new TimelineProjection();
+
+    const items = projection.project([
+      eventRow('row-1', 'first', { readers: [BEA] }),
+      eventRow('row-2', 'second'),
+    ]);
+
+    expect(items.map((item) => item.isReadByOthers)).toEqual([true, false]);
+  });
+
+  it('moves the mark forward when only the row the receipt moved to changed', () => {
+    // The reason the scan cannot be folded into the per-row cache. When a reader
+    // moves on, the binding hands over new objects for the two rows the receipt
+    // left and arrived at — and for nothing in between, whose answer changed all
+    // the same. Caching the finished item against the row object would leave the
+    // middle of the conversation reporting the old answer for good.
+    const projection = new TimelineProjection();
+    const middle = eventRow('row-2', 'second');
+    projection.project([
+      eventRow('row-1', 'first', { readers: [BEA] }),
+      middle,
+      eventRow('row-3', 'third'),
+    ]);
+
+    const after = projection.project([
+      eventRow('row-1', 'first'),
+      middle,
+      eventRow('row-3', 'third', { readers: [BEA] }),
+    ]);
+
+    expect(after.map((item) => item.isReadByOthers)).toEqual([true, true, true]);
+  });
+
+  it('does not read the unchanged row again to move its mark', () => {
+    // The mark moved without an FFI call, which is the point of doing it in a
+    // second pass: a receipt arriving must not cost a round trip per message in
+    // the window.
+    const projection = new TimelineProjection();
+    const middle = eventRow('row-2', 'second');
+    projection.project([middle, eventRow('row-3', 'third')]);
+
+    projection.project([middle, eventRow('row-3', 'third', { readers: [BEA] })]);
+
+    expect(middle.reads()).toBe(1);
+  });
+
+  it('hands back the same item object while the mark has not changed', () => {
+    const projection = new TimelineProjection();
+    const row = eventRow('row-1', 'first', { readers: [BEA] });
+
+    const before = projection.project([row]);
+    const after = projection.project([row]);
+
+    expect(after[0]).toBe(before[0]);
+  });
+
+  it('does not count the sender reading their own message', () => {
+    const projection = new TimelineProjection();
+
+    const items = projection.project([
+      eventRow('row-1', 'first', { sender: BEA, readers: [BEA] }),
+    ]);
+
+    expect(items[0]?.isReadByOthers).toBe(false);
   });
 });

--- a/packages/frontend/__tests__/matrix/translate.test.ts
+++ b/packages/frontend/__tests__/matrix/translate.test.ts
@@ -16,6 +16,8 @@ import type { EventTimelineItem, TimelineItemContent as SdkTimelineItemContent }
 
 import {
   toEncryptionState,
+  toReactions,
+  toReaders,
   toRoomSummary,
   toSyncState,
   toTimelineItem,
@@ -58,6 +60,7 @@ function event(overrides: Partial<TimelineEventFields> = {}): TimelineEventField
     timestamp: 1_700_000_000_000n,
     isOwn: false,
     localSendState: undefined,
+    readReceipts: new Map(),
     ...overrides,
   };
 }
@@ -315,5 +318,92 @@ describe('toTimelineItem', () => {
     expect(toTimelineItem('row-1', event({ timestamp: 1_234_567_890_123n })).sentAt).toBe(
       1_234_567_890_123,
     );
+  });
+
+  it('leaves the read mark for the projection to settle', () => {
+    // Whether a message has been read is decided by a receipt on a *later* row,
+    // so it cannot be answered from one event. Reporting `true` here would need
+    // information this function does not have.
+    expect(toTimelineItem('row-1', event()).isReadByOthers).toBe(false);
+  });
+});
+
+describe('toReactions', () => {
+  function reacted(reactions: { key: string; senders: string[] }[]): SdkTimelineItemContent {
+    return new TimelineItemContent.MsgLike({
+      content: {
+        kind: new MsgLikeKind.Message({
+          content: {
+            msgType: new MessageType.Text({ content: { body: 'hello' } }),
+            body: 'hello',
+            isEdited: false,
+          },
+        }),
+        reactions: reactions.map((reaction) => ({
+          key: reaction.key,
+          senders: reaction.senders.map((senderId) => ({
+            senderId,
+            timestamp: 1_700_000_000_000n,
+          })),
+        })),
+      },
+    });
+  }
+
+  it('reads the emoji and everyone who sent it', () => {
+    expect(
+      toReactions(
+        reacted([
+          { key: '👍', senders: ['@alice:allo.you', '@bea:allo.you'] },
+          { key: '❤️', senders: ['@bea:allo.you'] },
+        ]),
+      ),
+    ).toEqual([
+      { key: '👍', senders: ['@alice:allo.you', '@bea:allo.you'] },
+      { key: '❤️', senders: ['@bea:allo.you'] },
+    ]);
+  });
+
+  it('reports a message nobody has reacted to as no reactions', () => {
+    expect(toReactions(reacted([]))).toEqual([]);
+  });
+
+  it('reports no reactions for an event that cannot carry any', () => {
+    // A state event has no annotations, and the binding says so in the shape:
+    // `reactions` lives on the message-like content and nowhere else.
+    expect(toReactions(new TimelineItemContent.CallInvite())).toEqual([]);
+  });
+
+  it('keeps the reactions on a redacted message', () => {
+    // A redaction empties the message, not the emoji people put on it.
+    expect(
+      toReactions(
+        new TimelineItemContent.MsgLike({
+          content: {
+            kind: new MsgLikeKind.Redacted(),
+            reactions: [
+              { key: '👍', senders: [{ senderId: '@bea:allo.you', timestamp: 1n }] },
+            ],
+          },
+        }),
+      ),
+    ).toEqual([{ key: '👍', senders: ['@bea:allo.you'] }]);
+  });
+});
+
+describe('toReaders', () => {
+  it('reads the user ids off the receipts the binding attached', () => {
+    expect(
+      toReaders({
+        readReceipts: new Map([
+          ['@bea:allo.you', { timestamp: 1n }],
+          ['@carla:allo.you', { timestamp: 2n }],
+        ]),
+      }),
+    ).toEqual(['@bea:allo.you', '@carla:allo.you']);
+  });
+
+  it('reports an event nobody has receipted as nobody', () => {
+    expect(toReaders({ readReceipts: new Map() })).toEqual([]);
   });
 });

--- a/packages/frontend/__tests__/matrix/web/translate.test.ts
+++ b/packages/frontend/__tests__/matrix/web/translate.test.ts
@@ -1,8 +1,12 @@
 import {
+  isTimelineRow,
   toEncryptionState,
+  toReactions,
+  toReaders,
   toRoomSummary,
   toSyncState,
   toTimelineItem,
+  type ReactionEventFields,
   type RoomStateFields,
   type RoomSummaryFields,
   type TimelineEventFields,
@@ -50,6 +54,7 @@ function event(overrides: Partial<TimelineEventFields> = {}): TimelineEventField
     getContent: () => ({ msgtype: 'm.text', body: 'hello' }),
     getTs: () => 1_700_000_000_000,
     isRedacted: () => false,
+    getRelation: () => null,
     replacingEvent: () => null,
     status: null,
     sender: { name: 'Alice' },
@@ -161,7 +166,7 @@ describe('toRoomSummary', () => {
 
 describe('toTimelineItem', () => {
   it('reads a text message', () => {
-    expect(toTimelineItem(event(), VIEWER)).toEqual({
+    expect(toTimelineItem(event(), VIEWER, [])).toEqual({
       key: '$event',
       id: { kind: 'remote', eventId: '$event' },
       sender: '@alice:allo.you',
@@ -170,15 +175,19 @@ describe('toTimelineItem', () => {
       isOwn: false,
       sendState: 'sent',
       content: { kind: 'text', body: 'hello', isEdited: false },
+      reactions: [],
+      // Settled by the caller, which is the only place that can see the later
+      // rows a read receipt actually sits on.
+      isReadByOthers: false,
     });
   });
 
   it('knows which messages are the viewer’s own', () => {
-    expect(toTimelineItem(event({ getSender: () => VIEWER }), VIEWER)?.isOwn).toBe(true);
+    expect(toTimelineItem(event({ getSender: () => VIEWER }), VIEWER, [])?.isOwn).toBe(true);
   });
 
   it('leaves the sender nameless until the SDK has resolved one', () => {
-    expect(toTimelineItem(event({ sender: null }), VIEWER)?.senderDisplayName).toBe(undefined);
+    expect(toTimelineItem(event({ sender: null }), VIEWER, [])?.senderDisplayName).toBe(undefined);
   });
 
   it('reports an edited message with the content that replaced it', () => {
@@ -190,6 +199,7 @@ describe('toTimelineItem', () => {
         replacingEvent: () => ({}),
       }),
       VIEWER,
+      [],
     );
 
     expect(item?.content).toEqual({ kind: 'text', body: 'hello again', isEdited: true });
@@ -200,7 +210,7 @@ describe('toTimelineItem', () => {
       // A device that has just been set up sees this for every message sent
       // before it existed. "Arrived but cannot be read" and "did not arrive" are
       // different facts and the UI has to be able to tell them apart.
-      expect(toTimelineItem(event({ getType: () => 'm.room.encrypted' }), VIEWER)?.content).toEqual(
+      expect(toTimelineItem(event({ getType: () => 'm.room.encrypted' }), VIEWER, [])?.content).toEqual(
         { kind: 'undecryptable' },
       );
     });
@@ -212,6 +222,7 @@ describe('toTimelineItem', () => {
           getContent: () => ({ msgtype: 'm.text', body: 'ciphertext leaked into content' }),
         }),
         VIEWER,
+        [],
       );
 
       expect(item?.content).toEqual({ kind: 'undecryptable' });
@@ -221,6 +232,7 @@ describe('toTimelineItem', () => {
       const item = toTimelineItem(
         event({ getType: () => 'm.room.encrypted', isRedacted: () => true }),
         VIEWER,
+        [],
       );
 
       expect(item?.content).toEqual({ kind: 'redacted' });
@@ -230,7 +242,7 @@ describe('toTimelineItem', () => {
   describe('an event Allo does not draw', () => {
     it('is reported as itself rather than dropped', () => {
       // A gap in a conversation should be visible instead of silent.
-      expect(toTimelineItem(event({ getType: () => 'm.room.member' }), VIEWER)?.content).toEqual({
+      expect(toTimelineItem(event({ getType: () => 'm.room.member' }), VIEWER, [])?.content).toEqual({
         kind: 'unsupported',
         description: 'm.room.member',
       });
@@ -242,6 +254,7 @@ describe('toTimelineItem', () => {
       const item = toTimelineItem(
         event({ getContent: () => ({ msgtype: 'm.image', body: 'holiday.jpg' }) }),
         VIEWER,
+        [],
       );
 
       expect(item?.content).toEqual({
@@ -254,6 +267,7 @@ describe('toTimelineItem', () => {
       const item = toTimelineItem(
         event({ getContent: () => ({ msgtype: 'm.text', body: { evil: true } }) }),
         VIEWER,
+        [],
       );
 
       expect(item?.content.kind).toBe('unsupported');
@@ -270,6 +284,7 @@ describe('toTimelineItem', () => {
           getId: () => '~!room:allo.you:m1700000000',
         }),
         VIEWER,
+        [],
       );
 
       expect(item?.id).toEqual({ kind: 'local', transactionId: 'm1700000000' });
@@ -283,10 +298,12 @@ describe('toTimelineItem', () => {
       const local = toTimelineItem(
         event({ status: 'sending', getTxnId: () => 'm1', getId: () => '~!room:allo.you:m1' }),
         VIEWER,
+        [],
       );
       const remote = toTimelineItem(
         event({ status: 'sent', getTxnId: () => 'm1', getId: () => '$real' }),
         VIEWER,
+        [],
       );
 
       expect(local?.key).toBe(remote?.key);
@@ -295,7 +312,7 @@ describe('toTimelineItem', () => {
 
     it('reports a send that failed as failed, and a cancelled one too', () => {
       const send = (status: 'not_sent' | 'cancelled'): string | undefined =>
-        toTimelineItem(event({ status, getTxnId: () => 'm1' }), VIEWER)?.sendState;
+        toTimelineItem(event({ status, getTxnId: () => 'm1' }), VIEWER, [])?.sendState;
 
       expect(send('not_sent')).toBe('failed');
       expect(send('cancelled')).toBe('failed');
@@ -305,11 +322,115 @@ describe('toTimelineItem', () => {
   describe('an event that cannot be addressed', () => {
     it('is refused rather than given a made-up key', () => {
       // Two rows sharing a key is a list that reorders itself under the user.
-      expect(toTimelineItem(event({ getId: () => undefined }), VIEWER)).toBe(undefined);
+      expect(toTimelineItem(event({ getId: () => undefined }), VIEWER, [])).toBe(undefined);
     });
 
     it('is refused when it has no sender', () => {
-      expect(toTimelineItem(event({ getSender: () => undefined }), VIEWER)).toBe(undefined);
+      expect(toTimelineItem(event({ getSender: () => undefined }), VIEWER, [])).toBe(undefined);
     });
+  });
+});
+
+describe('isTimelineRow', () => {
+  it('keeps an ordinary message', () => {
+    expect(isTimelineRow(event())).toBe(true);
+  });
+
+  it('keeps a redacted message', () => {
+    // The mistake this holds down. A redacted event is not an absent one: it
+    // keeps its place, its sender and its time, and the UI has to be able to draw
+    // "this was deleted" where the message was. Filtering it out would close the
+    // gap and renumber the conversation under the reader.
+    expect(
+      isTimelineRow(event({ isRedacted: () => true, getContent: () => ({}) })),
+    ).toBe(true);
+  });
+
+  it('drops a reaction', () => {
+    // Reactions are timeline events and belong on the message they annotate.
+    // Without this, the first emoji Allo sends comes back down sync and draws
+    // itself as "Allo cannot show this yet (m.reaction)".
+    expect(isTimelineRow(event({ getType: () => 'm.reaction' }))).toBe(false);
+  });
+
+  it('drops a redaction event', () => {
+    // The redaction itself is not a row. What it did to the event it names is.
+    expect(isTimelineRow(event({ getType: () => 'm.room.redaction' }))).toBe(false);
+  });
+
+  it('drops an edit', () => {
+    // The SDK folds the new body into the original, so drawing the replacement
+    // too would show the message twice — the second time with a leading `* `.
+    expect(
+      isTimelineRow(event({ getRelation: () => ({ rel_type: 'm.replace' }) })),
+    ).toBe(false);
+  });
+
+  it('keeps a reply, which points at another event and is still a message', () => {
+    expect(isTimelineRow(event({ getRelation: () => ({}) }))).toBe(true);
+  });
+});
+
+describe('toReactions', () => {
+  function annotation(sender: string | undefined, isRedacted = false): ReactionEventFields {
+    return { getSender: () => sender, isRedacted: () => isRedacted };
+  }
+
+  it('reads the emoji and everyone who sent it', () => {
+    expect(
+      toReactions([
+        ['👍', new Set([annotation('@alice:allo.you'), annotation('@bea:allo.you')])],
+        ['❤️', new Set([annotation('@bea:allo.you')])],
+      ]),
+    ).toEqual([
+      { key: '👍', senders: ['@alice:allo.you', '@bea:allo.you'] },
+      { key: '❤️', senders: ['@bea:allo.you'] },
+    ]);
+  });
+
+  it('reports a message nobody has reacted to as no reactions', () => {
+    // `null` is what the SDK answers for an event with no annotations, and it is
+    // the common case rather than a failure.
+    expect(toReactions(null)).toEqual([]);
+    expect(toReactions([])).toEqual([]);
+  });
+
+  it('leaves out an annotation that was taken back', () => {
+    expect(toReactions([['👍', new Set([annotation('@bea:allo.you', true)])]])).toEqual([]);
+  });
+
+  it('counts a sender once however many annotations arrive from them', () => {
+    // The events come from a homeserver, which is to say from outside.
+    expect(
+      toReactions([
+        ['👍', new Set([annotation('@bea:allo.you'), annotation('@bea:allo.you')])],
+      ]),
+    ).toEqual([{ key: '👍', senders: ['@bea:allo.you'] }]);
+  });
+
+  it('leaves out an annotation with no sender', () => {
+    expect(toReactions([['👍', new Set([annotation(undefined)])]])).toEqual([]);
+  });
+});
+
+describe('toReaders', () => {
+  it('reads the user ids off the read receipts', () => {
+    expect(
+      toReaders([
+        { type: 'm.read', userId: '@bea:allo.you' },
+        { type: 'm.read.private', userId: '@viewer:allo.you' },
+      ]),
+    ).toEqual(['@bea:allo.you', '@viewer:allo.you']);
+  });
+
+  it('leaves out the fully-read marker', () => {
+    // A private bookmark the user's own client moves around. It says where they
+    // stopped, not what they saw, and counting it would let one participant's
+    // scroll position mark another participant's message as read.
+    expect(toReaders([{ type: 'm.fully_read', userId: '@bea:allo.you' }])).toEqual([]);
+  });
+
+  it('reports an event nobody has receipted as nobody', () => {
+    expect(toReaders([])).toEqual([]);
   });
 });

--- a/packages/frontend/__tests__/messages/messageStatus.test.ts
+++ b/packages/frontend/__tests__/messages/messageStatus.test.ts
@@ -1,0 +1,44 @@
+import { statusMark } from '@/components/messages/messageStatus';
+
+/**
+ * Which mark a message's status draws.
+ *
+ * One case here is the point and the rest are its context: a send that failed
+ * must not draw the clock. The clock says "still on its way", and it is the one
+ * thing a failed send is not — the Rust SDK's queue has stopped retrying, and on
+ * the web there was never a queue to retry with. A user looking at a clock waits;
+ * a user looking at an error sends it again.
+ */
+
+describe('statusMark', () => {
+  it('draws a failed send as an error and never as the clock', () => {
+    expect(statusMark('failed')).toBe('error');
+    expect(statusMark('failed')).not.toBe('clock');
+  });
+
+  it('draws a message still on its way as the clock', () => {
+    expect(statusMark('pending')).toBe('clock');
+  });
+
+  it('draws a sent message as one tick', () => {
+    expect(statusMark('sent')).toBe('tick');
+  });
+
+  it('draws a read message as two ticks', () => {
+    expect(statusMark('read')).toBe('double-tick');
+  });
+
+  it('gives failed and pending different marks', () => {
+    // Stated on its own because the two are one careless `default:` apart, and
+    // that is exactly how this was drawn before.
+    expect(statusMark('failed')).not.toBe(statusMark('pending'));
+  });
+
+  it('gives every status a mark', () => {
+    const statuses = ['pending', 'sent', 'delivered', 'read', 'failed'] as const;
+
+    for (const status of statuses) {
+      expect(statusMark(status)).toBeDefined();
+    }
+  });
+});

--- a/packages/frontend/assets/icons/msgfailed-icon.tsx
+++ b/packages/frontend/assets/icons/msgfailed-icon.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+import { ViewStyle } from 'react-native';
+import { colors } from '@/styles/colors';
+
+/**
+ * The status a message shows when it is not going to arrive.
+ *
+ * Deliberately not another tick and not another clock. The clock says "still on
+ * its way", which is the one thing a failed send is not, and a reader who has to
+ * tell two nearly identical marks apart at eleven pixels will not.
+ *
+ * Drawn on the same 16x15 canvas as the tick and the clock so the three line up
+ * inside a bubble's metadata row.
+ */
+export const MsgFailedIcon = ({
+  color = colors.primaryColor,
+  size = 26,
+  style,
+}: {
+  color?: string;
+  size?: number;
+  style?: ViewStyle;
+}) => {
+  return (
+    <Svg viewBox="0 0 16 15" width={size} height={size} style={{ ...style }}>
+      <Path
+        fill={color}
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8,1.7c-3.2,0-5.8,2.6-5.8,5.8S4.8,13.3,8,13.3s5.8-2.6,5.8-5.8S11.2,1.7,8,1.7z M8,2.9 c2.5,0,4.6,2.1,4.6,4.6S10.5,12.1,8,12.1S3.4,10,3.4,7.5S5.5,2.9,8,2.9z M8,4.2c-0.3,0-0.6,0.3-0.6,0.6v3.1c0,0.3,0.3,0.6,0.6,0.6 s0.6-0.3,0.6-0.6V4.8C8.6,4.5,8.3,4.2,8,4.2z M8,9.5c-0.4,0-0.7,0.3-0.7,0.7s0.3,0.7,0.7,0.7s0.7-0.3,0.7-0.7S8.4,9.5,8,9.5z"
+      />
+    </Svg>
+  );
+};

--- a/packages/frontend/components/conversation/ConversationView.tsx
+++ b/packages/frontend/components/conversation/ConversationView.tsx
@@ -40,6 +40,7 @@ import { ReplyIcon } from '@/assets/icons/reply-icon';
 import { ForwardIcon } from '@/assets/icons/forward-icon';
 import { CopyIcon } from '@/assets/icons/copy-icon';
 import { TrashIcon } from '@/assets/icons/trash-icon';
+import { CloseIcon } from '@/assets/icons/close-icon';
 
 // Icons
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
@@ -181,7 +182,7 @@ export default function ConversationView({ conversationId: propConversationId }:
 
   // Initialize realtime messaging and typing indicator hooks
   const { sendTypingIndicator } = useRealtimeMessaging(conversationId);
-  const typingUserIds = useTypingIndicator(conversationId);
+  const storedTypingUserIds = useTypingIndicator(conversationId);
 
   const isLargeScreen = useOptimizedMediaQuery({ minWidth: 768 });
 
@@ -195,6 +196,28 @@ export default function ConversationView({ conversationId: propConversationId }:
   // there is no fetch: opening it is subscribing to it.
   const matrixTimeline = useMatrixTimeline(conversationId);
   const messages = matrixTimeline?.messages ?? storedMessages;
+
+  // The store-backed indicator is re-emitted as a DOM event and so only ever
+  // fires on web; the port's comes from the homeserver and works everywhere.
+  const typingUserIds = matrixTimeline?.typingUserIds ?? storedTypingUserIds;
+
+  /**
+   * Says the viewer is typing, wherever this conversation lives.
+   *
+   * The throttling around this — one notice per five seconds, a stop after three
+   * idle — belongs to the composer and is the same either way; only the wire
+   * changes.
+   */
+  const notifyTyping = useCallback(
+    (isTyping: boolean) => {
+      if (matrixTimeline) {
+        matrixTimeline.setTyping(isTyping);
+        return;
+      }
+      sendTypingIndicator(isTyping);
+    },
+    [matrixTimeline, sendTypingIndicator],
+  );
 
   // Group messages by time and format with day separators
   const messageGroups = useMemo(() => {
@@ -219,12 +242,36 @@ export default function ConversationView({ conversationId: propConversationId }:
     conversationId ? state.getVisibleTimestampId(conversationId) : null
   );
 
+  const editingMessageId = useChatUIStore(state =>
+    conversationId ? state.editingByConversation[conversationId] : undefined
+  );
+
   // Get store actions (using selectors to avoid re-renders)
   const fetchMessages = useMessagesStore(state => state.fetchMessages);
   const clearConversationUI = useChatUIStore(state => state.clearConversationUI);
   const setInputText = useChatUIStore(state => state.setInputText);
   const setVisibleTimestamp = useChatUIStore(state => state.setVisibleTimestamp);
+  const setEditing = useChatUIStore(state => state.setEditing);
   const sendMessage = useMessagesStore(state => state.sendMessage);
+
+  /**
+   * Tell the homeserver the newest message here has been seen.
+   *
+   * An Effect because it is the one thing on this screen that is neither derived
+   * state nor a response to something the user did: nobody taps "I have read
+   * this", and the fact being reported — that a conversation with these messages
+   * in it is on screen — only exists after the render that put them there. It is
+   * a write to an external system, which is the case Effects are for.
+   *
+   * Keyed on the newest message rather than on the list, so scrolling, a
+   * reaction, or an edit does not re-send. Re-running is harmless anyway: the
+   * source drops a receipt for an event it has already sent one for.
+   */
+  const markRead = matrixTimeline?.markRead;
+  const newestMessageId = messages.length > 0 ? messages[messages.length - 1].id : undefined;
+  useEffect(() => {
+    markRead?.();
+  }, [markRead, newestMessageId]);
 
 
   const flatListRef = useRef<FlashListRef<FormattedMessageGroup> | null>(null);
@@ -409,6 +456,21 @@ export default function ConversationView({ conversationId: propConversationId }:
       alignItems: 'center',
       padding: 32,
     },
+    editingBanner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      backgroundColor: theme.colors.backgroundSecondary,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: theme.colors.border,
+    },
+    editingBannerText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: theme.colors.primary,
+    },
     typingIndicator: {
       paddingHorizontal: 16,
       paddingVertical: 8,
@@ -477,21 +539,21 @@ export default function ConversationView({ conversationId: propConversationId }:
         // Throttle: only send typing=true once every 5 seconds
         const now = Date.now();
         if (now - lastTypingEmitRef.current > 5000) {
-          sendTypingIndicator(true);
+          notifyTyping(true);
           lastTypingEmitRef.current = now;
         }
         // Stop typing after 3 seconds of no input
         typingTimeoutRef.current = setTimeout(() => {
-          sendTypingIndicator(false);
+          notifyTyping(false);
           lastTypingEmitRef.current = 0;
           typingTimeoutRef.current = null;
         }, 3000);
       } else {
-        sendTypingIndicator(false);
+        notifyTyping(false);
         lastTypingEmitRef.current = 0;
       }
     }
-  }, [conversationId, setInputText, sendTypingIndicator]);
+  }, [conversationId, setInputText, notifyTyping]);
 
   const handleSend = useCallback(async (sizeToUse?: number) => {
     if (!conversationId || inputText.trim().length === 0) return;
@@ -505,7 +567,7 @@ export default function ConversationView({ conversationId: propConversationId }:
       clearTimeout(typingTimeoutRef.current);
       typingTimeoutRef.current = null;
     }
-    sendTypingIndicator(false);
+    notifyTyping(false);
 
     // Clear input immediately for better UX (before sending)
     if (conversationId) {
@@ -530,7 +592,15 @@ export default function ConversationView({ conversationId: propConversationId }:
     // The gesture still adjusts the composer; it just does not reach the message.
     if (matrixTimeline) {
       try {
-        await matrixTimeline.send(text);
+        // The same composer, sending or rewriting. An edit keeps the original
+        // event's place and timestamp on every client in the room; only the body
+        // changes, which is why the row does not move when this returns.
+        if (editingMessageId !== undefined) {
+          await matrixTimeline.edit(editingMessageId, text);
+          setEditing(conversationId, undefined);
+        } else {
+          await matrixTimeline.send(text);
+        }
       } catch (error) {
         console.error('Error sending message:', error);
         const errorMessage = error instanceof Error ? error.message : 'Failed to send message. Please try again.';
@@ -627,7 +697,7 @@ export default function ConversationView({ conversationId: propConversationId }:
     setTimeout(() => {
       inputRef.current?.focus();
     }, 100);
-  }, [conversationId, inputText, sendMessage, setInputText, messageTextSize, setMessageTextSize, conversation, isGroup, currentUserId, matrixTimeline]);
+  }, [conversationId, inputText, sendMessage, setInputText, messageTextSize, setMessageTextSize, conversation, isGroup, currentUserId, matrixTimeline, notifyTyping, editingMessageId, setEditing]);
 
   /**
    * Handle Enter key press to send message
@@ -823,13 +893,21 @@ export default function ConversationView({ conversationId: propConversationId }:
     }
 
     try {
-      const currentReactions = selectedMessage.reactions || {};
-      const hasReacted = currentReactions[emoji]?.includes(currentUserId || '') || false;
-
-      if (hasReacted) {
-        await removeReaction(conversationId, selectedMessage.id, emoji);
+      if (matrixTimeline) {
+        // One call for both directions. Which one it is depends on whether this
+        // account has already annotated the event, and the port asks the SDK
+        // that question against state a snapshot here could be a sync behind —
+        // a reaction sent from the user's phone a moment ago, for instance.
+        await matrixTimeline.toggleReaction(selectedMessage.id, emoji);
       } else {
-        await addReaction(conversationId, selectedMessage.id, emoji);
+        const currentReactions = selectedMessage.reactions || {};
+        const hasReacted = currentReactions[emoji]?.includes(currentUserId || '') || false;
+
+        if (hasReacted) {
+          await removeReaction(conversationId, selectedMessage.id, emoji);
+        } else {
+          await addReaction(conversationId, selectedMessage.id, emoji);
+        }
       }
     } catch (error) {
       console.error('[Conversation] Error toggling reaction:', error);
@@ -837,7 +915,7 @@ export default function ConversationView({ conversationId: propConversationId }:
     } finally {
       resetSelectionState();
     }
-  }, [selectedMessage, conversationId, currentUserId, addReaction, removeReaction, resetSelectionState]);
+  }, [selectedMessage, conversationId, currentUserId, addReaction, removeReaction, resetSelectionState, matrixTimeline]);
 
   const setReplyTo = useChatUIStore((state) => state.setReplyTo);
   const replyTo = useChatUIStore((state) => conversationId && state.replyToByConversation ? state.replyToByConversation[conversationId] : undefined);
@@ -876,12 +954,48 @@ export default function ConversationView({ conversationId: propConversationId }:
   }, [resetSelectionState]);
 
   /**
+   * Handle edit action
+   *
+   * Puts the composer into rewrite mode with the current body in it. The message
+   * is not touched until the user sends; cancelling leaves it exactly as it was.
+   */
+  const handleEdit = useCallback((message: Message) => {
+    resetSelectionState({ preserveMessage: true });
+    if (!conversationId) return;
+    setEditing(conversationId, message.id);
+    setInputText(conversationId, message.text);
+    inputRef.current?.focus();
+  }, [resetSelectionState, conversationId, setEditing, setInputText]);
+
+  const handleCancelEdit = useCallback(() => {
+    if (!conversationId) return;
+    setEditing(conversationId, undefined);
+    setInputText(conversationId, '');
+  }, [conversationId, setEditing, setInputText]);
+
+  /**
    * Handle delete action
+   *
+   * On Matrix this is a redaction, and a redaction is not a disappearance: the
+   * event keeps its place, its sender and its time on every client in the room,
+   * and only its content goes. The row stays and starts drawing itself as
+   * deleted, which is the protocol working — see `AlloTimelineHandle.redact`.
    */
   const handleDelete = useCallback((message: Message) => {
     resetSelectionState({ preserveMessage: true });
-    // TODO: Implement delete functionality
-  }, [resetSelectionState]);
+    if (!matrixTimeline) {
+      // The Express backend has no endpoint that removes a message, so there is
+      // nothing to call and no reason to pretend otherwise by clearing it here:
+      // a message gone from this device and present on every other one is worse
+      // than one that is still there.
+      toast.error('Deleting messages is not available on this account.');
+      return;
+    }
+    matrixTimeline.deleteMessage(message.id).catch((error: unknown) => {
+      console.error('[Conversation] Error deleting message:', error);
+      toast.error('Failed to delete message');
+    });
+  }, [resetSelectionState, matrixTimeline]);
 
   /**
    * Handle info action
@@ -918,18 +1032,32 @@ export default function ConversationView({ conversationId: propConversationId }:
         label: 'Info',
         onPress: () => handleInfo(message),
       },
-      {
+    ];
+
+    // Both only ever apply to the viewer's own messages. Matrix lets a moderator
+    // redact somebody else's, but Allo does not check power levels, and an
+    // action offered to everyone that works for a few is worse than one that is
+    // not offered: the failure arrives after the tap, from the homeserver.
+    if (message.isSent) {
+      if (matrixTimeline) {
+        actions.push({
+          label: 'Edit',
+          onPress: () => handleEdit(message),
+        });
+      }
+      actions.push({
         label: 'Delete',
         icon: <TrashIcon size={20} color="#FF3B30" />,
         onPress: () => handleDelete(message),
         destructive: true,
-      },
-    ];
+      });
+    }
+
     if (context === 'media') {
       return actions.filter(action => action.label !== 'Copy');
     }
     return actions;
-  }, [theme.colors.text, handleReply, handleForward, handleCopy, handleInfo, handleDelete]);
+  }, [theme.colors.text, handleReply, handleForward, handleCopy, handleInfo, handleEdit, handleDelete, matrixTimeline]);
 
   /**
    * Handle swipe to reply
@@ -1139,6 +1267,22 @@ export default function ConversationView({ conversationId: propConversationId }:
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             keyboardVerticalOffset={Platform.OS === 'ios' ? MESSAGING_CONSTANTS.KEYBOARD_OFFSET_IOS : 0}
           >
+            {/* Rewrite mode. Without a way out of it, the next thing the user
+                typed would silently replace an old message instead of sending. */}
+            {editingMessageId !== undefined && (
+              <View style={styles.editingBanner}>
+                <ThemedText style={styles.editingBannerText}>Editing message</ThemedText>
+                <TouchableOpacity
+                  onPress={handleCancelEdit}
+                  activeOpacity={0.7}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel editing"
+                >
+                  <CloseIcon size={18} color={theme.colors.textSecondary} />
+                </TouchableOpacity>
+              </View>
+            )}
             <View style={styles.inputContainer}>
               {/* Attach Button */}
               <TouchableOpacity

--- a/packages/frontend/components/messages/MessageBlock.tsx
+++ b/packages/frontend/components/messages/MessageBlock.tsx
@@ -324,7 +324,7 @@ export const MessageBlock = memo<MessageBlockProps>(({
                       isCloseToPrevious={isCloseToPrevious}
                       messageType={message.messageType || 'user'}
                       readStatus={message.readStatus}
-                      isEdited={false} // TODO: Add edited status to Message type
+                      isEdited={message.isEdited === true}
                       fontSize={message.fontSize} // Use custom font size if set
                     />
                   </View>

--- a/packages/frontend/components/messages/MessageBubble.tsx
+++ b/packages/frontend/components/messages/MessageBubble.tsx
@@ -5,6 +5,7 @@ import { colors } from '@/styles/colors';
 import { useTheme } from '@/hooks/useTheme';
 import { MESSAGING_CONSTANTS } from '@/constants/messaging';
 import { useMessagePreferencesStore } from '@/stores';
+import type { MessageReadStatus } from '@/stores/messagesStore';
 import { MessageMetadata } from './MessageMetadata';
 
 /**
@@ -37,8 +38,8 @@ export interface MessageBubbleProps {
   isCloseToPrevious?: boolean;
   /** Type of message: 'user' (with bubble) or 'ai' (plain text, no bubble) */
   messageType?: MessageType;
-  /** Read status for sent messages */
-  readStatus?: 'pending' | 'sent' | 'delivered' | 'read';
+  /** Read status for sent messages. `failed` draws an error, not the clock. */
+  readStatus?: MessageReadStatus;
   /** Whether the message was edited */
   isEdited?: boolean;
   /** Custom font size for this message (if adjusted via send button) */

--- a/packages/frontend/components/messages/MessageInfoScreen.tsx
+++ b/packages/frontend/components/messages/MessageInfoScreen.tsx
@@ -252,7 +252,7 @@ export const MessageInfoScreen = memo<MessageInfoScreenProps>(({
                 <MessageMetadata
                   timestamp={message.timestamp}
                   isSent={message.isSent}
-                  isEdited={false}
+                  isEdited={message.isEdited === true}
                   readStatus={message.readStatus}
                   showTimestamp={true}
                 />

--- a/packages/frontend/components/messages/MessageMetadata.tsx
+++ b/packages/frontend/components/messages/MessageMetadata.tsx
@@ -6,12 +6,26 @@ import { colors } from '@/styles/colors';
 import { MsgDblCheckIcon } from '@/assets/icons/msgdblcheck-icon';
 import { MsgCheckIcon } from '@/assets/icons/msgcheck-icon';
 import { MsgPendingIcon } from '@/assets/icons/msgpending-icon';
+import { MsgFailedIcon } from '@/assets/icons/msgfailed-icon';
+import { statusMark, type MessageStatusMark } from '@/components/messages/messageStatus';
+import type { MessageReadStatus } from '@/stores/messagesStore';
+
+/** The picture for each mark. Which mark a status gets is `messageStatus.ts`. */
+const MARK_ICONS: Record<
+  MessageStatusMark,
+  (props: { size: number; color: string }) => React.ReactElement
+> = {
+  clock: MsgPendingIcon,
+  tick: MsgCheckIcon,
+  'double-tick': MsgDblCheckIcon,
+  error: MsgFailedIcon,
+};
 
 export interface MessageMetadataProps {
   timestamp: Date;
   isSent?: boolean;
   isEdited?: boolean;
-  readStatus?: 'pending' | 'sent' | 'delivered' | 'read';
+  readStatus?: MessageReadStatus;
   showTimestamp?: boolean;
   variant?: 'default' | 'bubble';
 }
@@ -88,6 +102,12 @@ export const MessageMetadata = memo<MessageMetadataProps>(({
   }), [isBubbleVariant, isSent, theme, timestampColor]);
 
   const readIndicatorColor = useMemo(() => {
+    // A failure is the one status that keeps its own colour inside a bubble.
+    // Everything else on that background is deliberately quiet, and a mark the
+    // user is meant to act on cannot be.
+    if (readStatus === 'failed') {
+      return theme.colors.error;
+    }
     if (isBubbleVariant) {
       return timestampColor;
     }
@@ -100,19 +120,9 @@ export const MessageMetadata = memo<MessageMetadataProps>(({
   const statusIcon = useMemo(() => {
     if (!isSent || !readStatus) return null;
     const iconSize = isBubbleVariant ? MESSAGING_CONSTANTS.TIMESTAMP_SIZE : MESSAGING_CONSTANTS.TIMESTAMP_SIZE + 2;
-    const commonProps = { size: iconSize, color: readIndicatorColor };
+    const Icon = MARK_ICONS[statusMark(readStatus)];
 
-    switch (readStatus) {
-      case 'read':
-        return <MsgDblCheckIcon {...commonProps} />;
-      case 'delivered':
-        return <MsgCheckIcon {...commonProps} />;
-      case 'sent':
-        return <MsgCheckIcon {...commonProps} />;
-      case 'pending':
-      default:
-        return <MsgPendingIcon {...commonProps} />;
-    }
+    return <Icon size={iconSize} color={readIndicatorColor} />;
   }, [isBubbleVariant, isSent, readStatus, readIndicatorColor]);
 
   if (!showTimestamp) {

--- a/packages/frontend/components/messages/messageStatus.ts
+++ b/packages/frontend/components/messages/messageStatus.ts
@@ -1,0 +1,31 @@
+import type { MessageReadStatus } from '@/stores/messagesStore';
+
+/**
+ * Which mark a message's status draws.
+ *
+ * Separated from `MessageMetadata` because it is the one part of that component
+ * that can be got wrong silently. Four statuses share three marks, so the mapping
+ * is not obvious, and the mistake it exists to prevent has a name: drawing a
+ * failed send as pending. The clock says "still on its way", and a failed send is
+ * precisely the case where nothing is on its way any more — on iOS and Android
+ * the queue has given up, and on the web there was never a queue.
+ *
+ * A lookup table rather than a `switch` with a `default`, for the same reason the
+ * translation modules use one: a status nobody handled is a type error here,
+ * where a `default` would quietly draw it as the clock.
+ */
+export type MessageStatusMark = 'clock' | 'tick' | 'double-tick' | 'error';
+
+const MARKS: Record<MessageReadStatus, MessageStatusMark> = {
+  pending: 'clock',
+  sent: 'tick',
+  // One tick each. They differ in what the sender knows — the homeserver has it,
+  // versus their device has it — and Allo has never drawn them apart.
+  delivered: 'tick',
+  read: 'double-tick',
+  failed: 'error',
+};
+
+export function statusMark(readStatus: MessageReadStatus): MessageStatusMark {
+  return MARKS[readStatus];
+}

--- a/packages/frontend/hooks/useMatrixTimeline.ts
+++ b/packages/frontend/hooks/useMatrixTimeline.ts
@@ -34,6 +34,7 @@ const CLOSED_TIMELINE: TimelineSnapshot = {
   isOpening: false,
   isPaginating: false,
   reachedStart: false,
+  typingUserIds: [],
 };
 const closedTimeline = (): TimelineSnapshot => CLOSED_TIMELINE;
 
@@ -46,9 +47,30 @@ export interface MatrixTimeline {
   readonly isPaginating: boolean;
   /** The first message of the conversation is on screen; stop asking for more. */
   readonly reachedStart: boolean;
+  /** Matrix user ids of everyone else typing here, right now. */
+  readonly typingUserIds: readonly string[];
   /** Asks the homeserver for older messages. Safe to call on every scroll. */
   readonly loadOlder: () => void;
   readonly send: (body: string) => Promise<void>;
+  /** Adds the viewer's reaction to a message, or takes it away. */
+  readonly toggleReaction: (messageId: string, emoji: string) => Promise<void>;
+  /** Replaces the body of a message the viewer sent. */
+  readonly edit: (messageId: string, body: string) => Promise<void>;
+  /**
+   * Removes a message's content.
+   *
+   * The row stays and starts drawing itself as deleted, because that is what a
+   * Matrix redaction does — see `AlloTimelineHandle.redact`.
+   */
+  readonly deleteMessage: (messageId: string) => Promise<void>;
+  /**
+   * Tells the homeserver everything up to the newest message has been read.
+   *
+   * Cheap and idempotent: an event already receipted is not sent again.
+   */
+  readonly markRead: () => void;
+  /** Says whether the viewer is typing here. */
+  readonly setTyping: (isTyping: boolean) => void;
 }
 
 export function useMatrixTimeline(
@@ -108,6 +130,67 @@ export function useMatrixTimeline(
     [source],
   );
 
+  const toggleReaction = useCallback(
+    async (messageId: string, emoji: string): Promise<void> => {
+      if (source === undefined) {
+        return;
+      }
+      await source.toggleReaction(messageId, emoji);
+    },
+    [source],
+  );
+
+  const edit = useCallback(
+    async (messageId: string, body: string): Promise<void> => {
+      if (source === undefined) {
+        return;
+      }
+      await source.edit(messageId, body);
+    },
+    [source],
+  );
+
+  const deleteMessage = useCallback(
+    async (messageId: string): Promise<void> => {
+      if (source === undefined) {
+        return;
+      }
+      // No reason is sent. Allo has nowhere to ask for one, and a reason is
+      // visible to the whole room — inventing "Deleted by the user" would put
+      // words in the sender's mouth on every other client.
+      await source.redact(messageId);
+    },
+    [source],
+  );
+
+  const markRead = useCallback(() => {
+    if (source === undefined) {
+      return;
+    }
+    // Deliberately not awaited and its failures not shown: a read receipt is
+    // something the reader neither asked for nor can act on. It is logged
+    // because a receipt that never goes out leaves the *sender's* bubble one
+    // tick short, and that is a real bug with no other symptom.
+    source.markRead().catch((error: unknown) => {
+      logger.error('[chat] a read receipt could not be sent', error);
+    });
+  }, [source]);
+
+  const setTyping = useCallback(
+    (isTyping: boolean) => {
+      if (source === undefined) {
+        return;
+      }
+      // Not awaited either. A typing notice is only worth anything while it is
+      // still true, so there is nothing useful to do about one that failed —
+      // and the composer must not wait on the network between keystrokes.
+      source.sendTypingNotice(isTyping).catch((error: unknown) => {
+        logger.error('[chat] a typing notice could not be sent', error);
+      });
+    },
+    [source],
+  );
+
   return useMemo(
     () =>
       source === undefined
@@ -117,9 +200,26 @@ export function useMatrixTimeline(
             isLoading: snapshot.isOpening,
             isPaginating: snapshot.isPaginating,
             reachedStart: snapshot.reachedStart,
+            typingUserIds: snapshot.typingUserIds,
             loadOlder,
             send,
+            toggleReaction,
+            edit,
+            deleteMessage,
+            markRead,
+            setTyping,
           },
-    [source, messages, snapshot, loadOlder, send],
+    [
+      source,
+      messages,
+      snapshot,
+      loadOlder,
+      send,
+      toggleReaction,
+      edit,
+      deleteMessage,
+      markRead,
+      setTyping,
+    ],
   );
 }

--- a/packages/frontend/lib/chat/matrixViewModel.ts
+++ b/packages/frontend/lib/chat/matrixViewModel.ts
@@ -88,8 +88,30 @@ export function toMessage(
     conversationId: roomId,
     messageType: 'user',
     isEncrypted: item.content.kind === 'undecryptable',
+    isEdited: item.content.kind === 'text' && item.content.isEdited,
+    reactions: toReactions(item),
     readStatus: toReadStatus(item),
   };
+}
+
+/**
+ * Reactions, in the shape the bubble's vocabulary has: emoji to the user ids who
+ * sent it.
+ *
+ * `undefined` and not an empty object for a message nobody has reacted to. The
+ * field is optional in `Message` and the overwhelming majority of rows have no
+ * reactions, so this is one fewer object per message per redraw — and the two
+ * are already the same thing to every reader of the field.
+ */
+function toReactions(item: AlloTimelineItem): Message['reactions'] {
+  if (item.reactions.length === 0) {
+    return undefined;
+  }
+  const reactions: Record<string, string[]> = {};
+  for (const reaction of item.reactions) {
+    reactions[reaction.key] = [...reaction.senders];
+  }
+  return reactions;
 }
 
 function bodyOf(item: AlloTimelineItem, labels: UnreadableEventLabels): string {
@@ -108,23 +130,33 @@ function bodyOf(item: AlloTimelineItem, labels: UnreadableEventLabels): string {
 /**
  * How far along an outgoing message is, in the vocabulary the bubble has.
  *
- * The two vocabularies do not line up and the mismatch is worth naming rather
- * than hiding:
+ * Only the sender's own messages carry a status: `MessageMetadata` draws nothing
+ * for anyone else's, so reporting one would be noise.
  *
- * - Only the sender's own messages carry a status. `MessageMetadata` draws
- *   nothing for anyone else's, so reporting one would be noise.
- * - Matrix has no delivery receipt at all (`docs/matrix/data-model.md` §9,
- *   `deliveredTo`), so `delivered` and `read` are never reached here. Every
- *   message the user sends stops at one tick.
- * - `failed` has nowhere to go: the bubble's states are pending, sent, delivered
- *   and read. It is reported as `pending`, which draws the clock — true on iOS
- *   and Android, where the SDK's send queue really is still trying, and
- *   optimistic on web, where nothing retries. Telling the two apart needs a state
- *   in `MessageMetadata` that does not exist.
+ * One of the bubble's five states is unreachable from here, and it is worth
+ * naming rather than hiding. **`delivered` never happens.** Matrix has no
+ * delivery receipt — there is no event for "it reached their device"
+ * (`docs/matrix/data-model.md` §9, `deliveredTo`) — so a message goes from one
+ * tick straight to read, and the middle state belongs to the Express backend
+ * alone. Inventing it here, by treating "the homeserver has it" as delivery,
+ * would put two ticks on a message nobody has received.
  */
 function toReadStatus(item: AlloTimelineItem): Message['readStatus'] {
   if (!item.isOwn) {
     return undefined;
   }
-  return item.sendState === 'sent' ? 'sent' : 'pending';
+  switch (item.sendState) {
+    case 'pending':
+      return 'pending';
+    // Drawn as an error and not as the clock. The clock is honest on iOS and
+    // Android, where the Rust SDK's queue really is still retrying, and a lie on
+    // the web, where nothing retries and the message is simply gone. One of the
+    // two had to be chosen for both, and a message shown as failed that a queue
+    // then sends is a surprise the user recovers from; a message shown as
+    // pending forever is one they do not.
+    case 'failed':
+      return 'failed';
+    case 'sent':
+      return item.isReadByOthers ? 'read' : 'sent';
+  }
 }

--- a/packages/frontend/lib/chat/timelineSource.ts
+++ b/packages/frontend/lib/chat/timelineSource.ts
@@ -1,3 +1,4 @@
+import { MatrixEventNotSentError } from '@/lib/matrix/errors';
 import type {
   AlloPaginationOutcome,
   AlloTimelineHandle,
@@ -32,15 +33,19 @@ export interface TimelineSnapshot {
   readonly isPaginating: boolean;
   /** There are no older events to ask for. */
   readonly reachedStart: boolean;
+  /** Matrix user ids of everyone else typing in this room, right now. */
+  readonly typingUserIds: readonly string[];
 }
 
 const NO_ITEMS: readonly AlloTimelineItem[] = [];
+const NOBODY_TYPING: readonly string[] = [];
 
 const CLOSED: TimelineSnapshot = {
   items: NO_ITEMS,
   isOpening: false,
   isPaginating: false,
   reachedStart: false,
+  typingUserIds: NOBODY_TYPING,
 };
 
 const OPENING: TimelineSnapshot = { ...CLOSED, isOpening: true };
@@ -53,6 +58,23 @@ export class TimelineNotOpenError extends Error {
         'watching it.',
     );
     this.name = 'TimelineNotOpenError';
+  }
+}
+
+/**
+ * An operation named a row that is not in the timeline.
+ *
+ * The UI addresses messages by the key it draws them with, and a key that is no
+ * longer there is ordinary rather than exceptional: a conversation can be reset
+ * by a gappy sync between a long press and the tap that follows it.
+ */
+export class TimelineRowNotFoundError extends Error {
+  constructor(operation: string, key: string, roomId: string) {
+    super(
+      `${operation} names the message ${key}, which is no longer in the timeline ` +
+        `of ${roomId}.`,
+    );
+    this.name = 'TimelineRowNotFoundError';
   }
 }
 
@@ -83,6 +105,9 @@ export class TimelineSource {
   #handle: AlloTimelineHandle | undefined;
   #opening: Promise<AlloTimelineHandle> | undefined;
   #watchingRuntime: AlloUnsubscribe | undefined;
+  #watchingTyping: AlloUnsubscribe | undefined;
+  /** The last event id a read receipt was sent for. See {@link markRead}. */
+  #receipted: string | undefined;
   /** See `roomListSource.ts`: invalidates callbacks from a superseded handle. */
   #generation = 0;
 
@@ -153,6 +178,99 @@ export class TimelineSource {
     await handle.sendText(body);
   };
 
+  /** Adds the viewer's reaction to a row, or takes it away. */
+  readonly toggleReaction = async (key: string, emoji: string): Promise<void> => {
+    const handle = await this.#require('Reacting to a message');
+    await handle.toggleReaction(this.#eventId('Reacting to a message', key), emoji);
+  };
+
+  /** Replaces the body of a row the viewer sent. */
+  readonly edit = async (key: string, body: string): Promise<void> => {
+    const handle = await this.#require('Editing a message');
+    await handle.edit(this.#eventId('Editing a message', key), body);
+  };
+
+  /**
+   * Removes a row's content.
+   *
+   * The row stays: a redaction leaves the event's skeleton standing and the
+   * timeline reports it with a `redacted` content kind. Nothing is removed from
+   * the snapshot here, and nothing should be — a row that vanished locally and
+   * stayed everywhere else would be a lie that survives until the next sync.
+   */
+  readonly redact = async (key: string, reason?: string): Promise<void> => {
+    const handle = await this.#require('Deleting a message');
+    await handle.redact(this.#eventId('Deleting a message', key), reason);
+  };
+
+  /**
+   * Tells the homeserver everything up to the newest row has been read.
+   *
+   * Safe to call on every render that might have changed the conversation: an
+   * event already receipted is not sent again, and a timeline whose newest row is
+   * still a local echo has nothing to receipt yet.
+   */
+  readonly markRead = async (): Promise<void> => {
+    const newest = this.#newestRemoteEventId();
+    if (newest === undefined || newest === this.#receipted) {
+      return;
+    }
+    const handle = await this.#require('Sending a read receipt');
+    // Recorded before the call rather than after it, so that a second render
+    // arriving while this one is in flight does not send the same receipt twice.
+    this.#receipted = newest;
+    try {
+      await handle.sendReadReceipt(newest);
+    } catch (error) {
+      // Let the next change try again: a receipt that never went out leaves the
+      // sender's bubble one tick short for good.
+      if (this.#receipted === newest) {
+        this.#receipted = undefined;
+      }
+      throw error;
+    }
+  };
+
+  /** Says whether the viewer is typing here. */
+  readonly sendTypingNotice = async (isTyping: boolean): Promise<void> => {
+    const handle = await this.#require('Sending a typing notice');
+    await handle.sendTypingNotice(isTyping);
+  };
+
+  /**
+   * The event id of a row, by the key the UI draws it with.
+   *
+   * Two ways to fail and they are different problems, so they are different
+   * errors: the row is gone, or the row is there and is still on its way out.
+   */
+  #eventId(operation: string, key: string): string {
+    const item = this.#snapshot.items.find((candidate) => candidate.key === key);
+    if (item === undefined) {
+      throw new TimelineRowNotFoundError(operation, key, this.#roomId);
+    }
+    if (item.id.kind !== 'remote') {
+      throw new MatrixEventNotSentError(operation, key);
+    }
+    return item.id.eventId;
+  }
+
+  /**
+   * The newest row the homeserver has accepted, if there is one.
+   *
+   * Searched from the end, because the rows this skips over — a message the user
+   * has just sent and its neighbours — are the only ones that can be local.
+   */
+  #newestRemoteEventId(): string | undefined {
+    const items = this.#snapshot.items;
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const id = items[index].id;
+      if (id.kind === 'remote') {
+        return id.eventId;
+      }
+    }
+    return undefined;
+  }
+
   readonly #onRuntimeChanged = (): void => {
     if (this.#runtime.getState().phase === 'ready') {
       if (this.#handle === undefined && this.#opening === undefined) {
@@ -191,6 +309,11 @@ export class TimelineSource {
         }
         this.#handle = handle;
         this.#opening = undefined;
+        this.#watchingTyping = handle.observeTyping((typingUserIds) => {
+          if (generation === this.#generation) {
+            this.#publish({ typingUserIds });
+          }
+        });
         this.#publish({ isOpening: false });
         this.#publishItems(generation, handle.items());
         return handle;
@@ -210,6 +333,11 @@ export class TimelineSource {
   #drop(): void {
     this.#generation += 1;
     this.#opening = undefined;
+    this.#watchingTyping?.();
+    this.#watchingTyping = undefined;
+    // The receipt belongs to the handle that sent it. A session that came back
+    // has to be free to say again what it said before it went away.
+    this.#receipted = undefined;
     const handle = this.#handle;
     this.#handle = undefined;
     handle?.close();
@@ -238,7 +366,8 @@ export class TimelineSource {
       next.items === this.#snapshot.items &&
       next.isOpening === this.#snapshot.isOpening &&
       next.isPaginating === this.#snapshot.isPaginating &&
-      next.reachedStart === this.#snapshot.reachedStart
+      next.reachedStart === this.#snapshot.reachedStart &&
+      next.typingUserIds === this.#snapshot.typingUserIds
     ) {
       return;
     }

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -1,8 +1,11 @@
 import {
   ClientBuilder,
+  EditedContent,
+  EventOrTransactionId,
   LogLevel,
   MessageType,
   OidcPrompt,
+  ReceiptType,
   RoomListEntriesDynamicFilterKind,
   SlidingSyncVersion,
   SlidingSyncVersionBuilder,
@@ -345,9 +348,18 @@ class NativeAlloChatClient implements AlloChatClient {
   ): Promise<AlloTimelineHandle> {
     const room = this.#requireRoom(roomId, 'Opening a timeline');
     const timeline = await room.timeline();
-    const handle = new NativeTimelineHandle(timeline, onChange, () => {
-      this.#timelines.delete(handle);
-    });
+    // The room travels with the timeline because two of the handle's operations
+    // are the room's in the binding and not the timeline's: a typing notice is
+    // about the conversation, not about any event in it.
+    const handle = new NativeTimelineHandle(
+      timeline,
+      room,
+      this.#client.userId(),
+      onChange,
+      () => {
+        this.#timelines.delete(handle);
+      },
+    );
     await handle.attach();
     this.#timelines.add(handle);
     return handle;
@@ -517,21 +529,29 @@ class NativeRoomListHandle implements AlloRoomListHandle {
 
 class NativeTimelineHandle implements AlloTimelineHandle {
   readonly #timeline: TimelineLike;
+  readonly #room: RoomLike;
+  readonly #viewerUserId: string;
   readonly #onChange: (items: readonly AlloTimelineItem[]) => void;
   readonly #onClose: () => void;
   readonly #rows: TimelineItemLike[] = [];
   readonly #projection = new TimelineProjection();
+  readonly #typingListeners = new Set<(userIds: readonly string[]) => void>();
 
   #items: readonly AlloTimelineItem[] = [];
   #stream: TaskHandleLike | undefined;
+  #typingStream: TaskHandleLike | undefined;
   #closed = false;
 
   constructor(
     timeline: TimelineLike,
+    room: RoomLike,
+    viewerUserId: string,
     onChange: (items: readonly AlloTimelineItem[]) => void,
     onClose: () => void,
   ) {
     this.#timeline = timeline;
+    this.#room = room;
+    this.#viewerUserId = viewerUserId;
     this.#onChange = onChange;
     this.#onClose = onClose;
   }
@@ -571,6 +591,60 @@ class NativeTimelineHandle implements AlloTimelineHandle {
     );
   }
 
+  async toggleReaction(eventId: string, key: string): Promise<void> {
+    // One call for both directions: the binding looks up whether this account
+    // already annotated the event and either sends or redacts accordingly.
+    await this.#timeline.toggleReaction(toEventOrTransactionId(eventId), key);
+  }
+
+  async edit(eventId: string, body: string): Promise<void> {
+    await this.#timeline.edit(
+      toEventOrTransactionId(eventId),
+      // Text for the same reason `sendText` is text: an edit is the user typing
+      // again, and their asterisks are asterisks.
+      new EditedContent.RoomMessage({
+        content: messageEventContentNew(new MessageType.Text({ content: { body } })),
+      }),
+    );
+  }
+
+  async redact(eventId: string, reason: string | undefined): Promise<void> {
+    await this.#timeline.redactEvent(toEventOrTransactionId(eventId), reason);
+  }
+
+  async sendReadReceipt(eventId: string): Promise<void> {
+    // `Read` and not `ReadPrivate`: a read mark nobody else can see is one the
+    // sender's own bubble could never draw, and drawing it is the point.
+    await this.#timeline.sendReadReceipt(ReceiptType.Read, eventId);
+  }
+
+  async sendTypingNotice(isTyping: boolean): Promise<void> {
+    await this.#room.typingNotice(isTyping);
+  }
+
+  observeTyping(onChange: (userIds: readonly string[]) => void): AlloUnsubscribe {
+    this.#typingListeners.add(onChange);
+    // Subscribed on the first listener rather than in `attach`, so a conversation
+    // nobody is watching for typing costs no stream at all.
+    this.#typingStream ??= this.#room.subscribeToTypingNotifications({
+      call: (typingUserIds: string[]): void => {
+        // The viewer's own typing comes back down sync on some homeservers, and
+        // "you are typing" is not something to draw at the reader.
+        const others = typingUserIds.filter((userId) => userId !== this.#viewerUserId);
+        for (const listener of this.#typingListeners) {
+          listener(others);
+        }
+      },
+    });
+    return () => {
+      this.#typingListeners.delete(onChange);
+      if (this.#typingListeners.size === 0) {
+        this.#typingStream?.cancel();
+        this.#typingStream = undefined;
+      }
+    };
+  }
+
   close(): void {
     if (this.#closed) {
       return;
@@ -578,8 +652,23 @@ class NativeTimelineHandle implements AlloTimelineHandle {
     this.#closed = true;
     this.#stream?.cancel();
     this.#stream = undefined;
+    this.#typingStream?.cancel();
+    this.#typingStream = undefined;
+    this.#typingListeners.clear();
     this.#onClose();
   }
+}
+
+/**
+ * An event id in the shape the timeline addresses rows with.
+ *
+ * Always the `EventId` arm. The port's message operations take an event id and
+ * nothing else — see `AlloTimelineHandle` — so the transaction id arm, which is
+ * how the binding addresses a row still on its way out, is unreachable from here
+ * by construction.
+ */
+function toEventOrTransactionId(eventId: string): EventOrTransactionId {
+  return new EventOrTransactionId.EventId({ eventId });
 }
 
 /**

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -9,7 +9,10 @@ import {
   MemoryStore,
   MsgType,
   OAuth2,
+  ReceiptType,
+  RelationType,
   RoomEvent,
+  RoomMemberEvent,
   RoomStateEvent,
   TokenRefresher,
   createClient,
@@ -47,11 +50,13 @@ import {
 // rule to trust. The platform-resolved name is for the code above the split,
 // which must not care.
 import { cryptoDatabasePrefix } from '@/lib/matrix/store.web';
+import { markReadByOthers } from '@/lib/matrix/readReceipts';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
   AlloChatClientFactory,
   AlloEncryptionState,
+  AlloReaction,
   AlloOidcLoginOptions,
   AlloOidcLoginRequest,
   AlloPaginationOutcome,
@@ -77,7 +82,15 @@ import { planKeyBackup, toRecoveryState } from './web/recovery';
 import { directRoomIds, orderRoomList, type RoomListEntry } from './web/roomList';
 import { createSecretStorageKeyCallback } from './web/secretStorage';
 import { decodeAuthData, encodeAuthData } from './web/session';
-import { toEncryptionState, toRoomSummary, toSyncState, toTimelineItem } from './web/translate';
+import {
+  isTimelineRow,
+  toEncryptionState,
+  toReactions,
+  toReaders,
+  toRoomSummary,
+  toSyncState,
+  toTimelineItem,
+} from './web/translate';
 
 /**
  * The web implementation of the Allo chat port, over `matrix-js-sdk` and the Rust
@@ -130,6 +143,27 @@ const INITIAL_SYNC_LIMIT = 20;
 
 /** `m.room.encryption` is room state with an empty state key. */
 const ENCRYPTION_STATE_KEY = '';
+
+/**
+ * How long the homeserver keeps this browser's typing notice alive.
+ *
+ * Longer than the composer's re-emit interval, so a user typing steadily never
+ * flickers, and short enough that a tab closed mid-sentence stops claiming to be
+ * typing within a few seconds. There is nothing to clean up on the way out: the
+ * server forgets it on its own, which is the only cleanup a closed tab gets.
+ */
+const TYPING_NOTICE_TIMEOUT_MS = 10_000;
+
+/**
+ * What an edit's `body` is prefixed with for clients that cannot aggregate.
+ *
+ * The convention the spec suggests and every client follows: a receiver that does
+ * not understand `m.replace` shows the fallback body, and the leading `* ` is
+ * what tells its reader they are looking at a correction. Clients that do
+ * understand it — including both halves of this port — read `m.new_content`
+ * instead and never show the prefix.
+ */
+const EDIT_FALLBACK_PREFIX = ' * ';
 
 /**
  * The SDK's crypto surface. Taken off the client rather than imported, because
@@ -879,8 +913,10 @@ class WebTimelineHandle implements AlloTimelineHandle {
   readonly #onChange: (items: readonly AlloTimelineItem[]) => void;
   readonly #onClose: () => void;
   readonly #coalescer: Coalescer;
+  readonly #typingListeners = new Set<(userIds: readonly string[]) => void>();
 
   #items: readonly AlloTimelineItem[] = [];
+  #typing: readonly string[] = [];
   #closed = false;
 
   constructor(
@@ -905,6 +941,9 @@ class WebTimelineHandle implements AlloTimelineHandle {
     this.#client.on(RoomEvent.TimelineReset, this.#onTimelineReset);
     this.#client.on(RoomEvent.LocalEchoUpdated, this.#onRoomChanged);
     this.#client.on(RoomEvent.Redaction, this.#onRoomChanged);
+    // Somebody read something. Nothing else reports it: a receipt is not a
+    // timeline event, and it is what moves a row's read mark.
+    this.#client.on(RoomEvent.Receipt, this.#onRoomChanged);
     // A room key arriving turns an unreadable row into a readable one.
     this.#client.on(MatrixEventEvent.Decrypted, this.#onEventChanged);
     this.#client.on(MatrixEventEvent.Replaced, this.#onEventChanged);
@@ -933,6 +972,77 @@ class WebTimelineHandle implements AlloTimelineHandle {
     await this.#client.sendMessage(this.#room.roomId, { msgtype: MsgType.Text, body });
   }
 
+  /**
+   * Adds the viewer's annotation, or redacts the one they already sent.
+   *
+   * The SDK has no toggle, so the decision is made here, and it is made from the
+   * aggregated relations rather than from anything this handle remembers: a
+   * reaction sent from the user's phone a second ago is in there and is not in
+   * any local state.
+   */
+  async toggleReaction(eventId: string, key: string): Promise<void> {
+    const existing = this.#viewerReaction(eventId, key);
+    if (existing !== undefined) {
+      await this.#client.redactEvent(this.#room.roomId, existing);
+      return;
+    }
+    await this.#client.sendEvent(this.#room.roomId, EventType.Reaction, {
+      'm.relates_to': { rel_type: RelationType.Annotation, event_id: eventId, key },
+    });
+  }
+
+  async edit(eventId: string, body: string): Promise<void> {
+    await this.#client.sendMessage(this.#room.roomId, {
+      msgtype: MsgType.Text,
+      body: `${EDIT_FALLBACK_PREFIX}${body}`,
+      'm.new_content': { msgtype: MsgType.Text, body },
+      'm.relates_to': { rel_type: RelationType.Replace, event_id: eventId },
+    });
+  }
+
+  async redact(eventId: string, reason: string | undefined): Promise<void> {
+    await this.#client.redactEvent(this.#room.roomId, eventId, undefined, { reason });
+  }
+
+  /**
+   * Sends a public read receipt for one event.
+   *
+   * An event id the room does not hold is reported and dropped rather than
+   * thrown: the caller is a reader scrolling, the id came from a timeline that
+   * may since have been reset by a gappy sync, and there is no version of "your
+   * read receipt did not go out" worth interrupting them with.
+   */
+  async sendReadReceipt(eventId: string): Promise<void> {
+    const event = this.#room.findEventById(eventId);
+    if (event === undefined) {
+      logger.warn(
+        `${LOG_TAG} no read receipt was sent for ${eventId}: it is not in ` +
+          `${this.#room.roomId}`,
+      );
+      return;
+    }
+    // `Read` and not `ReadPrivate`: a mark nobody else can see is one the
+    // sender's own bubble could never draw, and drawing it is the point.
+    await this.#client.sendReadReceipt(event, ReceiptType.Read);
+  }
+
+  async sendTypingNotice(isTyping: boolean): Promise<void> {
+    await this.#client.sendTyping(this.#room.roomId, isTyping, TYPING_NOTICE_TIMEOUT_MS);
+  }
+
+  observeTyping(onChange: (userIds: readonly string[]) => void): AlloUnsubscribe {
+    this.#typingListeners.add(onChange);
+    if (this.#typingListeners.size === 1) {
+      this.#client.on(RoomMemberEvent.Typing, this.#onTyping);
+    }
+    return () => {
+      this.#typingListeners.delete(onChange);
+      if (this.#typingListeners.size === 0) {
+        this.#client.off(RoomMemberEvent.Typing, this.#onTyping);
+      }
+    };
+  }
+
   close(): void {
     if (this.#closed) {
       return;
@@ -944,10 +1054,41 @@ class WebTimelineHandle implements AlloTimelineHandle {
     this.#client.off(RoomEvent.TimelineReset, this.#onTimelineReset);
     this.#client.off(RoomEvent.LocalEchoUpdated, this.#onRoomChanged);
     this.#client.off(RoomEvent.Redaction, this.#onRoomChanged);
+    this.#client.off(RoomEvent.Receipt, this.#onRoomChanged);
     this.#client.off(MatrixEventEvent.Decrypted, this.#onEventChanged);
     this.#client.off(MatrixEventEvent.Replaced, this.#onEventChanged);
+    if (this.#typingListeners.size > 0) {
+      this.#client.off(RoomMemberEvent.Typing, this.#onTyping);
+    }
+    this.#typingListeners.clear();
 
     this.#onClose();
+  }
+
+  /**
+   * The id of the viewer's own annotation with this key, if they sent one.
+   *
+   * Redacted annotations are skipped: the relation container usually drops them
+   * on redaction, and redacting one twice would be a request the homeserver
+   * refuses rather than a reaction the user gets back.
+   */
+  #viewerReaction(eventId: string, key: string): string | undefined {
+    const viewerUserId = this.#client.getSafeUserId();
+    const annotations = this.#room.relations.getChildEventsForEvent(
+      eventId,
+      RelationType.Annotation,
+      EventType.Reaction,
+    );
+    for (const annotation of annotations?.getRelations() ?? []) {
+      if (
+        annotation.getSender() === viewerUserId &&
+        annotation.getRelation()?.key === key &&
+        !annotation.isRedacted()
+      ) {
+        return annotation.getId();
+      }
+    }
+    return undefined;
   }
 
   readonly #onRoomChanged = (_event: unknown, room?: Room): void => {
@@ -976,6 +1117,47 @@ class WebTimelineHandle implements AlloTimelineHandle {
     }
   };
 
+  /**
+   * Not coalesced with the timeline.
+   *
+   * The two travel at different speeds and mean different things: a typing notice
+   * is only useful while it is true, and putting it behind the same frame of
+   * delay as a batch of decrypted messages is how "is typing" arrives after the
+   * message it was announcing.
+   */
+  readonly #onTyping = (_event: MatrixEvent, member: { roomId: string }): void => {
+    if (member.roomId === this.#room.roomId) {
+      this.#publishTyping();
+    }
+  };
+
+  #publishTyping(): void {
+    if (this.#closed) {
+      return;
+    }
+    const viewerUserId = this.#client.getSafeUserId();
+    // Asked of the room rather than accumulated from the events, because the
+    // SDK's members are the state the events have already been applied to — and
+    // one member stopping does not tell us about the others.
+    const typing = this.#room
+      .getMembers()
+      .filter((member) => member.typing && member.userId !== viewerUserId)
+      .map((member) => member.userId);
+
+    if (
+      typing.length === this.#typing.length &&
+      typing.every((userId, index) => userId === this.#typing[index])
+    ) {
+      // `RoomMember.typing` is republished on every sync that carries an
+      // `m.typing`, which for one person typing steadily is several a second.
+      return;
+    }
+    this.#typing = typing;
+    for (const listener of this.#typingListeners) {
+      listener(typing);
+    }
+  }
+
   #publish(): void {
     if (this.#closed) {
       return;
@@ -983,11 +1165,17 @@ class WebTimelineHandle implements AlloTimelineHandle {
 
     const viewerUserId = this.#client.getSafeUserId();
     const items: AlloTimelineItem[] = [];
+    const readers: (readonly string[])[] = [];
     // Local echoes are in here too: the client is started with the SDK's default
     // chronological ordering, which puts a message in the timeline the moment it
     // is sent rather than in a list of its own.
     for (const event of this.#room.getLiveTimeline().getEvents()) {
-      const item = toTimelineItem(event, viewerUserId);
+      // Reactions, redactions and edits are in the timeline and are not rows of
+      // it; each one changes a row that is already there. See `isTimelineRow`.
+      if (!isTimelineRow(event)) {
+        continue;
+      }
+      const item = toTimelineItem(event, viewerUserId, this.#reactionsFor(event));
       if (item === undefined) {
         logger.warn(
           `${LOG_TAG} an event in ${this.#room.roomId} has neither an event id nor a ` +
@@ -996,9 +1184,38 @@ class WebTimelineHandle implements AlloTimelineHandle {
         continue;
       }
       items.push(item);
+      readers.push(toReaders(this.#room.getReceiptsForEvent(event)));
     }
 
-    this.#items = items;
+    // A receipt names one event and covers every earlier one, so the read mark of
+    // a row comes from what is *after* it. See `lib/matrix/readReceipts.ts`.
+    const readByOthers = markReadByOthers(
+      items.map((item, index) => ({ sender: item.sender, readers: readers[index] })),
+    );
+
+    this.#items = items.map((item, index) =>
+      readByOthers[index] ? { ...item, isReadByOthers: true } : item,
+    );
     this.#onChange(this.#items);
   }
+
+  /**
+   * The reactions the SDK has aggregated onto one event.
+   *
+   * A local echo has no event id the homeserver knows, so nothing can have
+   * annotated it yet and there is nothing to look up.
+   */
+  #reactionsFor(event: MatrixEvent): readonly AlloReaction[] {
+    const eventId = event.getId();
+    if (eventId === undefined) {
+      return NO_REACTIONS;
+    }
+    return toReactions(
+      this.#room.relations
+        .getChildEventsForEvent(eventId, RelationType.Annotation, EventType.Reaction)
+        ?.getSortedAnnotationsByKey() ?? null,
+    );
+  }
 }
+
+const NO_REACTIONS: readonly AlloReaction[] = [];

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -165,6 +165,9 @@ const TYPING_NOTICE_TIMEOUT_MS = 10_000;
  */
 const EDIT_FALLBACK_PREFIX = ' * ';
 
+/** Shared by every row nobody has reacted to, which is nearly all of them. */
+const NO_REACTIONS: readonly AlloReaction[] = [];
+
 /**
  * The SDK's crypto surface. Taken off the client rather than imported, because
  * `matrix-js-sdk@42` does not export `CryptoApi` from its root.
@@ -1217,5 +1220,3 @@ class WebTimelineHandle implements AlloTimelineHandle {
     );
   }
 }
-
-const NO_REACTIONS: readonly AlloReaction[] = [];

--- a/packages/frontend/lib/matrix/errors.ts
+++ b/packages/frontend/lib/matrix/errors.ts
@@ -55,6 +55,24 @@ export class MatrixRoomNotFoundError extends MatrixPortError {
   }
 }
 
+/**
+ * A message operation was asked for on an event the homeserver has not accepted.
+ *
+ * Reactions, edits, redactions and read receipts all address an event by its id,
+ * and a message still on its way out has none — it is addressable only by the
+ * transaction id its own timeline minted for it. The Rust binding can address
+ * some of those anyway and `matrix-js-sdk` cannot, so rather than let the two
+ * platforms disagree about which taps do nothing, both refuse with this.
+ */
+export class MatrixEventNotSentError extends MatrixPortError {
+  constructor(operation: string, key: string) {
+    super(
+      `${operation} needs an event id, and the message ${key} has not been ` +
+        'accepted by the homeserver yet. Wait for it to be sent.',
+    );
+  }
+}
+
 /** Something that needs a session was attempted before there was one. */
 export class MatrixNotLoggedInError extends MatrixPortError {
   constructor(operation: string) {

--- a/packages/frontend/lib/matrix/native/timelineProjection.ts
+++ b/packages/frontend/lib/matrix/native/timelineProjection.ts
@@ -1,8 +1,9 @@
 import type { TimelineUniqueId } from '@unomed/react-native-matrix-sdk';
 
+import { markReadByOthers } from '@/lib/matrix/readReceipts';
 import type { AlloTimelineItem } from '@/lib/matrix/types';
 
-import { toTimelineItem, type TimelineEventFields } from './translate';
+import { toReaders, toTimelineItem, type TimelineEventFields } from './translate';
 
 /**
  * What this module needs of a timeline row, rather than the whole
@@ -16,9 +17,42 @@ export interface TimelineRow {
 }
 
 /**
+ * A row that has been read across the FFI boundary, kept so it is not read again.
+ *
+ * Two items rather than one because a row's read mark is not a property of the
+ * row: it comes from receipts on *later* rows, so the same event is drawn read or
+ * unread depending on what came after it, while the expensive part — the two FFI
+ * calls that produced it — is the same either way. The read variant is built when
+ * it is first needed and then kept, which is what lets an unchanged conversation
+ * hand back the very same objects on the next batch.
+ */
+class ProjectedRow {
+  readonly readers: readonly string[];
+  readonly #unread: AlloTimelineItem;
+  #read: AlloTimelineItem | undefined;
+
+  constructor(item: AlloTimelineItem, readers: readonly string[]) {
+    this.#unread = item;
+    this.readers = readers;
+  }
+
+  get sender(): string {
+    return this.#unread.sender;
+  }
+
+  item(isReadByOthers: boolean): AlloTimelineItem {
+    if (!isReadByOthers) {
+      return this.#unread;
+    }
+    this.#read ??= { ...this.#unread, isReadByOthers: true };
+    return this.#read;
+  }
+}
+
+/**
  * Turns the mirrored SDK list into the array the UI draws.
  *
- * Two things make this more than a `map`:
+ * Three things make this more than a `map`:
  *
  * - Rows that are not events — date separators, the read marker — are dropped.
  *   They are dropped here and not in the mirrored list because the SDK's diffs
@@ -28,32 +62,41 @@ export interface TimelineRow {
  *   received. Rows are therefore cached by object identity, which is sound
  *   because the binding hands over a fresh object whenever a row changes: the
  *   same object is, by construction, the same content.
+ * - Read receipts are resolved over the whole list rather than per row. A
+ *   receipt names one event and covers everything before it, so the second pass
+ *   below is not an optimisation of a per-row answer — it is the only place the
+ *   answer exists. Cheap, too: it touches no FFI at all.
  */
 export class TimelineProjection {
-  #cache = new Map<TimelineRow, AlloTimelineItem | null>();
+  #cache = new Map<TimelineRow, ProjectedRow | null>();
 
   project(rows: readonly TimelineRow[]): readonly AlloTimelineItem[] {
     const previous = this.#cache;
-    const next = new Map<TimelineRow, AlloTimelineItem | null>();
-    const items: AlloTimelineItem[] = [];
+    const next = new Map<TimelineRow, ProjectedRow | null>();
+    const projected: ProjectedRow[] = [];
 
     for (const row of rows) {
       // `null` means "read, and it is not an event"; `undefined` means "not read
       // yet". Conflating them would re-read every virtual row on every batch.
       const cached = previous.get(row);
-      const projected = cached === undefined ? project(row) : cached;
-      next.set(row, projected);
-      if (projected !== null) {
-        items.push(projected);
+      const value = cached === undefined ? project(row) : cached;
+      next.set(row, value);
+      if (value !== null) {
+        projected.push(value);
       }
     }
 
     this.#cache = next;
-    return items;
+
+    const readByOthers = markReadByOthers(projected);
+    return projected.map((row, index) => row.item(readByOthers[index]));
   }
 }
 
-function project(row: TimelineRow): AlloTimelineItem | null {
+function project(row: TimelineRow): ProjectedRow | null {
   const event = row.asEvent();
-  return event === undefined ? null : toTimelineItem(row.uniqueId().id, event);
+  if (event === undefined) {
+    return null;
+  }
+  return new ProjectedRow(toTimelineItem(row.uniqueId().id, event), toReaders(event));
 }

--- a/packages/frontend/lib/matrix/native/translate.ts
+++ b/packages/frontend/lib/matrix/native/translate.ts
@@ -19,6 +19,7 @@ import type {
   AlloEncryptionState,
   AlloEventContent,
   AlloEventKey,
+  AlloReaction,
   AlloRoomMembership,
   AlloRoomSummary,
   AlloSendState,
@@ -101,11 +102,17 @@ export type TimelineEventFields = Pick<
   | 'timestamp'
   | 'isOwn'
   | 'localSendState'
+  | 'readReceipts'
 >;
 
 /**
  * @param key identity of the row within its timeline, from the SDK's own list
  * identity, so that a local echo and the remote event it becomes are one row.
+ *
+ * `isReadByOthers` is left `false` here and settled by the projection. It is the
+ * one field of a row that is not a function of that row: a receipt sitting on a
+ * later message is what says this one was read, so the answer needs the whole
+ * timeline and this function has one event. See `lib/matrix/readReceipts.ts`.
  */
 export function toTimelineItem(
   key: string,
@@ -122,7 +129,51 @@ export function toTimelineItem(
     isOwn: event.isOwn,
     sendState: toSendState(event.localSendState),
     content: toEventContent(event.content),
+    reactions: toReactions(event.content),
+    isReadByOthers: false,
   };
+}
+
+/**
+ * The user ids whose read receipt names this event.
+ *
+ * The binding hands over a map keyed by user id, and the keys are the whole
+ * answer: what each `Receipt` carries beyond that is a timestamp and a thread
+ * id, and neither changes whether the message was read.
+ */
+export function toReaders(
+  event: Pick<TimelineEventFields, 'readReceipts'>,
+): readonly string[] {
+  return [...event.readReceipts.keys()];
+}
+
+const NO_REACTIONS: readonly AlloReaction[] = [];
+
+/**
+ * The reactions on a row.
+ *
+ * Only message-like events carry them — a state event has no annotations — and
+ * the binding says so in the shape: `reactions` lives on `MsgLikeContent` and
+ * not on `TimelineItemContent`. Reactions on an undecryptable or redacted event
+ * survive, which is right: an emoji on a message this device cannot read is
+ * still a fact about the conversation.
+ */
+export function toReactions(content: TimelineItemContent): readonly AlloReaction[] {
+  if (content.tag !== TimelineItemContent_Tags.MsgLike) {
+    return NO_REACTIONS;
+  }
+  const reactions = content.inner.content.reactions;
+  if (reactions.length === 0) {
+    // The common case by a wide margin, and worth not allocating for: this runs
+    // once per row per batch, and a batch arrives on every event received.
+    return NO_REACTIONS;
+  }
+  return reactions.map((reaction) => ({
+    key: reaction.key,
+    // The binding carries a timestamp per sender that Allo has nothing to draw
+    // with, and one sender can appear only once per key.
+    senders: reaction.senders.map((sender) => sender.senderId),
+  }));
 }
 
 function toEventKey(id: EventTimelineItem['eventOrTransactionId']): AlloEventKey {

--- a/packages/frontend/lib/matrix/readReceipts.ts
+++ b/packages/frontend/lib/matrix/readReceipts.ts
@@ -1,0 +1,59 @@
+/**
+ * Turning read receipts into the answer a message bubble needs.
+ *
+ * A Matrix read receipt names one event and means *everything up to and
+ * including it*. Both SDKs report receipts the way the protocol carries them —
+ * attached to the event they name — and in a conversation anybody has actually
+ * read, that is the newest event and nothing else. Asking either SDK "who has
+ * read this message?" about a message four rows back therefore answers "nobody",
+ * for every message except the last one.
+ *
+ * Reading the timeline backwards is what turns the one into the other, and it is
+ * a single pass: a receipt met at row *i* counts for every row before *i*, so
+ * carrying the readers seen so far from the newest row to the oldest answers
+ * every row at once and does it in one traversal rather than one per row.
+ *
+ * Shared by both implementations on purpose. It is the only piece of the two
+ * timelines that is the same computation on the same shape of data, and having
+ * one copy is what stops iOS and the web from disagreeing about whether a message
+ * has been read.
+ */
+
+/** What the scan needs of a row, in timeline order (oldest first). */
+export interface AlloReadRow {
+  /** Matrix user id of whoever sent the event. */
+  readonly sender: string;
+  /** Matrix user ids whose read receipt names this exact event. */
+  readonly readers: readonly string[];
+}
+
+/**
+ * For each row, whether somebody other than its sender has read it.
+ *
+ * The result is positional: index *i* answers for `rows[i]`.
+ *
+ * Excluding the sender is not a detail. A client sends a read receipt for the
+ * message it has just sent — it has, after all, read it — so counting it would
+ * mark every outgoing message as read the moment it arrived back down sync, and
+ * the read mark would carry no information at all.
+ */
+export function markReadByOthers(rows: readonly AlloReadRow[]): readonly boolean[] {
+  const flags = new Array<boolean>(rows.length);
+  // Everyone whose receipt sits on this row or on a later one. It only ever
+  // grows as the scan moves towards the start of the conversation, which is
+  // exactly the "up to and including" the protocol means.
+  const readers = new Set<string>();
+
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    for (const reader of row.readers) {
+      readers.add(reader);
+    }
+    // `readers` minus this row's sender is non-empty. Counted rather than
+    // filtered: building a second set per row would allocate one for every
+    // message in the window on every batch.
+    flags[index] = readers.size > (readers.has(row.sender) ? 1 : 0);
+  }
+
+  return flags;
+}

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -108,7 +108,54 @@ export interface AlloTimelineItem {
   readonly isOwn: boolean;
   readonly sendState: AlloSendState;
   readonly content: AlloEventContent;
+  /** Empty when nobody has reacted. Never `undefined`. */
+  readonly reactions: readonly AlloReaction[];
+  /**
+   * Somebody other than the sender has read this row.
+   *
+   * A boolean and not a list of readers, because that is the question the bubble
+   * asks and because the honest list is not available: a Matrix receipt is a
+   * high-water mark, so the only thing known about a reader who has moved on is
+   * that they read *at least* this far. Reporting a list would invite a group
+   * conversation to draw "read by 2 of 5" out of numbers that do not mean that.
+   *
+   * The sender is excluded from their own count. Clients send a receipt for the
+   * message they have just sent, and letting that count would put the read mark
+   * on every outgoing message the instant it left.
+   */
+  readonly isReadByOthers: boolean;
 }
+
+/* ---------------------------------------------------------------------------
+ * Message operations
+ *
+ * Everything below to the end of this comment block is about acting on a message
+ * that already exists — reacting to it, editing it, removing it — and about the
+ * two signals that travel alongside a conversation rather than inside it: read
+ * receipts and typing notices. The calls themselves live on
+ * {@link AlloTimelineHandle}, for the same reason `sendText` does: they are
+ * operations on an open conversation, and in the Rust binding most of them are
+ * literally timeline methods.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * One emoji, and everybody who sent it.
+ *
+ * Senders and not a count, because the only two questions the UI asks are how
+ * many there are and whether the viewer is among them, and a count answers only
+ * the first. Matrix identifies a reaction by an arbitrary string — `key` in the
+ * spec — which is an emoji by convention and not by rule; it is passed through
+ * unchanged rather than validated, because a homeserver will happily carry one
+ * Allo cannot draw and dropping it would understate the count.
+ */
+export interface AlloReaction {
+  /** The reaction itself, usually a single emoji. */
+  readonly key: string;
+  /** Matrix user ids, without duplicates. */
+  readonly senders: readonly string[];
+}
+
+/* ------------------------------------------------------------------------- */
 
 /**
  * Who Allo says it is to the authorization server.
@@ -280,12 +327,20 @@ export interface AlloRoomListHandle {
 }
 
 /**
- * A live view of one conversation, plus the two operations that only make sense
- * with it open.
+ * A live view of one conversation, plus the operations that only make sense with
+ * it open.
  *
  * Sending lives here and not on the client because in the Rust binding sending
  * *is* a timeline operation — `Room` has no send method — and a message's local
- * echo belongs to the timeline that produced it.
+ * echo belongs to the timeline that produced it. The message operations below it
+ * followed for the same reason and one more: every one of them is something the
+ * user does to a message they are looking at, so a caller that can name the event
+ * necessarily has the timeline open.
+ *
+ * All of them take an **event id** rather than an {@link AlloEventKey}. A row
+ * still on its way out has no event id, and nothing here can act on one; see
+ * `MatrixEventNotSentError` in `errors.ts` for why both platforms refuse rather
+ * than one of them trying.
  */
 export interface AlloTimelineHandle {
   /** The current items, oldest first. The array is replaced, never mutated. */
@@ -294,6 +349,71 @@ export interface AlloTimelineHandle {
   paginateBackwards(count: number): Promise<AlloPaginationOutcome>;
   /** Sends plain text. The body is sent verbatim; it is not parsed as markdown. */
   sendText(body: string): Promise<void>;
+
+  /**
+   * Adds the viewer's reaction, or takes it away if it is already there.
+   *
+   * One call and not two, because the protocol operation is not symmetric —
+   * adding sends an `m.annotation`, removing redacts the one that was sent — and
+   * only the client holding the timeline knows which of its own annotations to
+   * redact. A caller that tried to choose would be choosing from a snapshot that
+   * may be one sync behind.
+   */
+  toggleReaction(eventId: string, key: string): Promise<void>;
+
+  /**
+   * Replaces the body of a message the viewer sent.
+   *
+   * The original event stays on the homeserver and this is a new event pointing
+   * at it, which is why the row keeps its identity and its timestamp and only
+   * `isEdited` changes.
+   */
+  edit(eventId: string, body: string): Promise<void>;
+
+  /**
+   * Removes an event's content, which is what Matrix has instead of deleting.
+   *
+   * **The row does not go away.** A redaction strips the content and leaves the
+   * skeleton — sender, timestamp, position — standing, on this device and on
+   * everyone else's, and that is the protocol working rather than failing. It is
+   * why {@link AlloEventContent} has a `redacted` state at all: the UI has to be
+   * able to draw "this was deleted" and it must not draw it as an empty bubble
+   * or, worse, drop the row and renumber the conversation under the reader.
+   *
+   * `reason` is sent to the homeserver and is visible to everyone in the room.
+   */
+  redact(eventId: string, reason: string | undefined): Promise<void>;
+
+  /**
+   * Tells the homeserver the viewer has read up to and including this event.
+   *
+   * A Matrix receipt is a high-water mark, not a per-message flag: it names one
+   * event and covers everything before it. Sending one for an event older than
+   * the last one sent is therefore not an error and not a correction — the
+   * homeserver keeps the newer mark — so a caller may send freely as the reader
+   * scrolls.
+   */
+  sendReadReceipt(eventId: string): Promise<void>;
+
+  /**
+   * Says whether the viewer is typing in this room.
+   *
+   * The homeserver expires the notice on its own after a few seconds, so `true`
+   * has to be repeated while the user keeps typing and `false` is a courtesy
+   * rather than a requirement. Nothing is retried: a typing notice that did not
+   * arrive is worth nothing by the time it could be sent again.
+   */
+  sendTypingNotice(isTyping: boolean): Promise<void>;
+
+  /**
+   * Reports who else is typing in this room, whenever it changes.
+   *
+   * Changes only, and the viewer is never in the list. The state before the
+   * first call is nobody: a room nobody has typed in reports nothing, and there
+   * is nothing to report anyway.
+   */
+  observeTyping(onChange: (userIds: readonly string[]) => void): AlloUnsubscribe;
+
   close(): void;
 }
 

--- a/packages/frontend/lib/matrix/web/translate.ts
+++ b/packages/frontend/lib/matrix/web/translate.ts
@@ -4,6 +4,7 @@ import type {
   AlloEncryptionState,
   AlloEventContent,
   AlloEventKey,
+  AlloReaction,
   AlloRoomMembership,
   AlloRoomSummary,
   AlloSendState,
@@ -33,7 +34,12 @@ import type {
 const ROOM_CREATE_EVENT_TYPE = 'm.room.create';
 const ROOM_MESSAGE_EVENT_TYPE = 'm.room.message';
 const ROOM_ENCRYPTED_EVENT_TYPE = 'm.room.encrypted';
+const ROOM_REDACTION_EVENT_TYPE = 'm.room.redaction';
+const REACTION_EVENT_TYPE = 'm.reaction';
 const TEXT_MESSAGE_TYPE = 'm.text';
+const REPLACE_RELATION_TYPE = 'm.replace';
+const READ_RECEIPT_TYPE = 'm.read';
+const PRIVATE_READ_RECEIPT_TYPE = 'm.read.private';
 
 /**
  * The SDK's `SyncState` and `EventStatus`, written as the values of their
@@ -200,12 +206,42 @@ export interface TimelineEventFields {
   getContent(): IContent;
   getTs(): number;
   isRedacted(): boolean;
+  /** `null` for an event that does not point at another one. */
+  getRelation(): { readonly rel_type?: string } | null;
   /** Only its nullness is read: an event with a replacement has been edited. */
   replacingEvent(): object | null;
   /** `null` for every event the homeserver has already accepted. */
   readonly status: SdkEventStatus | null;
   /** The sender's room membership, once the SDK has resolved it. */
   readonly sender: { readonly name: string } | null;
+}
+
+/**
+ * Whether this event is a row of the conversation at all.
+ *
+ * Three kinds of event are in the timeline and are not rows, because each one
+ * exists to change a row that is already there:
+ *
+ * - **reactions**, which belong on the message they annotate;
+ * - **redactions**, which empty the event they name — that event stays, and
+ *   stays a row, which is what makes "deleted" different from "gone";
+ * - **edits**, which replace the body of the event they point at. The SDK
+ *   already folds the new body into the original, so drawing the replacement as
+ *   well would show the message twice, once with a leading `* `.
+ *
+ * The native SDK never surfaces any of these as timeline items, and this is the
+ * web half agreeing. It is not cosmetic: without it, the first reaction Allo
+ * sends comes back down sync and draws itself as "Allo cannot show this yet
+ * (m.reaction)" underneath the message it was meant to decorate.
+ */
+export function isTimelineRow(event: TimelineEventFields): boolean {
+  const type = event.getType();
+  if (type === REACTION_EVENT_TYPE || type === ROOM_REDACTION_EVENT_TYPE) {
+    return false;
+  }
+  // A redacted event has no content left to carry a relation, so this reads the
+  // relation of live events only — which is the only place one can be.
+  return event.getRelation()?.rel_type !== REPLACE_RELATION_TYPE;
 }
 
 /**
@@ -217,10 +253,15 @@ export interface TimelineEventFields {
  * transaction id the SDK minted for them. An event with neither is not something
  * to draw a guess for — it is a bug worth seeing — so the caller drops it and
  * says so rather than inventing a key, which would collide with the next one.
+ *
+ * `isReadByOthers` is left `false` and settled by the caller. It is the one field
+ * of a row that is not a function of that row: the receipt that says this message
+ * was read normally sits on a later one. See `lib/matrix/readReceipts.ts`.
  */
 export function toTimelineItem(
   event: TimelineEventFields,
   viewerUserId: string,
+  reactions: readonly AlloReaction[],
 ): AlloTimelineItem | undefined {
   const sender = event.getSender();
   const identity = toEventIdentity(event);
@@ -236,7 +277,78 @@ export function toTimelineItem(
     isOwn: sender === viewerUserId,
     sendState: toSendState(event.status),
     content: toEventContent(event),
+    reactions,
+    isReadByOthers: false,
   };
+}
+
+/** What {@link toReactions} needs of the annotation events the SDK aggregated. */
+export interface ReactionEventFields {
+  getSender(): string | undefined;
+  isRedacted(): boolean;
+}
+
+const NO_REACTIONS: readonly AlloReaction[] = [];
+
+/**
+ * The reactions on one message, from the SDK's aggregation of its annotations.
+ *
+ * `null` is what the SDK answers for a message nobody has reacted to, and it is
+ * the overwhelmingly common case: it is reported as no reactions rather than as
+ * an absence, because a message with none and a message whose annotations have
+ * not loaded look the same to a reader and there is nothing to draw for either.
+ *
+ * Two things are dropped. A redacted annotation is a reaction that was taken
+ * back — the container usually removes it, and a race where it has not is not a
+ * reason to draw it. And a sender is counted once per key however many
+ * annotations arrive from them, because the count is of people and the events
+ * come from a homeserver, which is to say from outside.
+ */
+export function toReactions(
+  annotations: readonly (readonly [string, ReadonlySet<ReactionEventFields>])[] | null,
+): readonly AlloReaction[] {
+  if (annotations === null || annotations.length === 0) {
+    return NO_REACTIONS;
+  }
+
+  const reactions: AlloReaction[] = [];
+  for (const [key, events] of annotations) {
+    const senders = new Set<string>();
+    for (const event of events) {
+      const sender = event.getSender();
+      if (sender !== undefined && !event.isRedacted()) {
+        senders.add(sender);
+      }
+    }
+    if (senders.size > 0) {
+      reactions.push({ key, senders: [...senders] });
+    }
+  }
+  return reactions.length === 0 ? NO_REACTIONS : reactions;
+}
+
+/** What {@link toReaders} needs of the SDK's cached receipts for one event. */
+export interface ReceiptFields {
+  readonly type: string;
+  readonly userId: string;
+}
+
+/**
+ * The user ids whose read receipt names this event.
+ *
+ * `m.fully_read` is filtered out and the two read receipts are kept. A fully-read
+ * marker is a private bookmark the user's own client moves around — it says where
+ * they stopped, not what they saw — and counting it would let one participant's
+ * scroll position mark another participant's message as read.
+ */
+export function toReaders(receipts: readonly ReceiptFields[]): readonly string[] {
+  const readers: string[] = [];
+  for (const receipt of receipts) {
+    if (receipt.type === READ_RECEIPT_TYPE || receipt.type === PRIVATE_READ_RECEIPT_TYPE) {
+      readers.push(receipt.userId);
+    }
+  }
+  return readers;
 }
 
 interface EventIdentity {

--- a/packages/frontend/stores/chatUIStore.ts
+++ b/packages/frontend/stores/chatUIStore.ts
@@ -39,12 +39,22 @@ interface ChatUIState {
   // Reply to message ID by conversation
   replyToByConversation: Record<string, string | undefined>;
 
+  /**
+   * The message the composer is currently rewriting, by conversation.
+   *
+   * Kept here beside the input text rather than in the screen, for the same
+   * reason the input text is: a conversation the user switches away from and
+   * comes back to still has the half-finished edit they left in it.
+   */
+  editingByConversation: Record<string, string | undefined>;
+
   // Actions
   setVisibleTimestamp: (conversationId: string, messageId: string | null) => void;
   setInputText: (conversationId: string, text: string) => void;
   clearInputText: (conversationId: string) => void;
   setAttachmentMenuOpen: (conversationId: string, isOpen: boolean) => void;
   setReplyTo: (conversationId: string, messageId: string | undefined) => void;
+  setEditing: (conversationId: string, messageId: string | undefined) => void;
   clearConversationUI: (conversationId: string) => void;
 
   // Selectors
@@ -60,6 +70,7 @@ export const useChatUIStore = create<ChatUIState>()(
     inputTextByConversation: {},
     isAttachmentMenuOpenByConversation: {},
     replyToByConversation: {},
+    editingByConversation: {},
 
     // Actions - Optimized with immer for O(1) updates (critical for typing performance)
     setVisibleTimestamp: (conversationId, messageId) => {
@@ -92,12 +103,19 @@ export const useChatUIStore = create<ChatUIState>()(
       });
     },
 
+    setEditing: (conversationId, messageId) => {
+      set((state) => {
+        state.editingByConversation[conversationId] = messageId;
+      });
+    },
+
     clearConversationUI: (conversationId) => {
       set((state) => {
         delete state.visibleTimestampByConversation[conversationId];
         delete state.inputTextByConversation[conversationId];
         delete state.isAttachmentMenuOpenByConversation[conversationId];
         delete state.replyToByConversation[conversationId];
+        delete state.editingByConversation[conversationId];
       });
     },
 

--- a/packages/frontend/stores/messagesStore.ts
+++ b/packages/frontend/stores/messagesStore.ts
@@ -43,6 +43,18 @@ export interface StickerItem {
   packId?: string;
 }
 
+/**
+ * How far a message the viewer sent got on its way out.
+ *
+ * `failed` is not a slower `pending`. Pending means something is still trying;
+ * failed means nothing is, and the two draw different marks — see
+ * `components/messages/messageStatus.ts`.
+ *
+ * `delivered` is only ever reached by the Express backend, which has a delivery
+ * receipt. Matrix has none.
+ */
+export type MessageReadStatus = 'pending' | 'sent' | 'delivered' | 'read' | 'failed';
+
 export interface Message {
   id: string;
   text: string;
@@ -62,8 +74,10 @@ export interface Message {
   isEncrypted?: boolean;
   ciphertext?: string;
   encryptionVersion?: number;
-  // Read receipt status
-  readStatus?: 'pending' | 'sent' | 'delivered' | 'read';
+  /** Drawn on the sender's own bubble only. See {@link MessageReadStatus}. */
+  readStatus?: MessageReadStatus;
+  /** The body has been replaced since it was sent. */
+  isEdited?: boolean;
   // Server timestamp set when the message has been edited
   editedAt?: Date;
 }


### PR DESCRIPTION
## Qué añade

Las operaciones que la UI de Allo **ya sabía dibujar** y que no existían por el camino de Matrix: reacciones, edición, borrado, recibos de lectura e indicador de escribiendo. La interfaz no se rediseña — se le da lo que le faltaba.

## Dos que no se migran: se implementan

En el camino viejo estaban rotas de punta a punta, así que copiarlas habría sido copiar código muerto:

- **Recibos de lectura**: el backend nunca emitía el evento y el cliente nunca llamaba a los endpoints, así que `readStatus` evaluaba siempre a `'sent'`.
- **Indicador de escribiendo**: se re-emitía como evento del DOM, o sea que **sólo funcionaba en web**.

## Un envío fallido ya no miente

`MessageMetadata` sólo conocía pendiente / enviado / entregado / leído, así que un fallo mostraba el reloj — cierto en móvil, donde la cola del SDK reintenta, y **falso en web**.

## El borrado, tal como es el protocolo

En Matrix borrar es redactar, y una redacción **deja el esqueleto del evento**: quién y cuándo siguen ahí. No es un fallo, es el protocolo — pero la UI tiene que distinguir «borrado» de «no existe».

## Sobre el merge

Incluye la resolución del conflicto con #62 (lista de salas), que entró mientras esto se escribía. Ambos ampliaban los mismos módulos y las dos ampliaciones conviven: él añadió vista previa y hora de sala, esto reacciones y estados de mensaje.

Verificado que la resolución no perdió ninguna garantía, volviendo a mutar las dos propiedades que cada lado protegía:

- fabricar la hora de una sala vacía → falla *"leaves a room with no latest event without a preview, and so without a time"*
- colapsar el estado redactado → falla *"reports a redacted event as redacted, not as empty text"*

## Plan de pruebas

- Typecheck del frontend en verde en condiciones de CI.
- **481 tests en 35 suites** — frente a 436 en la rama y 412 en main, que es lo que se espera si sobreviven ambos conjuntos.
- Cero `as any`, cero `@ts-ignore`. Hay **un** `useEffect` nuevo, y es de los legítimos: enviar un recibo es una escritura a un sistema externo sobre un hecho que sólo existe después del render que lo produjo, e indexado por el mensaje más reciente para que scroll, reacciones y ediciones no lo relancen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)