### PR TITLE
fix(api): circuit breaker was blocking a healthy backend

### DIFF
--- a/packages/frontend/__tests__/circuitBreaker.test.ts
+++ b/packages/frontend/__tests__/circuitBreaker.test.ts
@@ -1,0 +1,149 @@
+import { CircuitBreaker } from '@/lib/api/retryLogic';
+
+/**
+ * The breaker guards against a backend that is genuinely down. Every case here
+ * exists because the opposite behaviour once blocked message sending on a
+ * perfectly healthy server: the device-key lookups that encryption depends on
+ * go through this class, so an over-eager circuit means "you cannot send".
+ */
+
+const THRESHOLD = 5;
+const WINDOW_MS = 60_000;
+const RESET_MS = 30_000;
+
+function makeBreaker(): CircuitBreaker {
+  return new CircuitBreaker(THRESHOLD, WINDOW_MS, RESET_MS, 'test');
+}
+
+/** An error shaped like the axios rejections `getHttpStatus` reads. */
+function httpError(status: number): Error & { response: { status: number } } {
+  return Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+}
+
+async function failWith(breaker: CircuitBreaker, error: Error, times: number): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await expect(breaker.execute(() => Promise.reject(error))).rejects.toThrow();
+  }
+}
+
+describe('CircuitBreaker', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('what counts as a service failure', () => {
+    it.each([
+      ['401 unauthorized', 401],
+      ['403 forbidden', 403],
+      ['404 not found', 404],
+      ['400 bad request', 400],
+      ['409 conflict', 409],
+    ])('stays closed through repeated %s', async (_label, status) => {
+      const breaker = makeBreaker();
+
+      await failWith(breaker, httpError(status), THRESHOLD * 3);
+
+      expect(breaker.getState()).toBe('closed');
+      await expect(breaker.execute(() => Promise.resolve('ok'))).resolves.toBe('ok');
+    });
+
+    it.each([
+      ['500 server error', 500],
+      ['503 unavailable', 503],
+      ['429 rate limited', 429],
+      ['408 timeout', 408],
+    ])('opens after %s repeats past the threshold', async (_label, status) => {
+      const breaker = makeBreaker();
+
+      await failWith(breaker, httpError(status), THRESHOLD);
+
+      expect(breaker.getState()).toBe('open');
+    });
+
+    it('opens on transport failures that carry no status', async () => {
+      const breaker = makeBreaker();
+
+      await failWith(breaker, new Error('Network request failed'), THRESHOLD);
+
+      expect(breaker.getState()).toBe('open');
+    });
+
+    it('names itself and the remaining wait when rejecting an open circuit', async () => {
+      const breaker = makeBreaker();
+      await failWith(breaker, httpError(500), THRESHOLD);
+
+      await expect(breaker.execute(() => Promise.resolve('ok'))).rejects.toThrow(
+        /open for test .* Retrying in \d+s/
+      );
+    });
+  });
+
+  describe('failures are consecutive, not cumulative', () => {
+    it('clears the count after a success while closed', async () => {
+      const breaker = makeBreaker();
+
+      await failWith(breaker, httpError(500), THRESHOLD - 1);
+      await expect(breaker.execute(() => Promise.resolve('ok'))).resolves.toBe('ok');
+      await failWith(breaker, httpError(500), THRESHOLD - 1);
+
+      // Without the reset these 8 failures would have tripped the threshold of 5.
+      expect(breaker.getState()).toBe('closed');
+    });
+
+    it('discards failures older than the window', async () => {
+      jest.useFakeTimers();
+      const breaker = makeBreaker();
+
+      await failWith(breaker, httpError(500), THRESHOLD - 1);
+      jest.advanceTimersByTime(WINDOW_MS + 1);
+      await failWith(breaker, httpError(500), THRESHOLD - 1);
+
+      expect(breaker.getState()).toBe('closed');
+    });
+
+    it('opens when the failures fall inside the window', async () => {
+      jest.useFakeTimers();
+      const breaker = makeBreaker();
+
+      await failWith(breaker, httpError(500), THRESHOLD - 1);
+      jest.advanceTimersByTime(WINDOW_MS - 1);
+      await failWith(breaker, httpError(500), 1);
+
+      expect(breaker.getState()).toBe('open');
+    });
+  });
+
+  describe('recovery', () => {
+    it('rejects immediately while open, without calling through', async () => {
+      const breaker = makeBreaker();
+      await failWith(breaker, httpError(500), THRESHOLD);
+
+      const call = jest.fn(() => Promise.resolve('ok'));
+      await expect(breaker.execute(call)).rejects.toThrow(/Circuit breaker is open/);
+
+      expect(call).not.toHaveBeenCalled();
+    });
+
+    it('probes once the reset window elapses and closes on success', async () => {
+      jest.useFakeTimers();
+      const breaker = makeBreaker();
+      await failWith(breaker, httpError(500), THRESHOLD);
+
+      jest.advanceTimersByTime(RESET_MS + 1);
+
+      await expect(breaker.execute(() => Promise.resolve('ok'))).resolves.toBe('ok');
+      expect(breaker.getState()).toBe('closed');
+    });
+
+    it('reopens if the probe fails again', async () => {
+      jest.useFakeTimers();
+      const breaker = makeBreaker();
+      await failWith(breaker, httpError(500), THRESHOLD);
+
+      jest.advanceTimersByTime(RESET_MS + 1);
+      await failWith(breaker, httpError(500), 1);
+
+      expect(breaker.getState()).toBe('open');
+    });
+  });
+});

--- a/packages/frontend/app/(chat)/index.tsx
+++ b/packages/frontend/app/(chat)/index.tsx
@@ -4,7 +4,6 @@ import {
     View,
     Text,
     TouchableOpacity,
-    TextInput,
     useWindowDimensions,
     RefreshControl,
     type ViewStyle,
@@ -30,7 +29,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { toast } from '@oxyhq/bloom/toast';
 
 // Components
-import { Skeleton } from '@oxyhq/bloom';
+import { Search, Skeleton } from '@oxyhq/bloom';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import Avatar from '@/components/Avatar';
@@ -619,21 +618,6 @@ export default function ConversationsList() {
             paddingBottom: 8,
             backgroundColor: theme.colors.background,
         },
-        searchInputWrapper: {
-            flexDirection: 'row',
-            alignItems: 'center',
-            backgroundColor: theme.colors.backgroundSecondary || '#f0f2f5',
-            borderRadius: 20,
-            paddingHorizontal: 16,
-            paddingVertical: 8,
-            height: 40,
-        },
-        searchInput: {
-            flex: 1,
-            fontSize: 15,
-            color: theme.colors.text,
-            marginLeft: 8,
-        },
         selectionHeaderContent: {
             flexDirection: 'row',
             alignItems: 'center',
@@ -1026,40 +1010,15 @@ export default function ConversationsList() {
 
         return (
             <View style={styles.searchBarContainer}>
-                <View style={styles.searchInputWrapper}>
-                    <Ionicons
-                        name="search"
-                        size={20}
-                        color={theme.colors.textSecondary}
-                    />
-                    <TextInput
-                        style={styles.searchInput}
-                        placeholder="Ask Oxy AI or Search"
-                        placeholderTextColor={theme.colors.textSecondary}
-                        value={searchQuery}
-                        onChangeText={setSearchQuery}
-                        returnKeyType="search"
-                        accessibilityLabel="Search input"
-                        autoCapitalize="none"
-                        autoCorrect={false}
-                    />
-                    {searchQuery.length > 0 && (
-                        <TouchableOpacity
-                            onPress={() => setSearchQuery('')}
-                            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                            accessibilityLabel="Clear search"
-                        >
-                            <Ionicons
-                                name="close-circle"
-                                size={20}
-                                color={theme.colors.textSecondary}
-                            />
-                        </TouchableOpacity>
-                    )}
-                </View>
+                <Search
+                    label="Ask Oxy AI or Search"
+                    value={searchQuery}
+                    onChangeText={setSearchQuery}
+                    onClearText={() => setSearchQuery('')}
+                />
             </View>
         );
-    }, [isSelectionMode, searchQuery, theme.colors.textSecondary, styles.searchBarContainer, styles.searchInputWrapper, styles.searchInput]);
+    }, [isSelectionMode, searchQuery, styles.searchBarContainer]);
 
     /**
      * Render individual conversation item (useCallback for FlatList stability)

--- a/packages/frontend/app/(chat)/u/[id].tsx
+++ b/packages/frontend/app/(chat)/u/[id].tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { useLocalSearchParams, useRouter, type Href } from "expo-router";
+import { Redirect, useLocalSearchParams } from "expo-router";
 
 /**
  * Legacy route handler for /u/:id
@@ -11,14 +10,10 @@ import { useLocalSearchParams, useRouter, type Href } from "expo-router";
  */
 export default function LegacyUserConversationRoute() {
   const { id } = useLocalSearchParams<{ id: string }>();
-  const router = useRouter();
 
-  useEffect(() => {
-    if (id) {
-      // Redirect to unified conversation route
-      router.replace(`/c/${id}` as Href);
-    }
-  }, [id, router]);
+  if (!id) {
+    return null;
+  }
 
-  return null;
+  return <Redirect href={`/c/${id}`} />;
 }

--- a/packages/frontend/lib/api/retryLogic.ts
+++ b/packages/frontend/lib/api/retryLogic.ts
@@ -186,7 +186,9 @@ export class CircuitBreaker {
   constructor(
     private threshold: number = 5,
     private timeout: number = 60000, // 1 minute
-    private resetTimeout: number = 30000 // 30 seconds
+    private resetTimeout: number = 30000, // 30 seconds
+    /** Identifies this breaker in errors and logs, so an open circuit is diagnosable. */
+    private name: string = 'api'
   ) {}
 
   async execute<T>(fn: () => Promise<T>): Promise<T> {
@@ -194,7 +196,11 @@ export class CircuitBreaker {
     if (this.state === 'open') {
       const timeSinceLastFailure = Date.now() - this.lastFailureTime;
       if (timeSinceLastFailure < this.resetTimeout) {
-        throw new Error('Circuit breaker is open. Service unavailable.');
+        const retryInSeconds = Math.ceil((this.resetTimeout - timeSinceLastFailure) / 1000);
+        throw new Error(
+          `Circuit breaker is open for ${this.name} after ${this.failures} failures. ` +
+            `Retrying in ${retryInSeconds}s.`
+        );
       }
       // Try to transition to half-open
       this.state = 'half-open';
@@ -203,29 +209,47 @@ export class CircuitBreaker {
     try {
       const result = await fn();
 
-      // Success - reset circuit
-      if (this.state === 'half-open') {
-        this.state = 'closed';
-        this.failures = 0;
-      }
+      // Any success clears the count, not just one that closes a half-open
+      // circuit. The breaker trips on *consecutive* failures: a request that
+      // succeeds proves the service is up, so earlier isolated failures must
+      // not be held against it. Without this, failures accumulate for the
+      // lifetime of the app and the circuit eventually opens on a healthy
+      // backend.
+      this.state = 'closed';
+      this.failures = 0;
 
       return result;
     } catch (error: unknown) {
-      // Don't count auth errors (401/403) toward circuit breaker —
-      // these are not transient service failures
+      // A 4xx is a definitive answer from a healthy server: the request was
+      // rejected, the service is fine. Counting those toward the breaker lets
+      // an ordinary "not found" — a recipient with no registered device, say —
+      // trip the circuit and take down unrelated calls. Only server faults
+      // (5xx), an explicit back-off (429), a timeout (408), and transport
+      // failures (no status at all) mean the backend is actually in trouble.
       const status = getHttpStatus(error);
-      if (status === 401 || status === 403) {
+      const isClientError =
+        status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 429;
+      if (isClientError) {
         throw error;
       }
 
+      // Failures older than the window are stale evidence: a fault an hour ago
+      // says nothing about the service now, so the run starts over rather than
+      // accumulating across unrelated incidents.
+      const now = Date.now();
+      if (this.failures > 0 && now - this.lastFailureTime > this.timeout) {
+        this.failures = 0;
+      }
+
       this.failures++;
-      this.lastFailureTime = Date.now();
+      this.lastFailureTime = now;
 
       // Open circuit if threshold exceeded
       if (this.failures >= this.threshold) {
         this.state = 'open';
         console.error(
-          `[Circuit Breaker] Circuit opened after ${this.failures} failures`
+          `[Circuit Breaker] Opened for ${this.name} after ${this.failures} failures. ` +
+            `Last error: ${getErrorMessage(error)}`
         );
       }
 

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -22,9 +22,48 @@ const backendClient = linkedBackend.client;
 // from the package root, so an inferred type would reference an internal path.
 const authenticatedClient: ReturnType<typeof oxyClient.getClient> = oxyClient.getClient();
 
-// Circuit breaker to prevent cascading failures
-// Opens after 5 consecutive failures, stays open for 30 seconds
-const apiCircuitBreaker = new CircuitBreaker(5, 60000, 30000);
+// Circuit breakers prevent cascading failures: 5 consecutive failures open the
+// circuit for 30 seconds.
+//
+// They are scoped PER ENDPOINT, never shared across the whole API. A single
+// global breaker means any one failing endpoint disables every other one — a
+// flaky settings poll would block the device-key lookups that encryption
+// depends on, turning an unrelated outage into "no message can be sent at all".
+const CIRCUIT_FAILURE_THRESHOLD = 5;
+const CIRCUIT_FAILURE_WINDOW_MS = 60000;
+const CIRCUIT_RESET_MS = 30000;
+
+const circuitBreakers = new Map<string, CircuitBreaker>();
+
+// Path segments that carry an identifier rather than naming a resource. Without
+// collapsing them, every recipient would get their own breaker and the map
+// would grow without bound.
+const IDENTIFIER_SEGMENT = /^(\d+|[0-9a-fA-F]{16,}|[0-9A-Za-z_-]{20,})$/;
+
+/** Groups requests to the same resource, e.g. `/devices/user/abc` -> `/devices/user/:id`. */
+function circuitKeyFor(endpoint: string): string {
+  const [path] = endpoint.split('?');
+  return path
+    .split('/')
+    .map((segment) => (IDENTIFIER_SEGMENT.test(segment) ? ':id' : segment))
+    .join('/');
+}
+
+function breakerFor(endpoint: string): CircuitBreaker {
+  const key = circuitKeyFor(endpoint);
+  const existing = circuitBreakers.get(key);
+  if (existing) {
+    return existing;
+  }
+  const breaker = new CircuitBreaker(
+    CIRCUIT_FAILURE_THRESHOLD,
+    CIRCUIT_FAILURE_WINDOW_MS,
+    CIRCUIT_RESET_MS,
+    key
+  );
+  circuitBreakers.set(key, breaker);
+  return breaker;
+}
 
 // Request deduplication cache - prevents duplicate simultaneous requests
 // WhatsApp/Telegram pattern: if same request is in flight, return same promise
@@ -63,7 +102,7 @@ export const api = {
   async get<T = unknown>(endpoint: string, params?: Record<string, unknown>): Promise<{ data: T }> {
     const key = createRequestKey('GET', endpoint, params);
     const data = await deduplicateRequest(key, () =>
-      apiCircuitBreaker.execute(() =>
+      breakerFor(endpoint).execute(() =>
         backendClient.get<T>(endpoint, { params })
       )
     );
@@ -72,7 +111,7 @@ export const api = {
 
   async post<T = unknown>(endpoint: string, body?: unknown): Promise<{ data: T }> {
     // Don't deduplicate POST requests as they may have side effects
-    const data = await apiCircuitBreaker.execute(() =>
+    const data = await breakerFor(endpoint).execute(() =>
       backendClient.post<T>(endpoint, body)
     );
     return { data };
@@ -80,7 +119,7 @@ export const api = {
 
   async put<T = unknown>(endpoint: string, body?: unknown): Promise<{ data: T }> {
     // Don't deduplicate PUT requests as they may have side effects
-    const data = await apiCircuitBreaker.execute(() =>
+    const data = await breakerFor(endpoint).execute(() =>
       backendClient.put<T>(endpoint, body)
     );
     return { data };
@@ -88,7 +127,7 @@ export const api = {
 
   async delete<T = unknown>(endpoint: string): Promise<{ data: T }> {
     // Don't deduplicate DELETE requests as they may have side effects
-    const data = await apiCircuitBreaker.execute(() =>
+    const data = await breakerFor(endpoint).execute(() =>
       backendClient.delete<T>(endpoint)
     );
     return { data };
@@ -96,7 +135,7 @@ export const api = {
 
   async patch<T = unknown>(endpoint: string, body?: unknown): Promise<{ data: T }> {
     // Don't deduplicate PATCH requests as they may have side effects
-    const data = await apiCircuitBreaker.execute(() =>
+    const data = await breakerFor(endpoint).execute(() =>
       backendClient.patch<T>(endpoint, body)
     );
     return { data };


### PR DESCRIPTION
## Summary

"Circuit breaker is open" was blocking message sending while the backend was up, CORS correct and auth valid. Three defects in `CircuitBreaker` combined to take the app down against a healthy server:

- **Failures never reset.** A success only cleared the count when it closed a *half-open* circuit — in normal operation successes never reset it, so failures accumulated for the process lifetime.
- **The 60s window was dead code.** Accepted as a constructor argument, never read. Nothing aged out, so five unrelated failures hours apart tripped the circuit.
- **404 counted as an outage.** Everything except 401/403 counted. The send path fetches a recipient's prekeys, which legitimately 404s when they have no registered device. Now only 5xx/408/429/transport count.
- **One breaker for the whole API.** Any failing endpoint disabled every other one, including the device-key lookups encryption depends on. Now scoped per endpoint, keyed by path with identifier segments collapsed so the map stays bounded.

Open-circuit errors now name the endpoint and the remaining wait instead of "Service unavailable".

Also swaps the home screen's hand-rolled search field for Bloom's `Search`, which already ships the icon, pill radius, clear button and accessibility role (−41 lines).

## Test plan

- 17 new tests in `__tests__/circuitBreaker.test.ts`; **each of the three fixes verified by mutation** (reverting any one fails a test).
- Full frontend suite: 498 passed, 36 suites.
- `tsc --noEmit`: no errors in touched files (11 pre-existing expo-router typed-route errors elsewhere, untouched).
- `eslint` on changed files: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)