### PR TITLE
feat(matrix): adjuntos sobre el repositorio de media, cifrados

### DIFF
--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -71,16 +71,23 @@ lib/chat/
   matrixSessionStorage.ts dónde vive: llavero en nativo, localStorage en web
   roomListSource.ts      la lista de salas como external store
   timelineSource.ts      un timeline por sala, ídem, más paginar y enviar
+  mediaCache.ts          adjuntos ya bajados y descifrados, ídem
+  attachments.ts         elegir una foto y describirla; las miniaturas
   matrixViewModel.ts     AlloRoomSummary → Conversation, AlloTimelineItem → Message
 lib/matrix/
   directMessage.ts       cuándo crear una conversación es reutilizar una
   store.native.ts        dos directorios, y cómo borrarlos
   store.web.ts           una base de IndexedDB, y cómo borrarla
   readReceipts.ts        de «quién tiene recibo aquí» a «alguien ha leído esto»
+  native/media.ts        `MessageType` → `AlloMediaContent`, y los records de subida
+  web/attachments.ts     cifrar o negarse, y el contenido del evento
+  web/mediaTransfer.ts   fetch, la máquina de cripto y los object URL
 hooks/
   useMatrixRuntime.ts       useSyncExternalStore sobre el runtime
   useMatrixConversations.ts → Conversation[] | undefined
   useMatrixTimeline.ts      → { messages, loadOlder, send, … } | undefined
+  useMatrixMedia.ts         → { url(ref) } | undefined, para `getMediaUrl`
+  useMatrixEventLabels.ts   las palabras de los eventos que no tienen ninguna
 components/matrix/
   MatrixSignInGate.tsx      pinta a sus hijos salvo que falte sesión
 ```
@@ -169,6 +176,10 @@ encenderlo.
 - **Una invitación se distingue de una conversación** (`membership` en el
   resumen, `Conversation.isInvitation` en la pantalla). Qué hacer con el dato es
   de la UI, y hoy no hace nada distinto: ver §5.
+- **Adjuntos: fotos, vídeos y notas de voz.** Se eligen del carrete o de la
+  cámara, se envían y se reciben. Es la única de estas líneas que no es una
+  migración: en Allo la media nunca funcionó, porque el backend de Express nunca
+  tuvo endpoint de subida. Ver §7.
 
 ## 5. Qué no llega, y por qué
 
@@ -185,22 +196,34 @@ Por orden de cuánto se nota:
    No es un hueco del puerto: `Message.reactions` existe desde antes que él y
    ningún backend de Allo las ha pintado nunca. Hacerlo es UI nueva para los dos
    caminos, no cableado de éste.
-4. **Sin adjuntos.** El puerto no expone la operación todavía.
-5. **Nadie llama a `createRoom`.** El puerto sabe crear una conversación; no hay
+4. **Nadie llama a `createRoom`.** El puerto sabe crear una conversación; no hay
    pantalla que lo pida, así que en la app sigue sin poder empezarse un chat
    nuevo por el camino de Matrix.
-6. **Una sesión revocada desde fuera no se nota hasta el siguiente arranque.** Si
+5. **Una sesión revocada desde fuera no se nota hasta el siguiente arranque.** Si
    el usuario borra este dispositivo desde otro cliente, el sync empieza a fallar
    y la app lo dibuja como un error de sincronización, no como «te han cerrado la
    sesión». El binding lo cuenta (`ClientDelegate.didReceiveAuthError`) y
    `matrix-js-sdk` también (`HttpApiEvent.SessionLoggedOut`); el puerto no expone
    ninguno de los dos todavía. El camino de vuelta existe —cerrar sesión desde
    Ajustes— pero hay que saber que hace falta.
-7. **Una invitación se distingue pero se pinta igual.** El resumen dice cuál lo
+6. **Una invitación se distingue pero se pinta igual.** El resumen dice cuál lo
    es (`membership`) y `Conversation.isInvitation` lo lleva hasta la pantalla,
    que todavía no hace nada distinto con él: la fila se dibuja como cualquier
    otra y abrirla no da timeline. Aceptar o rechazar tampoco existe — el puerto
    no expone ninguna de las dos.
+7. **Un adjunto no se puede abrir a tamaño completo.** La burbuja dibuja la
+   miniatura y `handleMediaPress` sigue vacío, así que del original sólo se baja
+   lo que la miniatura no cubre: nada. El visor es UI nueva para los dos
+   caminos, no cableado de éste.
+8. **Una nota de voz se envía y no se escucha.** Llega como `m.audio` con su
+   duración y otros clientes la reproducen; aquí la fila dice que hay un
+   adjunto. Falta el reproductor, no el transporte.
+9. **Un vídeo grabado en Allo va sin miniatura.** `expo-image-manipulator` lee
+   imágenes, no fotogramas, así que sacar el primero necesita una dependencia
+   nativa más. Un vídeo de otro cliente suele traer la suya y ésa sí se dibuja.
+10. **Documentos, ubicación, contacto y encuesta** siguen sin implementar en
+    `AttachmentMenu`. El puerto ya sabe enviar un `m.file`; lo que falta es el
+    selector y, para los tres últimos, decidir qué se envía.
 
 ## 6. Web
 
@@ -224,3 +247,110 @@ motor de cripto. Una que quede de un cierre de sesión interrumpido sólo ocupa
 sitio —lleva el id del dispositivo en el nombre, así que la sesión siguiente no
 puede abrirla— y se barre en el arranque siguiente si el navegador ofrece
 `indexedDB.databases()`, que Firefox no tuvo hasta la 126.
+
+## 7. Adjuntos
+
+No es una migración. **En Allo la media nunca ha funcionado**: los seis
+manejadores de `AttachmentMenu` eran stubs vacíos, `onRecordEnd` un TODO, y el
+backend de Express nunca tuvo endpoint de subida. Así que no hay compatibilidad
+que mantener, y tampoco hay que construir un servidor de ficheros: el homeserver
+trae el suyo.
+
+### 7.1 Dónde viven los bytes
+
+Un adjunto son dos cosas que llegan por separado: un evento en la sala, que es
+lo que trae el timeline, y unos bytes en el repositorio de media del homeserver,
+que se piden aparte. **En una sala cifrada el cliente que envía cifra los bytes
+antes de subirlos**, así que el servidor guarda un blob opaco y la clave viaja
+dentro del evento cifrado — la misma protección que ya tenía el cuerpo del
+mensaje.
+
+De ahí sale la forma de `AlloMediaRef`: es **opaco**, y sobre todo **no es una
+URL**. Una URL sugiere algo que una vista puede pedir, y en una sala cifrada eso
+es justo lo que no vale: lo que sirve el homeserver en esa dirección es texto
+cifrado, y un `<Image>` apuntado ahí dibuja una imagen rota.
+`AlloChatClient.downloadMedia` es el único camino de un ref a algo que se pueda
+pintar.
+
+### 7.2 El cifrado, y por qué la mitad web tiene un módulo entero para él
+
+Las dos mitades del puerto llegan al mismo sitio por caminos muy distintos, y la
+asimetría es la razón de casi todo el código:
+
+- **Nativo.** `Timeline.sendImage` y sus hermanas leen el estado de cifrado de la
+  sala dentro de Rust, cifran si toca, suben y envían el evento. No hay parámetro
+  que pasar mal ni camino en claro al que caerse.
+- **Web.** `matrix-js-sdk` no tiene equivalente. `uploadContent()` sube lo que le
+  den a una URL pública y `sendMessage()` mete un `m.image` con `url` en claro en
+  una sala cifrada sin decir nada: no avisa, no falla, el cuerpo del evento sigue
+  cifrado y la burbuja es idéntica. La única diferencia es que la foto la puede
+  leer cualquiera que tenga el mxc.
+
+Por eso en web todo pasa por `resolveAttachmentSource`
+(`lib/matrix/web/attachments.ts`), que decide desde el estado de la sala y de
+nada más:
+
+| Estado de la sala | Qué hace |
+|---|---|
+| `encrypted` | cifra, sube el texto cifrado, y envía un `file` |
+| `unencrypted` | sube tal cual y envía un `url` |
+| `unknown` | **se niega** (`MatrixMediaEncryptionUnknownError`) |
+
+El tercero es el que importa. `unknown` es el estado normal de una sala que el
+sync todavía no ha entregado, y las dos formas de adivinar fallan con tamaños
+distintos: adivinar *cifrada* cuesta un envío fallido; adivinar *sin cifrar*
+deja una fotografía en claro en el homeserver y no hay nada en pantalla que se
+vea distinto. Reintentar en un momento es una recuperación que el usuario
+entiende.
+
+`AlloOutgoingAttachment` **no tiene un campo para pedir texto plano**, y eso es
+una decisión: un booleano ahí sería la vía por la que una pantalla, un refactor
+o un argumento por defecto apagan el cifrado.
+
+Lo que lo sostiene son dos pruebas. `web/attachments.test.ts` mira **los bytes
+que llegan al uploader**, no qué función se llamó — una implementación que cifra
+y luego sube el original pasaría un test de «se llamó a `encrypt()`» y filtraría
+la foto igual. Y `web/onePlaceUploads.test.ts` cubre lo que las unitarias no
+pueden: que no aparezca un **segundo** camino de subida, que es lo que hará la
+próxima persona que añada un selector de documentos o un avatar. Sigue el patrón
+de `recovery/noSilentReset.test.ts`.
+
+### 7.3 De un ref a un píxel
+
+`MediaCarousel` no cambió. Pide la URL de forma **síncrona** durante el render,
+con `getMediaUrl(id, kind)`, y conseguir una es una descarga y un descifrado. La
+respuesta sale por tanto de `lib/chat/mediaCache.ts`, un external store con la
+misma forma que `roomListSource` y `timelineSource`.
+
+**Pedir una URL es lo que arranca la descarga.** `url(ref)` se llama en render;
+si no la tiene, programa la petición y contesta `undefined`; la fila dibuja
+nada, la descarga termina, el store notifica y la fila dibuja la foto. Hacerlo
+desde un Effect sería un Effect por adjunto visible cuyo único trabajo es pedir
+algo que el render ya sabe que necesita. El read es idempotente y deduplicado
+—veinte filas pidiendo el mismo ref hacen una descarga— que es lo que lo hace
+seguro desde render.
+
+La caché está **acotada**, y no por rendimiento: cada entrada es una copia
+descifrada de una foto de una conversación cifrada — un object URL que fija los
+bytes en la pestaña, o un fichero en claro en el directorio de caché del móvil.
+Al desalojar una se libera, y al cambiar de cuenta o cerrar sesión se liberan
+todas.
+
+En la burbuja **la miniatura del emisor gana al original**: 250pt no piden una
+foto de 12 Mpx, y en una sala cifrada la del emisor es la única copia pequeña
+que existe, porque un homeserver no puede redimensionar lo que no puede leer.
+Allo genera la suya a 1024px al enviar.
+
+**`utils/mediaVariant.ts` no interviene.** Resuelve variantes de renderizado de
+Oxy Cloud, que es de donde vienen los avatares; un adjunto de mensaje va al
+repositorio del homeserver y ninguno de los dos servidores entiende los
+identificadores del otro. Los dos caminos conviven detrás de `getMediaUrl` y
+sólo se elige uno.
+
+### 7.4 La nota de voz
+
+Se envía como `m.audio` con su duración real y el marcador MSC3245 que la
+distingue de un fichero de audio. **Sin forma de onda**, y a propósito: el
+grabador de Allo no muestrea amplitudes, y una forma de onda inventada es un
+dibujo de un audio que nadie midió. Por eso tampoco se usa `sendVoiceMessage` en
+nativo, que la exige.

--- a/packages/frontend/__mocks__/@unomed/react-native-matrix-sdk.ts
+++ b/packages/frontend/__mocks__/@unomed/react-native-matrix-sdk.ts
@@ -111,6 +111,11 @@ export enum EventOrTransactionId_Tags {
   TransactionId = 'TransactionId',
 }
 
+export enum UploadSource_Tags {
+  File = 'File',
+  Data = 'Data',
+}
+
 export enum EventSendState_Tags {
   NotSentYet = 'NotSentYet',
   SendingFailed = 'SendingFailed',
@@ -171,6 +176,11 @@ export const MessageType = {
 export const EventOrTransactionId = {
   EventId: variant(EventOrTransactionId_Tags.EventId),
   TransactionId: variant(EventOrTransactionId_Tags.TransactionId),
+};
+
+export const UploadSource = {
+  File: variant(UploadSource_Tags.File),
+  Data: variant(UploadSource_Tags.Data),
 };
 
 export const EventSendState = {

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -7,6 +7,7 @@ import { encodeStoredSession } from '@/lib/chat/matrixSession';
 import type { MatrixSessionStorage } from '@/lib/chat/matrixSessionStorage';
 import type {
   AlloChatClient,
+  AlloMediaFile,
   AlloChatClientConfig,
   AlloClientStore,
   AlloEncryptionState,
@@ -256,6 +257,10 @@ class FakeChatClient implements AlloChatClient {
   }
 
   async openTimeline(): Promise<AlloTimelineHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async downloadMedia(): Promise<AlloMediaFile> {
     throw new Error('not used by these tests');
   }
 

--- a/packages/frontend/__tests__/chat/matrixViewModel.test.ts
+++ b/packages/frontend/__tests__/chat/matrixViewModel.test.ts
@@ -12,6 +12,8 @@ const LABELS: UnreadableEventLabels = {
   undecryptable: 'cannot be read on this device',
   redacted: 'was deleted',
   unsupported: (description) => `cannot show this yet (${description})`,
+  attachment: (filename) => `attachment ${filename}`,
+  mediaPreview: (kind) => `a ${kind}`,
 };
 
 function room(overrides: Partial<AlloRoomSummary> = {}): AlloRoomSummary {

--- a/packages/frontend/__tests__/chat/matrixViewModel.test.ts
+++ b/packages/frontend/__tests__/chat/matrixViewModel.test.ts
@@ -1,5 +1,10 @@
 import { toConversation, toMessage, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
-import type { AlloRoomPreview, AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
+import type {
+  AlloMediaContent,
+  AlloRoomPreview,
+  AlloRoomSummary,
+  AlloTimelineItem,
+} from '@/lib/matrix/types';
 import { formatConversationTimestamp } from '@/utils/dateUtils';
 
 /**
@@ -337,5 +342,127 @@ describe('toMessage', () => {
 
   it('leaves reactions unset when nobody has reacted', () => {
     expect(toMessage(event(), '!room:allo.you', LABELS).reactions).toBeUndefined();
+  });
+});
+
+describe('an attachment, as a message', () => {
+  function media(overrides: Partial<AlloMediaContent> = {}): AlloMediaContent {
+    return {
+      kind: 'image',
+      filename: 'holiday.jpg',
+      caption: undefined,
+      source: 'ref:full',
+      thumbnail: 'ref:thumb',
+      width: 3024,
+      height: 4032,
+      durationMs: undefined,
+      size: 2_400_000,
+      ...overrides,
+    };
+  }
+
+  function messageWith(overrides: Partial<AlloMediaContent> = {}) {
+    return toMessage(
+      event({ content: { kind: 'media', media: media(overrides) } }),
+      '!room:allo.you',
+      LABELS,
+    );
+  }
+
+  it('draws the sender\'s thumbnail rather than the original', () => {
+    // A bubble is 250pt wide and the original is a phone camera's full
+    // resolution. In an encrypted room the sender's thumbnail is the only
+    // smaller copy that exists: a homeserver cannot resize what it cannot read.
+    expect(messageWith().media).toEqual([{ id: 'ref:thumb', type: 'image' }]);
+  });
+
+  it('falls back to the original when the sender made no thumbnail', () => {
+    expect(messageWith({ thumbnail: undefined }).media).toEqual([
+      { id: 'ref:full', type: 'image' },
+    ]);
+  });
+
+  it('carries the port media ref as the id, because that is what resolves it', () => {
+    // `MediaCarousel` calls `getMediaUrl(item.id, …)`, and on the Matrix path
+    // that resolver is the media cache, which takes a ref. An id of Allo's own
+    // invention would resolve to nothing.
+    expect(messageWith().media?.[0].id).toBe('ref:thumb');
+  });
+
+  it('says nothing in the bubble for a picture with no caption', () => {
+    // The bubble *is* the picture. A filename printed under it is noise.
+    expect(messageWith().text).toBe('');
+  });
+
+  it("says the sender's words when there are some", () => {
+    expect(messageWith({ caption: 'look at this' }).text).toBe('look at this');
+  });
+
+  it('draws a video as a video', () => {
+    expect(messageWith({ kind: 'video' }).media).toEqual([
+      { id: 'ref:thumb', type: 'video' },
+    ]);
+  });
+
+  it.each(['audio', 'voice', 'file'] as const)(
+    'gives the carousel no %s, which it cannot draw',
+    (kind) => {
+      // `MediaCarousel` renders images and a still frame for videos and nothing
+      // else. Handing it one of these would produce an empty bubble.
+      const message = messageWith({ kind, filename: 'voice.m4a', thumbnail: undefined });
+
+      expect(message.media).toBeUndefined();
+      expect(message.text).toBe('attachment voice.m4a');
+    },
+  );
+
+  it('lets a caption speak for an attachment it cannot draw either', () => {
+    const message = messageWith({ kind: 'file', caption: 'the contract' });
+
+    expect(message.text).toBe('the contract');
+  });
+});
+
+describe('an attachment, as a conversation row', () => {
+  function rowFor(overrides: Partial<AlloMediaContent>) {
+    return toConversation(
+      room({
+        latestMessage: preview({
+          content: {
+            kind: 'media',
+            media: {
+              kind: 'image',
+              filename: 'holiday.jpg',
+              caption: undefined,
+              source: 'ref:full',
+              thumbnail: undefined,
+              width: undefined,
+              height: undefined,
+              durationMs: undefined,
+              size: undefined,
+              ...overrides,
+            },
+          },
+        }),
+      }),
+      LABELS,
+    );
+  }
+
+  it('names the kind rather than going blank', () => {
+    // The opposite of the bubble, and deliberately so: an empty preview reads
+    // as a conversation nobody has written in.
+    expect(rowFor({ kind: 'image' }).lastMessage).toBe('a image');
+    expect(rowFor({ kind: 'voice' }).lastMessage).toBe('a voice');
+  });
+
+  it('prefers the caption, which is what the sender actually wrote', () => {
+    expect(rowFor({ caption: 'look at this' }).lastMessage).toBe('look at this');
+  });
+
+  it('still shows the time, because a picture is a message', () => {
+    expect(rowFor({ kind: 'image' }).timestamp).toBe(
+      new Date(1_700_000_000_000).toISOString(),
+    );
   });
 });

--- a/packages/frontend/__tests__/chat/mediaCache.test.ts
+++ b/packages/frontend/__tests__/chat/mediaCache.test.ts
@@ -1,0 +1,329 @@
+import { IDLE_RUNTIME_STATE, type MatrixRuntimeLike, type MatrixRuntimeState } from '@/lib/chat/matrixRuntime';
+import { MatrixMediaCache } from '@/lib/chat/mediaCache';
+import type {
+  AlloChatClient,
+  AlloMediaFile,
+  AlloOidcLoginRequest,
+  AlloRecoveryState,
+  AlloRoomListHandle,
+  AlloSession,
+  AlloTimelineHandle,
+  AlloUnsubscribe,
+} from '@/lib/matrix/types';
+
+/**
+ * The cache that turns an opaque media ref into something a view can point at.
+ *
+ * Two properties carry it. **A read starts at most one download** — the read
+ * happens during render, on every row, on every frame, and a cache that fired a
+ * request each time would download a conversation's pictures hundreds of times.
+ * And **what it lets go of is released**, because every entry is a decrypted
+ * copy of a photograph from an encrypted conversation: on web an object URL
+ * pinning bytes in the tab, on a phone a plaintext file in the cache directory.
+ * A cache that merely forgot them would leave both behind.
+ */
+
+class FakeMediaFile implements AlloMediaFile {
+  releases = 0;
+
+  constructor(readonly uri: string) {}
+
+  release(): void {
+    this.releases += 1;
+  }
+}
+
+/** A client that can fetch attachments and refuses everything else. */
+class FakeChatClient implements AlloChatClient {
+  readonly requested: string[] = [];
+  readonly files: FakeMediaFile[] = [];
+  /** Refs that should fail, as a homeserver refusing one would. */
+  readonly failing = new Set<string>();
+  #pending: (() => void)[] = [];
+  #hold = false;
+
+  hold(): void {
+    this.#hold = true;
+  }
+
+  release(): void {
+    const pending = this.#pending;
+    this.#pending = [];
+    this.#hold = false;
+    for (const resolve of pending) {
+      resolve();
+    }
+  }
+
+  async downloadMedia(ref: string): Promise<AlloMediaFile> {
+    this.requested.push(ref);
+    if (this.#hold) {
+      await new Promise<void>((resolve) => {
+        this.#pending.push(resolve);
+      });
+    }
+    if (this.failing.has(ref)) {
+      throw new Error('the homeserver refused it');
+    }
+    const file = new FakeMediaFile(`file:///cache/${this.requested.length}`);
+    this.files.push(file);
+    return file;
+  }
+
+  async beginOidcLogin(): Promise<AlloOidcLoginRequest> {
+    throw new Error('not used by these tests');
+  }
+
+  async restoreSession(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  session(): AlloSession {
+    throw new Error('not used by these tests');
+  }
+
+  observeSession(): AlloUnsubscribe {
+    throw new Error('not used by these tests');
+  }
+
+  async logout(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async startSync(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async stopSync(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  observeSyncState(): AlloUnsubscribe {
+    throw new Error('not used by these tests');
+  }
+
+  async observeRooms(): Promise<AlloRoomListHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async createRoom(): Promise<string> {
+    throw new Error('not used by these tests');
+  }
+
+  async roomEncryption(): Promise<never> {
+    throw new Error('not used by these tests');
+  }
+
+  async openTimeline(): Promise<AlloTimelineHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoveryState(): Promise<AlloRecoveryState> {
+    throw new Error('not used by these tests');
+  }
+
+  async enableRecovery(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async recoverWithPassphrase(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+
+  async close(): Promise<void> {
+    throw new Error('not used by these tests');
+  }
+}
+
+class FakeRuntime implements MatrixRuntimeLike {
+  readonly chatClient = new FakeChatClient();
+  readonly #listeners = new Set<() => void>();
+
+  #state: MatrixRuntimeState = { ...IDLE_RUNTIME_STATE, phase: 'ready', userId: '@alice:allo.you' };
+
+  subscribe(listener: () => void): AlloUnsubscribe {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  getState(): MatrixRuntimeState {
+    return this.#state;
+  }
+
+  signInAs(userId: string | undefined): void {
+    this.#state = { ...this.#state, userId };
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  client(): AlloChatClient {
+    return this.chatClient;
+  }
+}
+
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('the media cache', () => {
+  it('answers nothing the first time and the URI once it has it', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    expect(cache.url('ref-1')).toBeUndefined();
+    await settle();
+
+    expect(cache.getSnapshot().get('ref-1')).toBe('file:///cache/1');
+  });
+
+  it('notifies its readers when a picture arrives', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    let notifications = 0;
+    cache.subscribe(() => {
+      notifications += 1;
+    });
+
+    cache.url('ref-1');
+    await settle();
+
+    // Without this the row that asked would keep drawing nothing: the read
+    // happens during render and nothing else would re-render it.
+    expect(notifications).toBeGreaterThan(0);
+  });
+
+  it('downloads once however many rows ask', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+    runtime.chatClient.hold();
+
+    for (let index = 0; index < 20; index += 1) {
+      cache.url('ref-1');
+    }
+    runtime.chatClient.release();
+    await settle();
+
+    expect(runtime.chatClient.requested).toEqual(['ref-1']);
+  });
+
+  it('does not download again once it has the picture', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    cache.url('ref-1');
+    await settle();
+    cache.url('ref-1');
+    cache.url('ref-1');
+    await settle();
+
+    expect(runtime.chatClient.requested).toEqual(['ref-1']);
+  });
+
+  it('does not retry one the homeserver refused', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+    runtime.chatClient.failing.add('ref-1');
+
+    cache.url('ref-1');
+    await settle();
+    // The read that would retry runs on every render. A homeserver that refused
+    // once will refuse sixty times a second just as readily.
+    cache.url('ref-1');
+    cache.url('ref-1');
+    await settle();
+
+    expect(runtime.chatClient.requested).toEqual(['ref-1']);
+    expect(cache.getSnapshot().has('ref-1')).toBe(false);
+  });
+
+  it('releases what it evicts', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    // One more than the cache holds, so the first one has to go.
+    for (let index = 0; index < 61; index += 1) {
+      cache.url(`ref-${index}`);
+      await settle();
+    }
+
+    expect(runtime.chatClient.files[0].releases).toBe(1);
+    expect(cache.getSnapshot().has('ref-0')).toBe(false);
+    // The newest is still there: eviction takes the oldest, not the latest.
+    expect(cache.getSnapshot().has('ref-60')).toBe(true);
+  });
+
+  it('lets an evicted picture be fetched again', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    for (let index = 0; index < 61; index += 1) {
+      cache.url(`ref-${index}`);
+      await settle();
+    }
+    cache.url('ref-0');
+    await settle();
+
+    expect(runtime.chatClient.requested.filter((ref) => ref === 'ref-0')).toHaveLength(2);
+  });
+
+  it('releases everything when the account changes', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    cache.url('ref-1');
+    await settle();
+    runtime.signInAs('@bob:allo.you');
+
+    // Every URI in there decrypts something the previous session was allowed to
+    // read. Keeping them would show one account another's photographs.
+    expect(runtime.chatClient.files[0].releases).toBe(1);
+    expect(cache.getSnapshot().size).toBe(0);
+  });
+
+  it('releases everything when the session ends', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    cache.url('ref-1');
+    await settle();
+    runtime.signInAs(undefined);
+
+    expect(runtime.chatClient.files[0].releases).toBe(1);
+  });
+
+  it('releases a download that landed after the session ended', async () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+    runtime.chatClient.hold();
+
+    cache.url('ref-1');
+    runtime.signInAs(undefined);
+    runtime.chatClient.release();
+    await settle();
+
+    // Nothing is waiting for it and the bytes belong to a client that is gone.
+    // Keeping it would leave a decrypted photograph behind a sign-out.
+    expect(runtime.chatClient.files[0].releases).toBe(1);
+    expect(cache.getSnapshot().size).toBe(0);
+  });
+
+  it('gives readers the same snapshot until something changes', () => {
+    const runtime = new FakeRuntime();
+    const cache = new MatrixMediaCache(runtime);
+    cache.subscribe(() => {});
+
+    // `useSyncExternalStore` compares snapshots by identity and throws on one
+    // that keeps changing, so "nothing fetched" has to be the same object.
+    expect(cache.getSnapshot()).toBe(cache.getSnapshot());
+  });
+});

--- a/packages/frontend/__tests__/chat/roomListSource.test.ts
+++ b/packages/frontend/__tests__/chat/roomListSource.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/chat/matrixRuntime';
 import type {
   AlloChatClient,
+  AlloMediaFile,
   AlloEncryptionState,
   AlloOidcLoginRequest,
   AlloRecoveryState,
@@ -151,6 +152,10 @@ class FakeChatClient implements AlloChatClient {
   }
 
   async openTimeline(): Promise<AlloTimelineHandle> {
+    throw new Error('not used by these tests');
+  }
+
+  async downloadMedia(): Promise<AlloMediaFile> {
     throw new Error('not used by these tests');
   }
 

--- a/packages/frontend/__tests__/chat/timelineSource.test.ts
+++ b/packages/frontend/__tests__/chat/timelineSource.test.ts
@@ -7,7 +7,9 @@ import { TimelineSource, timelineSource } from '@/lib/chat/timelineSource';
 import type {
   AlloChatClient,
   AlloEncryptionState,
+  AlloMediaFile,
   AlloOidcLoginRequest,
+  AlloOutgoingAttachment,
   AlloRecoveryState,
   AlloPaginationOutcome,
   AlloRoomListHandle,
@@ -59,6 +61,7 @@ class FakeTimeline implements AlloTimelineHandle {
   closes = 0;
   paginateCalls: number[] = [];
   sent: string[] = [];
+  attachments: AlloOutgoingAttachment[] = [];
   reacted: { eventId: string; key: string }[] = [];
   edited: { eventId: string; body: string }[] = [];
   redacted: { eventId: string; reason: string | undefined }[] = [];
@@ -111,6 +114,10 @@ class FakeTimeline implements AlloTimelineHandle {
 
   async sendText(body: string): Promise<void> {
     this.sent.push(body);
+  }
+
+  async sendAttachment(attachment: AlloOutgoingAttachment): Promise<void> {
+    this.attachments.push(attachment);
   }
 
   async toggleReaction(eventId: string, key: string): Promise<void> {
@@ -176,6 +183,10 @@ class FakeChatClient implements AlloChatClient {
       });
     }
     return timeline;
+  }
+
+  async downloadMedia(): Promise<AlloMediaFile> {
+    throw new Error('not used by these tests');
   }
 
   async beginOidcLogin(): Promise<AlloOidcLoginRequest> {

--- a/packages/frontend/__tests__/matrix/media.test.ts
+++ b/packages/frontend/__tests__/matrix/media.test.ts
@@ -1,0 +1,225 @@
+import { MessageType } from '@unomed/react-native-matrix-sdk';
+import type { MediaSourceLike } from '@unomed/react-native-matrix-sdk';
+
+import {
+  decodeMediaRef,
+  encodeMediaRef,
+  toFilesystemPath,
+  toMediaContent,
+  toThumbnailInfo,
+  toUploadParameters,
+} from '@/lib/matrix/native/media';
+import type { AlloOutgoingAttachment } from '@/lib/matrix/types';
+
+/**
+ * The native half's attachments.
+ *
+ * Nothing here tests encryption, and that is the point rather than a gap: on
+ * iOS and Android `Timeline.sendImage` reads the room's encryption state inside
+ * Rust and encrypts before it uploads, so there is no argument this file could
+ * pass wrong and no plaintext path to guard. What *can* go wrong here is the
+ * translation — a filename read from the wrong field, a `u64` that becomes
+ * `NaN`, a percent-encoded path handed to Rust — and that is what is pinned
+ * down below. The web half's equivalent, where the encryption decision really
+ * is Allo's, is `web/attachments.test.ts`.
+ */
+
+/** A `MediaSource` is an FFI object; only `toJson()` is ever read. */
+function source(json: string): MediaSourceLike {
+  return {
+    toJson: () => json,
+    url: () => 'mxc://allo.you/1',
+  };
+}
+
+describe('a media ref', () => {
+  it('carries what the download needs and nothing else', () => {
+    const ref = encodeMediaRef(source('{"Plain":"mxc://allo.you/1"}'), 'image/jpeg', 'a.jpg');
+
+    expect(decodeMediaRef(ref)).toEqual({
+      source: '{"Plain":"mxc://allo.you/1"}',
+      mimetype: 'image/jpeg',
+      filename: 'a.jpg',
+    });
+  });
+
+  it('falls back to a MIME type that claims nothing', () => {
+    const ref = encodeMediaRef(source('{}'), undefined, 'a.bin');
+
+    // Not `image/jpeg`. The SDK names the file it writes from this, and a
+    // wrong claim is worse than an honest absence of one.
+    expect(decodeMediaRef(ref).mimetype).toBe('application/octet-stream');
+  });
+
+  it('refuses one it did not write', () => {
+    // A ref outlives the render that made it — it is a React key — so one from
+    // an older build, or from the web half, turns up here eventually.
+    expect(() => decodeMediaRef('mxc://allo.you/1')).toThrow(/not a media reference/);
+    expect(() => decodeMediaRef('{"source":"x"}')).toThrow(/missing the fields/);
+  });
+});
+
+describe('toMediaContent', () => {
+  it('reads a picture, its dimensions and its thumbnail', () => {
+    const media = toMediaContent(
+      new MessageType.Image({
+        content: {
+          filename: 'holiday.jpg',
+          caption: 'look at this',
+          source: source('{"Plain":"mxc://allo.you/1"}'),
+          info: {
+            mimetype: 'image/jpeg',
+            width: 3024n,
+            height: 4032n,
+            size: 2_400_000n,
+            thumbnailSource: source('{"Plain":"mxc://allo.you/2"}'),
+            thumbnailInfo: { mimetype: 'image/jpeg', width: 1024n, height: 1365n },
+          },
+        },
+      }),
+    );
+
+    expect(media).toMatchObject({
+      kind: 'image',
+      filename: 'holiday.jpg',
+      caption: 'look at this',
+      width: 3024,
+      height: 4032,
+      size: 2_400_000,
+    });
+    expect(decodeMediaRef(media?.thumbnail ?? '').source).toBe('{"Plain":"mxc://allo.you/2"}');
+  });
+
+  it('keeps the filename separate from the caption', () => {
+    const media = toMediaContent(
+      new MessageType.Image({
+        content: {
+          // The binding has already resolved the spec's two spellings. Reading
+          // `body` here instead would print the caption as the filename.
+          filename: 'holiday.jpg',
+          caption: 'look at this',
+          source: source('{}'),
+        },
+      }),
+    );
+
+    expect(media?.filename).toBe('holiday.jpg');
+    expect(media?.caption).toBe('look at this');
+  });
+
+  it('reports a video duration in milliseconds', () => {
+    const media = toMediaContent(
+      new MessageType.Video({
+        content: {
+          filename: 'clip.mp4',
+          source: source('{}'),
+          info: { mimetype: 'video/mp4', duration: 12_500, width: 1920n, height: 1080n },
+        },
+      }),
+    );
+
+    expect(media).toMatchObject({ kind: 'video', durationMs: 12_500 });
+  });
+
+  it('tells a voice note from an audio file by the marker alone', () => {
+    const content = {
+      filename: 'voice.m4a',
+      source: source('{}'),
+      info: { mimetype: 'audio/mp4', duration: 4_200 },
+    };
+
+    expect(toMediaContent(new MessageType.Audio({ content }))?.kind).toBe('audio');
+    expect(
+      toMediaContent(new MessageType.Audio({ content: { ...content, voice: {} } }))?.kind,
+    ).toBe('voice');
+  });
+
+  it('treats a zero dimension as nothing measured', () => {
+    const media = toMediaContent(
+      new MessageType.Image({
+        content: {
+          filename: 'a.jpg',
+          source: source('{}'),
+          info: { mimetype: 'image/jpeg', width: 0n, height: 0n },
+        },
+      }),
+    );
+
+    // Zero is a field some client filled in with a default. A bubble laid out
+    // against it is a bubble laid out against a default.
+    expect(media?.width).toBeUndefined();
+    expect(media?.height).toBeUndefined();
+  });
+
+  it('has no thumbnail when the sender made none', () => {
+    const media = toMediaContent(
+      new MessageType.Image({
+        content: { filename: 'a.jpg', source: source('{}'), info: { mimetype: 'image/jpeg' } },
+      }),
+    );
+
+    expect(media?.thumbnail).toBeUndefined();
+  });
+
+  it('is not an attachment for text', () => {
+    expect(
+      toMediaContent(new MessageType.Text({ content: { body: 'hello' } })),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['a notice', new MessageType.Notice({ content: { body: 'the bridge went down' } })],
+    ['an emote', new MessageType.Emote({ content: { body: 'waves' } })],
+  ])('reports nothing for %s, so the row says it cannot draw it', (_name, message) => {
+    // Not a failure and not silence: `toEventContent` turns `undefined` here
+    // into `unsupported`, which the bubble draws as "Allo cannot show this
+    // yet". A gap in a conversation has to be visible.
+    expect(toMediaContent(message)).toBeUndefined();
+  });
+});
+
+describe('an outgoing attachment', () => {
+  const PHOTO: AlloOutgoingAttachment = {
+    kind: 'image',
+    filename: 'holiday.jpg',
+    mimetype: 'image/jpeg',
+    uri: 'file:///var/mobile/Media/holiday%20%232.jpg',
+    width: 3024,
+    height: 4032,
+  };
+
+  it('hands the SDK a path and not a URI', () => {
+    const parameters = toUploadParameters(PHOTO);
+
+    // Rust takes filesystem paths. A `file://` URI passed through fails inside
+    // the SDK with an error about a file that does not exist, naming a path
+    // that visibly does.
+    expect(parameters.source.inner).toEqual({
+      filename: '/var/mobile/Media/holiday #2.jpg',
+    });
+  });
+
+  it('sends the caption the user wrote', () => {
+    expect(toUploadParameters({ ...PHOTO, caption: 'look' }).caption).toBe('look');
+  });
+
+  it('describes the thumbnail in the units the binding wants', () => {
+    expect(
+      toThumbnailInfo({ uri: 'file:///t.jpg', mimetype: 'image/jpeg', width: 1024, height: 1365 }),
+    ).toEqual({ width: 1024n, height: 1365n, mimetype: 'image/jpeg' });
+  });
+
+  it('has no thumbnail info when there is no thumbnail', () => {
+    expect(toThumbnailInfo(undefined)).toBeUndefined();
+  });
+});
+
+describe('toFilesystemPath', () => {
+  it('decodes what a URI encoded', () => {
+    expect(toFilesystemPath('file:///tmp/a%20b%23c.jpg')).toBe('/tmp/a b#c.jpg');
+  });
+
+  it('leaves a path that is already one alone', () => {
+    expect(toFilesystemPath('/tmp/a.jpg')).toBe('/tmp/a.jpg');
+  });
+});

--- a/packages/frontend/__tests__/matrix/web/attachments.test.ts
+++ b/packages/frontend/__tests__/matrix/web/attachments.test.ts
@@ -1,0 +1,458 @@
+import {
+  MatrixMediaEncryptionUnknownError,
+  MatrixMediaUnreadableError,
+} from '@/lib/matrix/errors';
+import {
+  decodeMediaRef,
+  encodeMediaRef,
+  encryptionInfoOf,
+  mxcUriOf,
+  resolveAttachmentSource,
+  toAttachmentContent,
+  toMediaContent,
+  type AttachmentBytes,
+  type AttachmentSource,
+} from '@/lib/matrix/web/attachments';
+import type { AlloOutgoingAttachment } from '@/lib/matrix/types';
+
+/**
+ * The web half's attachments, and above all the one property that has to hold:
+ * **a picture sent to an encrypted room does not reach the homeserver in the
+ * clear.**
+ *
+ * That property is worth this much test code because of how it fails. Nothing
+ * throws, nothing logs, the event body is still encrypted and the bubble looks
+ * exactly the same; the only difference is that the bytes on the server are
+ * readable by anyone with the mxc URI. Allo has had a silent fall-back to
+ * plaintext before and it took a long time to find.
+ *
+ * So the assertions below are about the **bytes handed to the uploader**, not
+ * about which function was called. A test that checked "encrypt() was called"
+ * would pass on an implementation that called it and then uploaded the
+ * plaintext anyway.
+ */
+
+/** A plaintext that is easy to spot if it ever escapes. */
+const PLAINTEXT = new TextEncoder().encode('the photograph nobody else may see');
+
+const PHOTO: AlloOutgoingAttachment = {
+  kind: 'image',
+  filename: 'holiday.jpg',
+  mimetype: 'image/jpeg',
+  uri: 'blob:https://allo.you/1',
+  width: 3024,
+  height: 4032,
+  size: PLAINTEXT.byteLength,
+};
+
+/** What a real upload does, remembered rather than done. */
+class FakeUploader {
+  readonly uploads: AttachmentBytes[] = [];
+
+  readonly upload = async (payload: AttachmentBytes): Promise<string> => {
+    this.uploads.push(payload);
+    return `mxc://allo.you/${this.uploads.length}`;
+  };
+
+  /** Every byte string that reached the media repository. */
+  bytes(): Uint8Array[] {
+    return this.uploads.map((upload) => upload.bytes);
+  }
+}
+
+/**
+ * A stand-in for the crypto machine: XOR, which is reversible so a round trip
+ * can be asserted, and unmistakably not the input.
+ *
+ * Its `info` is a real `EncryptedFile` key block short of the URL, because the
+ * production code validates that shape field by field and a loose fake would
+ * hide it.
+ */
+const CIPHER_BYTE = 0x5a;
+
+function fakeEncrypt(plaintext: Uint8Array): {
+  ciphertext: Uint8Array;
+  info: string;
+} {
+  return {
+    ciphertext: plaintext.map((byte) => byte ^ CIPHER_BYTE),
+    info: JSON.stringify({
+      v: 'v2',
+      iv: 'aWFtYW5pdgAAAAAA',
+      hashes: { sha256: 'c2hhMjU2' },
+      key: {
+        alg: 'A256CTR',
+        ext: true,
+        k: 'dGhpcy1pcy1hLWtleQ',
+        key_ops: ['encrypt', 'decrypt'],
+        kty: 'oct',
+      },
+    }),
+  };
+}
+
+function payloadOf(bytes: Uint8Array = PLAINTEXT): AttachmentBytes {
+  return { bytes, mimetype: 'image/jpeg', filename: 'holiday.jpg' };
+}
+
+function deps(uploader: FakeUploader) {
+  return { upload: uploader.upload, encrypt: fakeEncrypt };
+}
+
+describe('resolveAttachmentSource, in an encrypted room', () => {
+  it('never hands the plaintext to the uploader', async () => {
+    const uploader = new FakeUploader();
+
+    await resolveAttachmentSource(payloadOf(), 'encrypted', '!room:allo.you', deps(uploader));
+
+    expect(uploader.uploads).toHaveLength(1);
+    for (const uploaded of uploader.bytes()) {
+      // The assertion that matters. Not "encrypt was called": an
+      // implementation that encrypts and then uploads the original passes that
+      // one and leaks the photograph.
+      expect([...uploaded]).not.toEqual([...PLAINTEXT]);
+    }
+  });
+
+  it('uploads exactly the ciphertext', async () => {
+    const uploader = new FakeUploader();
+
+    await resolveAttachmentSource(payloadOf(), 'encrypted', '!room:allo.you', deps(uploader));
+
+    expect([...uploader.bytes()[0]]).toEqual([...fakeEncrypt(PLAINTEXT).ciphertext]);
+  });
+
+  it('points the event at an encrypted file and not at a URL', async () => {
+    const uploader = new FakeUploader();
+
+    const source = await resolveAttachmentSource(
+      payloadOf(),
+      'encrypted',
+      '!room:allo.you',
+      deps(uploader),
+    );
+
+    expect(source).not.toHaveProperty('url');
+    expect(source).toHaveProperty('file');
+    expect(mxcUriOf(source)).toBe('mxc://allo.you/1');
+  });
+
+  it('carries the key material the receiver needs to open it', async () => {
+    const uploader = new FakeUploader();
+
+    const source = await resolveAttachmentSource(
+      payloadOf(),
+      'encrypted',
+      '!room:allo.you',
+      deps(uploader),
+    );
+
+    const info: unknown = JSON.parse(encryptionInfoOf(source) ?? '{}');
+    expect(info).toEqual(JSON.parse(fakeEncrypt(PLAINTEXT).info));
+  });
+
+  it('does not tell the homeserver the blob is a JPEG', async () => {
+    const uploader = new FakeUploader();
+
+    await resolveAttachmentSource(payloadOf(), 'encrypted', '!room:allo.you', deps(uploader));
+
+    // A server told it has an image will thumbnail, transcode or sniff
+    // something that is not one.
+    expect(uploader.uploads[0].mimetype).toBe('application/octet-stream');
+  });
+
+  it('refuses key material the crypto machine did not fill in', async () => {
+    const uploader = new FakeUploader();
+    const broken = { upload: uploader.upload, encrypt: () => ({
+      ciphertext: PLAINTEXT.map((byte) => byte ^ CIPHER_BYTE),
+      info: JSON.stringify({ v: 'v2', iv: 'aXY' }),
+    }) };
+
+    await expect(
+      resolveAttachmentSource(payloadOf(), 'encrypted', '!room:allo.you', broken),
+    ).rejects.toThrow(MatrixMediaUnreadableError);
+  });
+});
+
+describe('resolveAttachmentSource, in an unencrypted room', () => {
+  it('uploads the bytes as they are', async () => {
+    const uploader = new FakeUploader();
+
+    const source = await resolveAttachmentSource(
+      payloadOf(),
+      'unencrypted',
+      '!room:allo.you',
+      deps(uploader),
+    );
+
+    expect([...uploader.bytes()[0]]).toEqual([...PLAINTEXT]);
+    expect(source).toEqual({ url: 'mxc://allo.you/1' });
+  });
+});
+
+describe('resolveAttachmentSource, when the room has not synced', () => {
+  it('refuses rather than guessing', async () => {
+    const uploader = new FakeUploader();
+
+    await expect(
+      resolveAttachmentSource(payloadOf(), 'unknown', '!room:allo.you', deps(uploader)),
+    ).rejects.toThrow(MatrixMediaEncryptionUnknownError);
+  });
+
+  it('uploads nothing at all', async () => {
+    const uploader = new FakeUploader();
+
+    await resolveAttachmentSource(
+      payloadOf(),
+      'unknown',
+      '!room:allo.you',
+      deps(uploader),
+    ).catch(() => undefined);
+
+    // The refusal has to come *before* the upload. One that threw afterwards
+    // would leave the photograph on the homeserver and only look safe.
+    expect(uploader.uploads).toEqual([]);
+  });
+
+  it('names the conversation, because the user can retry', async () => {
+    const uploader = new FakeUploader();
+
+    await expect(
+      resolveAttachmentSource(payloadOf(), 'unknown', '!room:allo.you', deps(uploader)),
+    ).rejects.toThrow(/!room:allo\.you/);
+  });
+});
+
+describe('toAttachmentContent', () => {
+  async function contentFor(
+    attachment: AlloOutgoingAttachment,
+    encryption: 'encrypted' | 'unencrypted',
+    withThumbnail: boolean,
+  ) {
+    const uploader = new FakeUploader();
+    const source = await resolveAttachmentSource(
+      payloadOf(),
+      encryption,
+      '!room:allo.you',
+      deps(uploader),
+    );
+    const thumbnail = withThumbnail
+      ? {
+          source: await resolveAttachmentSource(
+            payloadOf(new Uint8Array([1, 2, 3])),
+            encryption,
+            '!room:allo.you',
+            deps(uploader),
+          ),
+          mimetype: 'image/jpeg',
+          width: 1024,
+          height: 1365,
+        }
+      : undefined;
+    return toAttachmentContent(attachment, source, thumbnail, PLAINTEXT.byteLength);
+  }
+
+  it('encrypts the thumbnail too', async () => {
+    const content = await contentFor(PHOTO, 'encrypted', true);
+
+    // A thumbnail of a private photograph gives it away as well as the
+    // photograph. An encrypted picture beside a plaintext thumbnail of itself
+    // is the leak wearing a smaller hat.
+    expect(content.info?.thumbnail_url).toBeUndefined();
+    expect(content.info?.thumbnail_file).toBeDefined();
+  });
+
+  it('uses the plain thumbnail keys in an unencrypted room', async () => {
+    const content = await contentFor(PHOTO, 'unencrypted', true);
+
+    expect(content.info?.thumbnail_url).toBe('mxc://allo.you/2');
+    expect(content.info?.thumbnail_file).toBeUndefined();
+  });
+
+  it('reports the dimensions the sender measured and invents no others', async () => {
+    const content = await contentFor(PHOTO, 'encrypted', false);
+
+    expect(content.info).toMatchObject({ w: 3024, h: 4032, mimetype: 'image/jpeg' });
+    // Nothing measured a duration for a still, so the field is absent rather
+    // than present and meaningless.
+    expect(content.info).not.toHaveProperty('duration');
+  });
+
+  it('shows the filename when there is no caption', async () => {
+    const content = await contentFor(PHOTO, 'encrypted', false);
+
+    expect(content.body).toBe('holiday.jpg');
+    expect(content.filename).toBe('holiday.jpg');
+  });
+
+  it("shows the sender's words when there are some", async () => {
+    const content = await contentFor(
+      { ...PHOTO, caption: '  look at this  ' },
+      'encrypted',
+      false,
+    );
+
+    expect(content.body).toBe('look at this');
+    expect(content.filename).toBe('holiday.jpg');
+  });
+
+  it('marks a recording as a voice message', async () => {
+    const content = await contentFor(
+      { kind: 'voice', filename: 'voice.m4a', mimetype: 'audio/mp4', uri: 'blob:x', durationMs: 4200 },
+      'encrypted',
+      false,
+    );
+
+    expect(content['org.matrix.msc3245.voice']).toEqual({});
+    expect(content.info?.duration).toBe(4200);
+  });
+
+  it('leaves an ordinary audio file unmarked', async () => {
+    const content = await contentFor(
+      { kind: 'audio', filename: 'song.mp3', mimetype: 'audio/mpeg', uri: 'blob:x' },
+      'encrypted',
+      false,
+    );
+
+    expect(content['org.matrix.msc3245.voice']).toBeUndefined();
+  });
+});
+
+describe('toMediaContent', () => {
+  const ENCRYPTED_FILE = {
+    url: 'mxc://allo.you/1',
+    v: 'v2',
+    iv: 'aWFtYW5pdgAAAAAA',
+    hashes: { sha256: 'c2hhMjU2' },
+    key: { alg: 'A256CTR', ext: true, k: 'a2V5', key_ops: ['encrypt', 'decrypt'], kty: 'oct' },
+  };
+
+  it('reads back an encrypted picture Allo itself sent', () => {
+    const media = toMediaContent({
+      msgtype: 'm.image',
+      body: 'holiday.jpg',
+      filename: 'holiday.jpg',
+      file: ENCRYPTED_FILE,
+      info: { mimetype: 'image/jpeg', w: 3024, h: 4032, size: 12 },
+    });
+
+    expect(media).toMatchObject({ kind: 'image', filename: 'holiday.jpg', width: 3024 });
+    expect(media?.caption).toBeUndefined();
+  });
+
+  it('prefers the encrypted file over a URL sitting beside it', () => {
+    const media = toMediaContent({
+      msgtype: 'm.image',
+      body: 'holiday.jpg',
+      url: 'mxc://allo.you/plaintext',
+      file: ENCRYPTED_FILE,
+      info: { mimetype: 'image/jpeg' },
+    });
+
+    expect(mxcUriOf(decodeMediaRef(media?.source ?? '').source)).toBe('mxc://allo.you/1');
+  });
+
+  it('reports nothing for an encrypted picture whose key is malformed', () => {
+    // The fall-back that must not exist: reading `url` here would fetch
+    // ciphertext and draw it as a broken image, and on an event where the two
+    // disagreed it would be the plaintext path reappearing.
+    const media = toMediaContent({
+      msgtype: 'm.image',
+      body: 'holiday.jpg',
+      url: 'mxc://allo.you/plaintext',
+      file: { ...ENCRYPTED_FILE, key: { alg: 'A256CTR' } },
+      info: { mimetype: 'image/jpeg' },
+    });
+
+    expect(media).toBeUndefined();
+  });
+
+  it("takes the sender's caption from body when it differs from the filename", () => {
+    const media = toMediaContent({
+      msgtype: 'm.image',
+      body: 'look at this',
+      filename: 'holiday.jpg',
+      url: 'mxc://allo.you/1',
+      info: { mimetype: 'image/jpeg' },
+    });
+
+    expect(media?.caption).toBe('look at this');
+    expect(media?.filename).toBe('holiday.jpg');
+  });
+
+  it('finds the thumbnail the sender uploaded', () => {
+    const media = toMediaContent({
+      msgtype: 'm.image',
+      body: 'holiday.jpg',
+      file: ENCRYPTED_FILE,
+      info: {
+        mimetype: 'image/jpeg',
+        thumbnail_file: { ...ENCRYPTED_FILE, url: 'mxc://allo.you/2' },
+        thumbnail_info: { mimetype: 'image/jpeg', w: 1024, h: 1365 },
+      },
+    });
+
+    expect(media?.thumbnail).toBeDefined();
+    expect(mxcUriOf(decodeMediaRef(media?.thumbnail ?? '').source)).toBe('mxc://allo.you/2');
+  });
+
+  it('tells a voice note from an audio file', () => {
+    const base = {
+      msgtype: 'm.audio',
+      body: 'voice.m4a',
+      url: 'mxc://allo.you/1',
+      info: { mimetype: 'audio/mp4', duration: 4200 },
+    };
+
+    expect(toMediaContent(base)?.kind).toBe('audio');
+    expect(toMediaContent({ ...base, 'org.matrix.msc3245.voice': {} })?.kind).toBe('voice');
+  });
+
+  it('is not a media event without somewhere to fetch the bytes', () => {
+    expect(toMediaContent({ msgtype: 'm.image', body: 'holiday.jpg' })).toBeUndefined();
+  });
+
+  it('is not a media event at all for text', () => {
+    expect(toMediaContent({ msgtype: 'm.text', body: 'hello' })).toBeUndefined();
+  });
+
+  it('ignores dimensions a sender reported as nonsense', () => {
+    const media = toMediaContent({
+      msgtype: 'm.image',
+      body: 'holiday.jpg',
+      url: 'mxc://allo.you/1',
+      info: { mimetype: 'image/jpeg', w: '3024', h: 0, size: -5 },
+    });
+
+    // Everything in `info` came from another client over the network. A bubble
+    // laid out against `"3024"` is a bubble laid out against a string.
+    expect(media?.width).toBeUndefined();
+    expect(media?.height).toBeUndefined();
+    expect(media?.size).toBeUndefined();
+  });
+});
+
+describe('a media ref', () => {
+  const SOURCE: AttachmentSource = { url: 'mxc://allo.you/1' };
+
+  it('survives a round trip', () => {
+    const decoded = decodeMediaRef(encodeMediaRef(SOURCE, 'image/jpeg'));
+
+    expect(decoded).toEqual({ source: SOURCE, mimetype: 'image/jpeg' });
+  });
+
+  it('says what the bytes are even when the sender did not', () => {
+    expect(decodeMediaRef(encodeMediaRef(SOURCE, undefined)).mimetype).toBe(
+      'application/octet-stream',
+    );
+  });
+
+  it('refuses one written by something else', () => {
+    // A ref outlives the render that made it — it is a React key — so one from
+    // an older build, or from the native half, turns up here eventually.
+    expect(() => decodeMediaRef('mxc://allo.you/1')).toThrow(MatrixMediaUnreadableError);
+    expect(() => decodeMediaRef('{"source":{},"mimetype":"image/jpeg"}')).toThrow(
+      MatrixMediaUnreadableError,
+    );
+  });
+});

--- a/packages/frontend/__tests__/matrix/web/onePlaceUploads.test.ts
+++ b/packages/frontend/__tests__/matrix/web/onePlaceUploads.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * There is one door to the homeserver's media repository, and this is the test
+ * that keeps it the only one.
+ *
+ * `attachments.test.ts` proves that {@link resolveAttachmentSource} encrypts
+ * when the room is encrypted and refuses when it does not know. What it cannot
+ * prove is that *everything* goes through it. The next person to add a document
+ * picker, an avatar upload or a sticker will reach for `uploadContent()` —
+ * because that is what `matrix-js-sdk` documents and what every other client
+ * calls — and their upload would be correct, would work, and would put the file
+ * on the homeserver in the clear.
+ *
+ * That failure is invisible from inside the app: the event is still encrypted,
+ * the bubble is identical, nothing is logged. So this is a test, and it fails on
+ * a second call site rather than on a broken one.
+ *
+ * **If a second upload path is ever genuinely needed**, the change is not to
+ * relax this. It is to route it through `resolveAttachmentSource` too, or to
+ * give it its own decision point with its own tests — and then to add it here by
+ * name so the next reader knows there are two and why.
+ */
+
+const PORT_DIRECTORY = join(__dirname, '..', '..', '..', 'lib', 'matrix');
+
+/**
+ * Ways to put bytes into the media repository, and the one file allowed to use
+ * each.
+ *
+ * The native half is absent from this list on purpose: `Timeline.sendImage` and
+ * its siblings upload *and* encrypt inside Rust, reading the room's state
+ * themselves, so there is no plaintext path there to guard.
+ */
+const UPLOADS: readonly { readonly call: string; readonly onlyIn: string }[] = [
+  { call: 'uploadContent', onlyIn: 'client.web.ts' },
+];
+
+function typeScriptFilesUnder(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return typeScriptFilesUnder(path);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+describe('uploading to the media repository', () => {
+  const files = typeScriptFilesUnder(PORT_DIRECTORY);
+
+  it('has source to check', () => {
+    // Without this the suite passes cheerfully if the directory ever moves.
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it.each(UPLOADS)('calls $call from $onlyIn and nowhere else', ({ call, onlyIn }) => {
+    const callSite = new RegExp(`\\.\\s*${call}\\s*\\(`, 'g');
+
+    const callers = files
+      .filter((file) => callSite.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(PORT_DIRECTORY, file));
+
+    expect(callers).toEqual([onlyIn]);
+  });
+
+  it.each(UPLOADS)('calls $call exactly once, from the port\'s one uploader', ({ call, onlyIn }) => {
+    const source = readFileSync(join(PORT_DIRECTORY, onlyIn), 'utf8');
+
+    // Two call sites means two places deciding whether to encrypt, and only one
+    // of them is covered by `attachments.test.ts`.
+    expect(source.match(new RegExp(`\\.\\s*${call}\\s*\\(`, 'g'))).toHaveLength(1);
+  });
+
+  it('gives no caller a way to ask for an unencrypted upload', () => {
+    // The other half of the guard. Even with one upload path, an
+    // `isEncrypted: boolean` on the outgoing attachment would let a screen, a
+    // default argument or a refactor turn encryption off — and the room's own
+    // state is the only honest source for that answer.
+    const contract = readFileSync(join(PORT_DIRECTORY, 'types.ts'), 'utf8');
+    const outgoing = contract.slice(
+      contract.indexOf('export interface AlloOutgoingAttachment'),
+    );
+    const body = outgoing.slice(0, outgoing.indexOf('\n}'));
+
+    expect(body).not.toMatch(/encrypt/i);
+    expect(body).not.toMatch(/plaintext/i);
+  });
+});

--- a/packages/frontend/__tests__/matrix/web/onePlaceUploads.test.ts
+++ b/packages/frontend/__tests__/matrix/web/onePlaceUploads.test.ts
@@ -78,13 +78,20 @@ describe('uploading to the media repository', () => {
     // `isEncrypted: boolean` on the outgoing attachment would let a screen, a
     // default argument or a refactor turn encryption off — and the room's own
     // state is the only honest source for that answer.
+    //
+    // Property declarations only, not the whole body: prose about encryption
+    // belongs in this interface's doc comments and saying so must not fail a
+    // test about what the interface *offers*.
     const contract = readFileSync(join(PORT_DIRECTORY, 'types.ts'), 'utf8');
     const outgoing = contract.slice(
       contract.indexOf('export interface AlloOutgoingAttachment'),
     );
-    const body = outgoing.slice(0, outgoing.indexOf('\n}'));
+    const properties = outgoing
+      .slice(0, outgoing.indexOf('\n}'))
+      .split('\n')
+      .filter((line) => /^\s*(readonly\s+)?[A-Za-z_$][\w$]*\??\s*:/.test(line));
 
-    expect(body).not.toMatch(/encrypt/i);
-    expect(body).not.toMatch(/plaintext/i);
+    expect(properties.length).toBeGreaterThan(4);
+    expect(properties.filter((line) => /encrypt|plaintext|clear/i.test(line))).toEqual([]);
   });
 });

--- a/packages/frontend/components/conversation/ConversationView.tsx
+++ b/packages/frontend/components/conversation/ConversationView.tsx
@@ -76,6 +76,13 @@ import { useSenderInfo } from '@/hooks/useSenderInfo';
 // Matrix chat backend (behind EXPO_PUBLIC_CHAT_BACKEND)
 import { CHAT_BACKEND } from '@/lib/chat/backend';
 import { useMatrixTimeline } from '@/hooks/useMatrixTimeline';
+import { useMatrixMedia } from '@/hooks/useMatrixMedia';
+import {
+  captureMediaAttachment,
+  pickMediaAttachments,
+  toVoiceAttachment,
+  type PickedAttachments,
+} from '@/lib/chat/attachments';
 
 // Constants
 import { MESSAGING_CONSTANTS } from '@/constants/messaging';
@@ -196,6 +203,11 @@ export default function ConversationView({ conversationId: propConversationId }:
   // there is no fetch: opening it is subscribing to it.
   const matrixTimeline = useMatrixTimeline(conversationId);
   const messages = matrixTimeline?.messages ?? storedMessages;
+
+  // Attachments the port has fetched and decrypted, keyed by the media refs the
+  // messages above carry. `undefined` on the Express path, where a media id is
+  // an Oxy Cloud file id instead — see `getMediaUrl`.
+  const matrixMedia = useMatrixMedia();
 
   // The store-backed indicator is re-emitted as a DOM event and so only ever
   // fires on web; the port's comes from the homeserver and works everywhere.
@@ -724,6 +736,64 @@ export default function ConversationView({ conversationId: propConversationId }:
   }, [inputText, handleSend]);
 
   /**
+   * Sends one attachment, and says so when it does not go.
+   *
+   * Attachments exist on the Matrix path only, and that is a property of the
+   * backend rather than a gap in this screen: Allo's Express API has never had
+   * an upload endpoint, and the homeserver's media repository is what replaces
+   * it. A build talking to the old backend says so instead of opening a picker
+   * that leads nowhere.
+   *
+   * Failures are shown rather than logged. An upload is something the user
+   * started and waited for, and the one that matters most —
+   * `MatrixMediaEncryptionUnknownError`, raised when the conversation's
+   * encryption state has not synced yet — is recovered from by trying again,
+   * which nobody does if nothing said anything.
+   */
+  const sendAttachments = useCallback(async (attachments: PickedAttachments) => {
+    if (attachments.length === 0) {
+      return;
+    }
+    if (!matrixTimeline) {
+      toast.error('Attachments need the Matrix chat backend.');
+      return;
+    }
+    for (const attachment of attachments) {
+      try {
+        await matrixTimeline.sendAttachment(attachment);
+      } catch (error) {
+        console.error('Error sending attachment:', error);
+        toast.error(
+          error instanceof Error ? error.message : 'The attachment could not be sent.'
+        );
+        return;
+      }
+    }
+    setTimeout(() => {
+      flatListRef.current?.scrollToEnd({ animated: true });
+    }, 100);
+  }, [matrixTimeline]);
+
+  /**
+   * Picks from the photo library, or takes a picture, and sends what comes back.
+   *
+   * The picker's own promise is what this awaits — there is no Effect and no
+   * subscription — because opening a picker is something the user did, and the
+   * result belongs to that event and not to a later render.
+   */
+  const handleSelectMedia = useCallback(
+    (pick: () => Promise<PickedAttachments>) => {
+      pick()
+        .then(sendAttachments)
+        .catch((error: unknown) => {
+          console.error('Error choosing an attachment:', error);
+          toast.error('The attachment could not be read.');
+        });
+    },
+    [sendAttachments]
+  );
+
+  /**
    * Handle attach button press
    * Opens WhatsApp-style attachment menu in bottom sheet
    */
@@ -733,18 +803,14 @@ export default function ConversationView({ conversationId: propConversationId }:
     bottomSheet.setBottomSheetContent(
       <AttachmentMenu
         onClose={() => bottomSheet.openBottomSheet(false)}
-        onSelectPhoto={() => {
-          // TODO: Implement photo picker
-        }}
+        onSelectPhoto={() => handleSelectMedia(pickMediaAttachments)}
         onSelectDocument={() => {
           // TODO: Implement document picker
         }}
         onSelectLocation={() => {
           // TODO: Implement location picker
         }}
-        onSelectCamera={() => {
-          // TODO: Implement camera
-        }}
+        onSelectCamera={() => handleSelectMedia(captureMediaAttachment)}
         onSelectContact={() => {
           // TODO: Implement contact picker
         }}
@@ -754,7 +820,7 @@ export default function ConversationView({ conversationId: propConversationId }:
       />
     );
     bottomSheet.openBottomSheet(true);
-  }, [bottomSheet]);
+  }, [bottomSheet, handleSelectMedia]);
 
   /**
    * Handle emoji button press
@@ -781,19 +847,31 @@ export default function ConversationView({ conversationId: propConversationId }:
 
 
   /**
-   * Resolve a media download URL from a media ID via the Oxy SDK. The rendition
-   * variant depends on the item's kind — see `mediaVariantForKind`. Returns an
-   * empty string on failure so the image renderer surfaces a real error state
-   * instead of a masking placeholder.
+   * Resolve a media download URL from a media ID.
+   *
+   * Two different resolutions behind one prop, and they must not be mixed. On
+   * the Matrix path the id is the port's opaque media ref: the bytes live in
+   * the homeserver's media repository, are encrypted in an encrypted room, and
+   * are fetched and decrypted by the port — so the answer comes from a cache and
+   * is `''` until it arrives. On the Express path the id is an Oxy Cloud file
+   * id and the URL is built from it, with a rendition variant that depends on
+   * the item's kind (`mediaVariantForKind`). Neither server can resolve the
+   * other's identifiers.
+   *
+   * Returns an empty string when there is nothing yet, so the image renderer
+   * surfaces its own empty state instead of a masking placeholder.
    */
   const getMediaUrl = useCallback((mediaId: string, kind: MediaItem['type']): string => {
+    if (matrixMedia) {
+      return matrixMedia.url(mediaId);
+    }
     try {
       return oxyServices.getFileDownloadUrl(mediaId, mediaVariantForKind(kind));
     } catch (error) {
       console.error('Error getting media URL:', error);
       return '';
     }
-  }, [oxyServices]);
+  }, [oxyServices, matrixMedia]);
   const selectedMessagePreview = useMemo(() => {
     if (!selectedMessage) {
       return null;
@@ -1346,8 +1424,9 @@ export default function ConversationView({ conversationId: propConversationId }:
                 scale={scale}
                 onRecordStart={() => {
                 }}
+                // The recorder reports seconds; `toVoiceAttachment` converts.
                 onRecordEnd={(uri, duration) => {
-                  // TODO: Send audio message
+                  void sendAttachments([toVoiceAttachment(uri, duration)]);
                 }}
                 onRecordCancel={() => {
                 }}

--- a/packages/frontend/hooks/useMatrixConversations.ts
+++ b/packages/frontend/hooks/useMatrixConversations.ts
@@ -1,9 +1,9 @@
 import { useMemo, useSyncExternalStore } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import type { Conversation } from '@/app/(chat)/index';
+import { useMatrixEventLabels } from '@/hooks/useMatrixEventLabels';
 import { CHAT_BACKEND } from '@/lib/chat/backend';
-import { toConversation, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
+import { toConversation } from '@/lib/chat/matrixViewModel';
 import { roomListSource } from '@/lib/chat/roomListSource';
 import type { AlloRoomSummary, AlloUnsubscribe } from '@/lib/matrix/types';
 
@@ -26,28 +26,17 @@ const noRooms = (): readonly AlloRoomSummary[] => NO_ROOMS;
 const enabled = CHAT_BACKEND === 'matrix';
 
 export function useMatrixConversations(): readonly Conversation[] | undefined {
-  const { t } = useTranslation();
-
   const rooms = useSyncExternalStore(
     enabled ? roomListSource.subscribe : subscribeToNothing,
     enabled ? roomListSource.getSnapshot : noRooms,
     noRooms,
   );
 
-  /**
-   * The same words the timeline uses for the same three facts. A conversation
-   * whose last message cannot be read on this device says so in the list too:
-   * an empty preview there reads as a conversation nobody has written in.
-   */
-  const labels = useMemo<UnreadableEventLabels>(
-    () => ({
-      undecryptable: t('This message cannot be read on this device.'),
-      redacted: t('This message was deleted.'),
-      unsupported: (description) =>
-        t('Allo cannot show this yet ({{kind}}).', { kind: description }),
-    }),
-    [t],
-  );
+  // The same words the timeline uses for the same facts. A conversation whose
+  // last message cannot be read on this device says so in the list too, and one
+  // whose last message is a photograph says "Photo": an empty preview reads as a
+  // conversation nobody has written in.
+  const labels = useMatrixEventLabels();
 
   // Derived during render, as a mapping of the snapshot should be. An Effect that
   // mirrored this into state would render one frame of the previous list every

--- a/packages/frontend/hooks/useMatrixEventLabels.ts
+++ b/packages/frontend/hooks/useMatrixEventLabels.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
+import type { AlloMediaKind } from '@/lib/matrix/types';
+
+/**
+ * The words for the events that have no words of their own.
+ *
+ * One hook for the conversation list and the timeline, because they have to
+ * agree: a message this device cannot decrypt says the same thing in the row as
+ * it does in the bubble, and a reader who saw two different sentences for one
+ * message would reasonably conclude they were two different problems.
+ *
+ * The mapping in `lib/chat/matrixViewModel.ts` takes these as arguments rather
+ * than reaching for `t` itself, which is what keeps it testable without i18n.
+ * This is where the two meet.
+ */
+export function useMatrixEventLabels(): UnreadableEventLabels {
+  const { t } = useTranslation();
+
+  return useMemo<UnreadableEventLabels>(() => {
+    /**
+     * What a conversation row calls an attachment nobody captioned.
+     *
+     * Written as five separate strings rather than one with the kind
+     * interpolated, because a translator needs the whole sentence: languages
+     * that inflect the noun cannot build "Photo" out of a template.
+     */
+    const mediaPreviews: Record<AlloMediaKind, string> = {
+      image: t('Photo'),
+      video: t('Video'),
+      audio: t('Audio'),
+      voice: t('Voice message'),
+      file: t('File'),
+    };
+
+    return {
+      undecryptable: t('This message cannot be read on this device.'),
+      redacted: t('This message was deleted.'),
+      unsupported: (description) =>
+        t('Allo cannot show this yet ({{kind}}).', { kind: description }),
+      // Says outright that there is a file here and Allo is not showing it,
+      // which is the truth: a voice note and a document both arrive playable
+      // and openable in other clients and neither has a player here yet.
+      attachment: (filename) => t('Attachment: {{name}}', { name: filename }),
+      mediaPreview: (kind) => mediaPreviews[kind],
+    };
+  }, [t]);
+}

--- a/packages/frontend/hooks/useMatrixMedia.ts
+++ b/packages/frontend/hooks/useMatrixMedia.ts
@@ -1,0 +1,63 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+import { mediaCache } from '@/lib/chat/mediaCache';
+import type { AlloMediaRef, AlloUnsubscribe } from '@/lib/matrix/types';
+
+/**
+ * Attachments from the Matrix port, in the shape `MediaCarousel` already asks
+ * for.
+ *
+ * The carousel's `getMediaUrl(id, kind)` is what this exists to answer. On the
+ * Matrix path the `id` is not an Oxy Cloud file id but the port's own opaque
+ * media ref (`AlloMediaRef`), so the `kind` is unused here: an Oxy rendition
+ * variant is MIME-specific and has to be chosen — see `utils/mediaVariant.ts` —
+ * while a Matrix attachment is a single blob in the homeserver's media
+ * repository, fetched and decrypted whole. The two paths must not be mixed;
+ * they resolve different identifiers against different servers.
+ *
+ * Answers `undefined` when this build talks to the Express API, so
+ * `ConversationView` falls through to the resolver it has always used.
+ */
+
+const enabled = CHAT_BACKEND === 'matrix';
+
+const NO_UNSUBSCRIBE: AlloUnsubscribe = () => {};
+const subscribeToNothing = (): AlloUnsubscribe => NO_UNSUBSCRIBE;
+const NOTHING: ReadonlyMap<AlloMediaRef, string> = new Map();
+const nothingFetched = (): ReadonlyMap<AlloMediaRef, string> => NOTHING;
+
+export interface MatrixMedia {
+  /**
+   * The local URI for an attachment, or `''` while it is still being fetched.
+   *
+   * `''` and not `undefined` because that is what the carousel's prop is typed
+   * as, and because an empty URI is what already means "no picture here" to
+   * every renderer downstream — `getMediaUrl` on the Express path answers the
+   * same way when it cannot resolve one.
+   *
+   * **Asking is what starts the download.** Safe to call during render and on
+   * every row; see `lib/chat/mediaCache.ts`.
+   */
+  readonly url: (ref: AlloMediaRef) => string;
+}
+
+export function useMatrixMedia(): MatrixMedia | undefined {
+  const fetched = useSyncExternalStore(
+    enabled ? mediaCache.subscribe : subscribeToNothing,
+    enabled ? mediaCache.getSnapshot : nothingFetched,
+    nothingFetched,
+  );
+
+  // Reads *through this render's snapshot* rather than straight off the cache,
+  // which is what ties the resolver to the subscription: a picture that has
+  // just finished downloading replaces the map, which replaces the resolver,
+  // which redraws the rows holding it. A hit never reaches the cache at all.
+  const url = useCallback(
+    (ref: AlloMediaRef): string =>
+      fetched.get(ref) ?? (enabled ? (mediaCache.url(ref) ?? '') : ''),
+    [fetched],
+  );
+
+  return enabled ? { url } : undefined;
+}

--- a/packages/frontend/hooks/useMatrixTimeline.ts
+++ b/packages/frontend/hooks/useMatrixTimeline.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
-import { useTranslation } from 'react-i18next';
 
+import { useMatrixEventLabels } from '@/hooks/useMatrixEventLabels';
 import { CHAT_BACKEND } from '@/lib/chat/backend';
-import { toMessage, type UnreadableEventLabels } from '@/lib/chat/matrixViewModel';
+import { toMessage } from '@/lib/chat/matrixViewModel';
 import { timelineSource, type TimelineSnapshot } from '@/lib/chat/timelineSource';
-import type { AlloUnsubscribe } from '@/lib/matrix/types';
+import type { AlloOutgoingAttachment, AlloUnsubscribe } from '@/lib/matrix/types';
 import type { Message } from '@/stores/messagesStore';
 import { logger } from '@/utils/logger';
 
@@ -52,6 +52,14 @@ export interface MatrixTimeline {
   /** Asks the homeserver for older messages. Safe to call on every scroll. */
   readonly loadOlder: () => void;
   readonly send: (body: string) => Promise<void>;
+  /**
+   * Uploads an attachment and sends it.
+   *
+   * Rejects rather than reporting a failed row when the conversation's
+   * encryption state is not settled yet — see `AlloTimelineHandle.sendAttachment`
+   * for why refusing is the only safe answer, and why the caller has to say so.
+   */
+  readonly sendAttachment: (attachment: AlloOutgoingAttachment) => Promise<void>;
   /** Adds the viewer's reaction to a message, or takes it away. */
   readonly toggleReaction: (messageId: string, emoji: string) => Promise<void>;
   /** Replaces the body of a message the viewer sent. */
@@ -76,8 +84,6 @@ export interface MatrixTimeline {
 export function useMatrixTimeline(
   conversationId: string | undefined,
 ): MatrixTimeline | undefined {
-  const { t } = useTranslation();
-
   const source = useMemo(
     () =>
       enabled && conversationId !== undefined ? timelineSource(conversationId) : undefined,
@@ -90,15 +96,7 @@ export function useMatrixTimeline(
     closedTimeline,
   );
 
-  const labels = useMemo<UnreadableEventLabels>(
-    () => ({
-      undecryptable: t('This message cannot be read on this device.'),
-      redacted: t('This message was deleted.'),
-      unsupported: (description) =>
-        t('Allo cannot show this yet ({{kind}}).', { kind: description }),
-    }),
-    [t],
-  );
+  const labels = useMatrixEventLabels();
 
   const messages = useMemo(
     () =>
@@ -126,6 +124,16 @@ export function useMatrixTimeline(
         return;
       }
       await source.sendText(body);
+    },
+    [source],
+  );
+
+  const sendAttachment = useCallback(
+    async (attachment: AlloOutgoingAttachment): Promise<void> => {
+      if (source === undefined) {
+        return;
+      }
+      await source.sendAttachment(attachment);
     },
     [source],
   );
@@ -203,6 +211,7 @@ export function useMatrixTimeline(
             typingUserIds: snapshot.typingUserIds,
             loadOlder,
             send,
+            sendAttachment,
             toggleReaction,
             edit,
             deleteMessage,
@@ -215,6 +224,7 @@ export function useMatrixTimeline(
       snapshot,
       loadOlder,
       send,
+      sendAttachment,
       toggleReaction,
       edit,
       deleteMessage,

--- a/packages/frontend/lib/chat/attachments.ts
+++ b/packages/frontend/lib/chat/attachments.ts
@@ -1,0 +1,228 @@
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import * as ImagePicker from 'expo-image-picker';
+
+import type { AlloOutgoingAttachment, AlloOutgoingThumbnail } from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
+
+/**
+ * Choosing something to send, and describing it well enough that the person
+ * receiving it does not have to download it to find out what it is.
+ *
+ * Everything here is platform-neutral on purpose: the port takes a URI, and a
+ * URI is what `expo-image-picker` hands over on all three platforms — a
+ * `file://` path on a phone, a `blob:` URL in a browser. Neither this module nor
+ * `ConversationView` has to know which one it is on.
+ *
+ * **This is not `utils/mediaVariant.ts`.** That resolves rendition variants for
+ * Oxy Cloud, which is where avatars come from. An attachment sent through here
+ * goes to the homeserver's own media repository and never touches Oxy.
+ */
+
+/**
+ * How wide a thumbnail is made.
+ *
+ * A bubble draws media 250pt across, so 1024 covers it at 3× with room for the
+ * viewer that does not exist yet, and costs perhaps 80 KB. Smaller would show
+ * visibly soft photographs on a modern phone; larger stops being a thumbnail.
+ */
+const THUMBNAIL_WIDTH = 1024;
+
+/**
+ * How hard the thumbnail is compressed.
+ *
+ * It is never the picture the user sent — the original is uploaded alongside it
+ * — so artefacts here cost a little quality in the timeline and nothing at all
+ * in what was actually delivered.
+ */
+const THUMBNAIL_QUALITY = 0.7;
+
+/** What a picker call answered. `undefined` for a user who backed out. */
+export type PickedAttachments = readonly AlloOutgoingAttachment[];
+
+/**
+ * Opens the photo library and describes what came back.
+ *
+ * An empty array means the user cancelled or denied access, which are the same
+ * thing to the caller: nothing to send, and nothing to apologise for.
+ */
+export async function pickMediaAttachments(): Promise<PickedAttachments> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) {
+    return [];
+  }
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images', 'videos'],
+    allowsMultipleSelection: true,
+    // The original bytes. Re-encoding here would cost quality twice — once for
+    // the copy that is sent and again for the thumbnail made from it — and the
+    // thumbnail is what the timeline actually draws.
+    quality: 1,
+    exif: false,
+  });
+  if (result.canceled) {
+    return [];
+  }
+  return describeAll(result.assets);
+}
+
+/** Opens the camera and describes the photograph or video it produced. */
+export async function captureMediaAttachment(): Promise<PickedAttachments> {
+  const permission = await ImagePicker.requestCameraPermissionsAsync();
+  if (!permission.granted) {
+    return [];
+  }
+  const result = await ImagePicker.launchCameraAsync({
+    mediaTypes: ['images', 'videos'],
+    quality: 1,
+    exif: false,
+  });
+  if (result.canceled) {
+    return [];
+  }
+  return describeAll(result.assets);
+}
+
+async function describeAll(
+  assets: readonly ImagePicker.ImagePickerAsset[],
+): Promise<PickedAttachments> {
+  // Sequential rather than `Promise.all`: each one renders a thumbnail through
+  // a native image pipeline, and a dozen photographs started at once is how a
+  // mid-range phone runs out of memory choosing an album.
+  const described: AlloOutgoingAttachment[] = [];
+  for (const asset of assets) {
+    described.push(await describe(asset));
+  }
+  return described;
+}
+
+async function describe(
+  asset: ImagePicker.ImagePickerAsset,
+): Promise<AlloOutgoingAttachment> {
+  const isVideo = asset.type === 'video';
+  const filename = asset.fileName ?? fallbackFilename(asset.uri, isVideo);
+  return {
+    kind: isVideo ? 'video' : 'image',
+    filename,
+    mimetype: asset.mimeType ?? mimetypeFromName(filename, isVideo),
+    uri: asset.uri,
+    width: asset.width,
+    height: asset.height,
+    size: asset.fileSize,
+    // `duration` is milliseconds on an `ImagePickerAsset`, and `null` for a
+    // still. The port's field is milliseconds too, so nothing is converted.
+    durationMs: asset.duration ?? undefined,
+    thumbnail: isVideo ? undefined : await renderThumbnail(asset),
+  };
+}
+
+/**
+ * A small copy of a picture, or `undefined` when one could not be made.
+ *
+ * **Only for stills.** A video's first frame needs a decoder Allo does not have
+ * — `expo-image-manipulator` reads images — so a video goes without, and the
+ * timeline draws the placeholder the carousel already has for one. A video from
+ * another client usually arrives with a thumbnail its sender made, and that one
+ * is drawn.
+ *
+ * A failure here is not a failure to send. The attachment goes anyway; what is
+ * lost is that receivers download the whole picture to draw the row.
+ */
+async function renderThumbnail(
+  asset: ImagePicker.ImagePickerAsset,
+): Promise<AlloOutgoingThumbnail | undefined> {
+  if (asset.width > 0 && asset.width <= THUMBNAIL_WIDTH) {
+    // Already small enough to be its own thumbnail. Uploading a second copy of
+    // the same picture would double what the sender pays to send it.
+    return undefined;
+  }
+  try {
+    const rendered = await ImageManipulator.manipulate(asset.uri)
+      .resize({ width: THUMBNAIL_WIDTH })
+      .renderAsync();
+    const saved = await rendered.saveAsync({
+      format: SaveFormat.JPEG,
+      compress: THUMBNAIL_QUALITY,
+    });
+    return {
+      uri: saved.uri,
+      mimetype: 'image/jpeg',
+      width: saved.width,
+      height: saved.height,
+    };
+  } catch (error) {
+    logger.warn('[chat] a thumbnail could not be rendered; sending without one', error);
+    return undefined;
+  }
+}
+
+/**
+ * A recording from the composer's microphone, as an attachment.
+ *
+ * `durationSeconds` is what `MicSendButton` reports; the port speaks
+ * milliseconds, which is also what Matrix's `info.duration` is. Getting that
+ * conversion wrong would put "0:00" under every voice message in every client.
+ */
+export function toVoiceAttachment(
+  uri: string,
+  durationSeconds: number,
+): AlloOutgoingAttachment {
+  const filename = fallbackFilename(uri, false, 'voice');
+  return {
+    kind: 'voice',
+    filename,
+    mimetype: mimetypeFromName(filename, false),
+    uri,
+    durationMs: Math.round(durationSeconds * 1000),
+  };
+}
+
+/**
+ * A name for a file the picker did not name.
+ *
+ * Android's document picker and every browser leave `fileName` empty often
+ * enough that this is the normal path, not the exceptional one. The extension is
+ * taken from the URI so the MIME type can be guessed from it afterwards.
+ */
+function fallbackFilename(uri: string, isVideo: boolean, prefix = 'attachment'): string {
+  const withoutQuery = uri.split(/[?#]/)[0];
+  const lastSegment = withoutQuery.slice(withoutQuery.lastIndexOf('/') + 1);
+  const dot = lastSegment.lastIndexOf('.');
+  const extension =
+    dot > 0 ? lastSegment.slice(dot + 1).toLowerCase() : isVideo ? 'mp4' : 'jpg';
+  return `${prefix}-${Date.now().toString(36)}.${extension}`;
+}
+
+/**
+ * MIME types by extension, for the pickers that do not report one.
+ *
+ * Deliberately short. A type that is not in here is sent as
+ * `application/octet-stream`, which every client handles as "a file"; guessing
+ * wrong is worse, because a receiver that trusts `image/jpeg` and finds a
+ * QuickTime movie draws a broken image instead of offering a download.
+ */
+const MIMETYPE_BY_EXTENSION: Readonly<Partial<Record<string, string>>> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  heic: 'image/heic',
+  heif: 'image/heif',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  webm: 'video/webm',
+  m4a: 'audio/mp4',
+  mp3: 'audio/mpeg',
+  aac: 'audio/aac',
+  ogg: 'audio/ogg',
+  wav: 'audio/wav',
+};
+
+function mimetypeFromName(filename: string, isVideo: boolean): string {
+  const dot = filename.lastIndexOf('.');
+  const extension = dot > 0 ? filename.slice(dot + 1).toLowerCase() : '';
+  return (
+    MIMETYPE_BY_EXTENSION[extension] ??
+    (isVideo ? 'video/mp4' : 'application/octet-stream')
+  );
+}

--- a/packages/frontend/lib/chat/matrixViewModel.ts
+++ b/packages/frontend/lib/chat/matrixViewModel.ts
@@ -1,6 +1,11 @@
 import type { Conversation } from '@/app/(chat)/index';
-import type { AlloEventContent, AlloRoomSummary, AlloTimelineItem } from '@/lib/matrix/types';
-import type { Message } from '@/stores/messagesStore';
+import type {
+  AlloEventContent,
+  AlloMediaContent,
+  AlloRoomSummary,
+  AlloTimelineItem,
+} from '@/lib/matrix/types';
+import type { MediaItem, Message } from '@/stores/messagesStore';
 
 /**
  * The port's view model, translated into the one Allo's chat components draw.
@@ -29,6 +34,25 @@ export interface UnreadableEventLabels {
   readonly redacted: string;
   /** Allo does not draw this kind of event yet. Given the kind's name. */
   readonly unsupported: (description: string) => string;
+  /**
+   * An attachment in a **bubble** that has no picture to draw and no caption: a
+   * voice note, an audio file, a document.
+   *
+   * Given the sender's filename, because that is the only thing about it worth
+   * reading. A picture and a video never use this — the bubble *is* the
+   * picture, and a filename printed under it is noise.
+   */
+  readonly attachment: (filename: string) => string;
+  /**
+   * An attachment in a **conversation row** that has no caption.
+   *
+   * Separate from {@link attachment} because the two places want opposite
+   * things. A picture in a bubble should say nothing; the same picture as a
+   * conversation's latest message must say "Photo", or the row goes blank and
+   * reads as a conversation nobody has written in — which is the mistake this
+   * whole mapping is shaped to prevent.
+   */
+  readonly mediaPreview: (kind: AlloMediaContent['kind']) => string;
 }
 
 /**
@@ -64,7 +88,7 @@ export function toConversation(
     // user sees while sync has not yet delivered the room's name or enough
     // members to compute one.
     name: summary.displayName ?? summary.roomId,
-    lastMessage: latest === undefined ? '' : bodyOf(latest.content, labels),
+    lastMessage: latest === undefined ? '' : previewOf(latest.content, labels),
     timestamp: latest === undefined ? '' : new Date(latest.sentAt).toISOString(),
     unreadCount: summary.unreadCount,
     avatar: summary.avatarUrl,
@@ -97,12 +121,54 @@ export function toMessage(
     isSent: item.isOwn,
     conversationId: roomId,
     messageType: 'user',
+    media: item.content.kind === 'media' ? toMediaItems(item.content.media) : undefined,
     isEncrypted: item.content.kind === 'undecryptable',
     isEdited: item.content.kind === 'text' && item.content.isEdited,
     reactions: toReactions(item),
     readStatus: toReadStatus(item),
   };
 }
+
+/**
+ * The picture or the video the carousel draws, or `undefined` for an attachment
+ * that has none.
+ *
+ * A list, because `Message.media` is one and `MessageBlock` flattens the group's
+ * — but always of length one here: a Matrix event carries a single attachment,
+ * and the several-in-one-message case is `m.gallery`, which Allo does not send
+ * and reports as unsupported.
+ *
+ * **The `id` is the port's media ref**, not an identifier of Allo's, and that is
+ * what makes the carousel work unchanged: it calls `getMediaUrl(item.id, …)`,
+ * and the ref is exactly what `AlloChatClient.downloadMedia` takes. See
+ * `lib/chat/mediaCache.ts` for what turns one into a URL.
+ *
+ * **The thumbnail is preferred over the original whenever the sender made one.**
+ * A bubble is 250pt wide and the original is a phone camera's full-resolution
+ * photograph; on an encrypted room the sender's thumbnail is the only smaller
+ * copy that exists, because a homeserver cannot resize what it cannot read.
+ */
+function toMediaItems(media: AlloMediaContent): MediaItem[] | undefined {
+  const type = CAROUSEL_TYPE_BY_KIND[media.kind];
+  if (type === undefined) {
+    return undefined;
+  }
+  return [{ id: media.thumbnail ?? media.source, type }];
+}
+
+/**
+ * Which attachments the carousel can draw, and as what.
+ *
+ * Audio, voice notes and documents are absent because `MediaCarousel` renders
+ * nothing for them — it draws images and a still frame for videos — and giving
+ * it one would produce an empty bubble. They are drawn as a line of text
+ * instead; see {@link UnreadableEventLabels.attachment}.
+ */
+const CAROUSEL_TYPE_BY_KIND: Readonly<Partial<Record<AlloMediaContent['kind'], MediaItem['type']>>> =
+  {
+    image: 'image',
+    video: 'video',
+  };
 
 /**
  * Reactions, in the shape the bubble's vocabulary has: emoji to the user ids who
@@ -125,17 +191,26 @@ function toReactions(item: AlloTimelineItem): Message['reactions'] {
 }
 
 /**
- * What an event says, in words, whether it is a bubble or a row's preview.
+ * What an event says in a **bubble**.
  *
- * One function for both because the three states that carry no text mean exactly
- * the same thing in each place. A conversation whose last message this device
- * cannot decrypt has to say so in the list as well as in the timeline: an empty
- * preview there reads as a conversation nobody has written in.
+ * The three states that carry no text mean the same thing here as in a
+ * conversation row, and {@link previewOf} delegates to this for all of them.
+ * Only an attachment differs, and it differs completely: see
+ * {@link UnreadableEventLabels.mediaPreview}.
  */
 function bodyOf(content: AlloEventContent, labels: UnreadableEventLabels): string {
   switch (content.kind) {
     case 'text':
       return content.body;
+    case 'media':
+      return (
+        captionOf(content.media) ??
+        // A picture says nothing: the bubble is the picture. Anything the
+        // carousel cannot draw has to say something, or it is an empty bubble.
+        (CAROUSEL_TYPE_BY_KIND[content.media.kind] === undefined
+          ? labels.attachment(content.media.filename)
+          : '')
+      );
     case 'undecryptable':
       return labels.undecryptable;
     case 'redacted':
@@ -143,6 +218,25 @@ function bodyOf(content: AlloEventContent, labels: UnreadableEventLabels): strin
     case 'unsupported':
       return labels.unsupported(content.description);
   }
+}
+
+/**
+ * What an event says in a **conversation row**.
+ *
+ * A conversation whose last message this device cannot decrypt has to say so in
+ * the list as well as in the timeline, and so does one whose last message is a
+ * photograph: an empty preview reads as a conversation nobody has written in.
+ */
+function previewOf(content: AlloEventContent, labels: UnreadableEventLabels): string {
+  if (content.kind === 'media') {
+    return captionOf(content.media) ?? labels.mediaPreview(content.media.kind);
+  }
+  return bodyOf(content, labels);
+}
+
+/** The sender's own words about an attachment, if they wrote any. */
+function captionOf(media: AlloMediaContent): string | undefined {
+  return media.caption !== undefined && media.caption !== '' ? media.caption : undefined;
 }
 
 /**

--- a/packages/frontend/lib/chat/mediaCache.ts
+++ b/packages/frontend/lib/chat/mediaCache.ts
@@ -1,0 +1,186 @@
+import type { AlloMediaFile, AlloMediaRef, AlloUnsubscribe } from '@/lib/matrix/types';
+import { logger } from '@/utils/logger';
+
+import { matrixRuntime, type MatrixRuntimeLike } from './matrixRuntime';
+
+/**
+ * Attachments that have been fetched, as something React can read without an
+ * Effect.
+ *
+ * The problem this solves is a mismatch that cannot be fixed on the other side.
+ * `MediaCarousel` asks for a URL **synchronously**, during render, from
+ * `getMediaUrl(id)` — and getting one is a download and, in an encrypted room, a
+ * decryption. So the answer has to come from a cache, and the cache has to tell
+ * React when it has changed. That is `useSyncExternalStore`, which is the same
+ * shape `roomListSource.ts` and `timelineSource.ts` already have.
+ *
+ * **Asking for a URL is what starts the download.** {@link MatrixMediaCache.url}
+ * is called during render and, on a miss, schedules a fetch and answers
+ * `undefined`; the row draws nothing, the fetch finishes, the store notifies,
+ * and the row draws the picture. Kicking it off from a component Effect instead
+ * would mean an Effect per visible attachment whose only job is to ask for
+ * something the render already knows it needs. The read is idempotent and
+ * deduplicated — a second call for a ref already in flight adds nothing — which
+ * is what makes it safe to do from render.
+ *
+ * Bounded, and the bound is not an optimisation: every entry is a decrypted copy
+ * of a picture from an encrypted conversation, sitting in the browser's memory
+ * or in the phone's cache directory. Evicting one releases it.
+ */
+
+/** How many fetched attachments are kept before the oldest is released. */
+const CAPACITY = 60;
+
+/** Nothing fetched. One object, because `useSyncExternalStore` compares by identity. */
+const NOTHING: ReadonlyMap<AlloMediaRef, string> = new Map();
+
+export class MatrixMediaCache {
+  readonly #runtime: MatrixRuntimeLike;
+  readonly #listeners = new Set<() => void>();
+  /** Insertion-ordered, which is what makes the oldest entry the first one. */
+  readonly #files = new Map<AlloMediaRef, AlloMediaFile>();
+  readonly #inFlight = new Set<AlloMediaRef>();
+  /** Refs that failed. Kept so a broken attachment is not retried on every frame. */
+  readonly #failed = new Set<AlloMediaRef>();
+
+  #snapshot: ReadonlyMap<AlloMediaRef, string> = NOTHING;
+  #watchingRuntime: AlloUnsubscribe | undefined;
+  #userId: string | undefined;
+
+  constructor(runtime: MatrixRuntimeLike) {
+    this.#runtime = runtime;
+  }
+
+  readonly subscribe = (listener: () => void): AlloUnsubscribe => {
+    this.#listeners.add(listener);
+    this.#watchingRuntime ??= this.#runtime.subscribe(this.#onRuntimeChanged);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  };
+
+  readonly getSnapshot = (): ReadonlyMap<AlloMediaRef, string> => this.#snapshot;
+
+  /**
+   * The local URI for an attachment, or `undefined` while there is not one yet.
+   *
+   * Safe to call on every render of every row. See the note at the top of this
+   * file for why a read starts a download.
+   */
+  readonly url = (ref: AlloMediaRef): string | undefined => {
+    const ready = this.#snapshot.get(ref);
+    if (ready !== undefined) {
+      return ready;
+    }
+    if (!this.#inFlight.has(ref) && !this.#failed.has(ref)) {
+      this.#inFlight.add(ref);
+      void this.#fetch(ref);
+    }
+    return undefined;
+  };
+
+  /**
+   * Releases everything fetched so far.
+   *
+   * Exposed for the runtime's sake — a session ending has to take the decrypted
+   * copies with it — and used by tests.
+   */
+  readonly clear = (): void => {
+    for (const file of this.#files.values()) {
+      release(file);
+    }
+    this.#files.clear();
+    this.#inFlight.clear();
+    this.#failed.clear();
+    if (this.#snapshot !== NOTHING) {
+      this.#snapshot = NOTHING;
+      this.#emit();
+    }
+  };
+
+  async #fetch(ref: AlloMediaRef): Promise<void> {
+    try {
+      const file = await this.#runtime
+        .client('Downloading an attachment')
+        .downloadMedia(ref);
+      if (!this.#inFlight.delete(ref)) {
+        // The session ended while this was in flight, so nothing is waiting for
+        // it and the bytes belong to a client that is gone.
+        release(file);
+        return;
+      }
+      this.#files.set(ref, file);
+      this.#evictOldest();
+      this.#publish();
+    } catch (error) {
+      this.#inFlight.delete(ref);
+      // Remembered as failed rather than retried. The read that would retry it
+      // happens on every render, and a homeserver that refused once will refuse
+      // sixty times a second just as readily.
+      this.#failed.add(ref);
+      logger.error('[chat] an attachment could not be downloaded', error);
+    }
+  }
+
+  #evictOldest(): void {
+    while (this.#files.size > CAPACITY) {
+      const oldest = this.#files.keys().next();
+      if (oldest.done === true) {
+        return;
+      }
+      const file = this.#files.get(oldest.value);
+      this.#files.delete(oldest.value);
+      if (file !== undefined) {
+        release(file);
+      }
+      // Allowed to be fetched again: it is gone from the snapshot, so the next
+      // render that wants it will ask, and asking is what starts a download.
+      this.#failed.delete(oldest.value);
+    }
+  }
+
+  readonly #onRuntimeChanged = (): void => {
+    const { userId } = this.#runtime.getState();
+    if (userId === this.#userId) {
+      return;
+    }
+    // A different account — or none — is looking at this app now. Every URI in
+    // here decrypts something the previous session was allowed to read.
+    this.#userId = userId;
+    this.clear();
+  };
+
+  #publish(): void {
+    const next = new Map<AlloMediaRef, string>();
+    for (const [ref, file] of this.#files) {
+      next.set(ref, file.uri);
+    }
+    this.#snapshot = next;
+    this.#emit();
+  }
+
+  #emit(): void {
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+}
+
+/**
+ * Lets go of a fetched attachment.
+ *
+ * Failures are logged and swallowed, and that is the right trade for once: a
+ * temporary file that could not be deleted is a file the operating system will
+ * reclaim, and throwing here would abort an eviction loop halfway and leak the
+ * rest.
+ */
+function release(file: AlloMediaFile): void {
+  try {
+    file.release();
+  } catch (error) {
+    logger.warn('[chat] a downloaded attachment could not be released', error);
+  }
+}
+
+/** The app's one attachment cache. */
+export const mediaCache = new MatrixMediaCache(matrixRuntime);

--- a/packages/frontend/lib/chat/mediaCache.ts
+++ b/packages/frontend/lib/chat/mediaCache.ts
@@ -53,7 +53,15 @@ export class MatrixMediaCache {
 
   readonly subscribe = (listener: () => void): AlloUnsubscribe => {
     this.#listeners.add(listener);
-    this.#watchingRuntime ??= this.#runtime.subscribe(this.#onRuntimeChanged);
+    if (this.#watchingRuntime === undefined) {
+      this.#watchingRuntime = this.#runtime.subscribe(this.#onRuntimeChanged);
+      // Read once on the way in as well as on every change. The runtime only
+      // notifies on change, so without this the cache would never learn *which*
+      // account it is holding pictures for — and a sign-out, which reports a
+      // user id of `undefined`, would look identical to the state it started in
+      // and clear nothing.
+      this.#onRuntimeChanged();
+    }
     return () => {
       this.#listeners.delete(listener);
     };

--- a/packages/frontend/lib/chat/timelineSource.ts
+++ b/packages/frontend/lib/chat/timelineSource.ts
@@ -1,5 +1,6 @@
 import { MatrixEventNotSentError } from '@/lib/matrix/errors';
 import type {
+  AlloOutgoingAttachment,
   AlloPaginationOutcome,
   AlloTimelineHandle,
   AlloTimelineItem,
@@ -176,6 +177,19 @@ export class TimelineSource {
   readonly sendText = async (body: string): Promise<void> => {
     const handle = await this.#require('Sending a message');
     await handle.sendText(body);
+  };
+
+  /**
+   * Uploads an attachment and sends it.
+   *
+   * Nothing optimistic happens here either, and it matters more than it does
+   * for text: an upload takes seconds, so the local echo the port puts in the
+   * timeline is the only thing on screen while it runs, and a second row added
+   * here would sit beside it for the whole upload.
+   */
+  readonly sendAttachment = async (attachment: AlloOutgoingAttachment): Promise<void> => {
+    const handle = await this.#require('Sending an attachment');
+    await handle.sendAttachment(attachment);
   };
 
   /** Adds the viewer's reaction to a row, or takes it away. */

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -1,8 +1,10 @@
+import { Directory, File, Paths } from 'expo-file-system';
 import {
   ClientBuilder,
   EditedContent,
   EventOrTransactionId,
   LogLevel,
+  MediaSource,
   Membership,
   MessageType,
   OidcPrompt,
@@ -24,6 +26,7 @@ import type {
   RoomListEntriesListener,
   RoomListEntriesUpdate,
   RoomListEntriesWithDynamicAdaptersResultLike,
+  SendAttachmentJoinHandleLike,
   Session,
   SyncServiceLike,
   TaskHandleLike,
@@ -46,10 +49,13 @@ import type {
   AlloClientStore,
   AlloCreateRoomRequest,
   AlloEncryptionState,
+  AlloMediaFile,
+  AlloMediaRef,
   AlloOidcClientMetadata,
   AlloOidcLoginOptions,
   AlloOidcLoginRequest,
   AlloOidcPrompt,
+  AlloOutgoingAttachment,
   AlloPaginationOutcome,
   AlloRecoveryState,
   AlloRoomListHandle,
@@ -63,6 +69,12 @@ import type {
 import { logger } from '@/utils/logger';
 
 import { applyListUpdate } from './native/listDiff';
+import {
+  decodeMediaRef,
+  toThumbnailInfo,
+  toThumbnailSource,
+  toUploadParameters,
+} from './native/media';
 import { NativeOidcLoginRequest } from './native/oidcLogin';
 import { describeEnableRecoveryProgress, toRecoveryState } from './native/recovery';
 import { RoomSummaryCache } from './native/roomSummaries';
@@ -102,6 +114,19 @@ const REUSABLE_MEMBERSHIPS: ReadonlySet<Membership> = new Set([
   Membership.Joined,
   Membership.Invited,
 ]);
+
+/**
+ * Where downloaded attachments are put, inside the app's cache directory.
+ *
+ * A cache and not a document directory, because everything in it is a *copy* of
+ * something the homeserver still holds and can be fetched again — and because
+ * the decrypted copy of a picture from an encrypted conversation is the one
+ * piece of Allo's data the system should be free to reclaim.
+ */
+const MEDIA_DIRECTORY = 'matrix-media';
+
+/** Makes each downloaded file's name unique within a run. See {@link cacheFileName}. */
+let mediaSequence = 0;
 
 /**
  * Rust's logging and callback machinery is process-global and has to be set up
@@ -426,6 +451,68 @@ class NativeAlloChatClient implements AlloChatClient {
     return handle;
   }
 
+  /**
+   * Fetches an attachment and puts it somewhere a view can read it.
+   *
+   * Three things happen here and each one is deliberate.
+   *
+   * `getMediaFile` streams and **decrypts**: the SDK downloads the blob, and
+   * when the ref names media from an encrypted room it decrypts it with the key
+   * that travelled inside the event. Nothing in JavaScript ever holds the
+   * bytes, which is what keeps a video off the bridge.
+   *
+   * The file is then `persist`ed into a directory Allo owns, and the SDK's own
+   * handle is dropped. That is not tidiness: the binding's handle deletes its
+   * file when it is garbage collected, and nothing here can say when that is —
+   * a picture would vanish from the screen at a moment decided by the
+   * collector. Owning the file makes {@link AlloMediaFile.release} the only
+   * thing that removes it.
+   *
+   * The name it lands under is built from a counter and the extension, never
+   * from the sender's filename. A filename arrives from another device, over
+   * the network, and a `../` in one is how a remote sender would write outside
+   * this directory.
+   */
+  async downloadMedia(ref: AlloMediaRef): Promise<AlloMediaFile> {
+    const { source, mimetype, filename } = decodeMediaRef(ref);
+    const handle = await this.#client.getMediaFile(
+      MediaSource.fromJson(source),
+      filename,
+      mimetype,
+      // Cached, so scrolling past the same picture twice downloads it once.
+      true,
+      undefined,
+    );
+
+    const directory = new Directory(Paths.cache, MEDIA_DIRECTORY);
+    directory.create({ intermediates: true, idempotent: true });
+    mediaSequence += 1;
+    const file = new File(directory, cacheFileName(mediaSequence, filename));
+
+    if (!handle.persist(toStorePath(file.uri))) {
+      throw new Error(
+        `The attachment ${filename} was downloaded but could not be written to ` +
+          "the app's cache directory.",
+      );
+    }
+
+    return {
+      uri: file.uri,
+      release: () => {
+        // Plaintext on a phone's disk. A picture from an encrypted conversation
+        // that outlives the screen showing it is exactly what the encryption was
+        // for, so this is not housekeeping.
+        try {
+          if (file.exists) {
+            file.delete();
+          }
+        } catch (error) {
+          logger.warn(`${LOG_TAG} a downloaded attachment could not be removed`, error);
+        }
+      },
+    };
+  }
+
   async close(): Promise<void> {
     for (const timeline of [...this.#timelines]) {
       timeline.close();
@@ -652,6 +739,68 @@ class NativeTimelineHandle implements AlloTimelineHandle {
     );
   }
 
+  /**
+   * Uploads an attachment and sends the event that points at it.
+   *
+   * **Nothing here decides whether to encrypt, and nothing here can get it
+   * wrong.** These five calls read the room's encryption state inside Rust and
+   * encrypt the bytes before they are uploaded when it is set; there is no
+   * parameter to pass and no plaintext path to fall into. The web half has to
+   * do it by hand, which is why `web/attachments.ts` exists and why it fails
+   * closed. See `docs/matrix/data-model.md` §6.
+   */
+  async sendAttachment(attachment: AlloOutgoingAttachment): Promise<void> {
+    const parameters = toUploadParameters(attachment);
+    const thumbnailSource = toThumbnailSource(attachment.thumbnail);
+    const thumbnailInfo = toThumbnailInfo(attachment.thumbnail);
+    const size = toU64(attachment.size);
+
+    const sending = ((): SendAttachmentJoinHandleLike => {
+      switch (attachment.kind) {
+        case 'image':
+          return this.#timeline.sendImage(parameters, thumbnailSource, {
+            width: toU64(attachment.width),
+            height: toU64(attachment.height),
+            mimetype: attachment.mimetype,
+            size,
+            thumbnailInfo,
+          });
+        case 'video':
+          return this.#timeline.sendVideo(parameters, thumbnailSource, {
+            duration: attachment.durationMs,
+            width: toU64(attachment.width),
+            height: toU64(attachment.height),
+            mimetype: attachment.mimetype,
+            size,
+            thumbnailInfo,
+          });
+        // Both arms send `m.audio`, and the difference between them is a marker
+        // the binding does not let this file set: `sendVoiceMessage` demands a
+        // waveform, and Allo's recorder samples no amplitudes. Inventing one
+        // would draw a picture of audio that was never measured, so a recording
+        // goes out as an ordinary audio attachment carrying its real duration.
+        case 'audio':
+        case 'voice':
+          return this.#timeline.sendAudio(parameters, {
+            duration: attachment.durationMs,
+            mimetype: attachment.mimetype,
+            size,
+          });
+        case 'file':
+          return this.#timeline.sendFile(parameters, {
+            mimetype: attachment.mimetype,
+            size,
+            thumbnailInfo,
+          });
+      }
+    })();
+
+    // The `join()` is what makes this promise mean anything: the call above
+    // returns as soon as the upload has been *queued*, so without it the
+    // composer would clear itself before a byte had left the phone.
+    await sending.join();
+  }
+
   async toggleReaction(eventId: string, key: string): Promise<void> {
     // One call for both directions: the binding looks up whether this account
     // already annotated the event and either sends or redacts accordingly.
@@ -730,6 +879,46 @@ class NativeTimelineHandle implements AlloTimelineHandle {
  */
 function toEventOrTransactionId(eventId: string): EventOrTransactionId {
   return new EventOrTransactionId.EventId({ eventId });
+}
+
+/**
+ * A `u64` field of the binding's media records, from a JavaScript number.
+ *
+ * `undefined` stays `undefined`, and so does anything that is not a positive
+ * whole number: `BigInt(1.5)` throws, and a width of zero is a default some
+ * client filled in rather than a measurement.
+ */
+function toU64(value: number | undefined): bigint | undefined {
+  return value !== undefined && Number.isSafeInteger(value) && value > 0
+    ? BigInt(value)
+    : undefined;
+}
+
+/**
+ * What a downloaded attachment is called on disk.
+ *
+ * **Nothing of the sender's filename reaches the path except its extension**,
+ * and that is stripped to letters and digits. The name came from another
+ * device over the network; a `../` or an absolute path in one is how a remote
+ * sender would write outside the cache directory. The extension survives
+ * because `expo-image` and `expo-video` pick a decoder from it.
+ */
+function cacheFileName(sequence: number, filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  const extension =
+    dot > 0 ? filename.slice(dot + 1).replace(/[^A-Za-z0-9]/g, '').slice(0, 8) : '';
+  return extension === '' ? `${sequence}` : `${sequence}.${extension}`;
+}
+
+/**
+ * The plain path the Rust SDK writes to, from the URI expo-file-system speaks.
+ *
+ * The same conversion `store.native.ts` does for the SQLite directories, for
+ * the same reason: the binding takes operating system paths, and a URI's
+ * percent-encoding has to come off before one becomes a path.
+ */
+function toStorePath(uri: string): string {
+  return uri.startsWith('file://') ? decodeURIComponent(uri.slice('file://'.length)) : uri;
 }
 
 /**

--- a/packages/frontend/lib/matrix/client.native.ts
+++ b/packages/frontend/lib/matrix/client.native.ts
@@ -747,7 +747,7 @@ class NativeTimelineHandle implements AlloTimelineHandle {
    * encrypt the bytes before they are uploaded when it is set; there is no
    * parameter to pass and no plaintext path to fall into. The web half has to
    * do it by hand, which is why `web/attachments.ts` exists and why it fails
-   * closed. See `docs/matrix/data-model.md` §6.
+   * closed. See `docs/matrix/ui-wiring.md` §7.
    */
   async sendAttachment(attachment: AlloOutgoingAttachment): Promise<void> {
     const parameters = toUploadParameters(attachment);

--- a/packages/frontend/lib/matrix/client.web.ts
+++ b/packages/frontend/lib/matrix/client.web.ts
@@ -40,6 +40,7 @@ import type {
 import {
   MatrixBackupExistsOnServerError,
   MatrixCryptoUnavailableError,
+  MatrixMediaUnreadableError,
   MatrixNotLoggedInError,
   MatrixOidcCallbackError,
   MatrixRoomNotFoundError,
@@ -61,9 +62,12 @@ import type {
   AlloChatClientFactory,
   AlloCreateRoomRequest,
   AlloEncryptionState,
+  AlloMediaFile,
+  AlloMediaRef,
   AlloReaction,
   AlloOidcLoginOptions,
   AlloOidcLoginRequest,
+  AlloOutgoingAttachment,
   AlloPaginationOutcome,
   AlloRecoveryState,
   AlloRoomListHandle,
@@ -76,8 +80,22 @@ import type {
 } from '@/lib/matrix/types';
 import { logger } from '@/utils/logger';
 
+import {
+  decodeMediaRef,
+  encryptionInfoOf,
+  mxcUriOf,
+  resolveAttachmentSource,
+  toAttachmentContent,
+  type OutgoingThumbnailSource,
+} from './web/attachments';
 import { Coalescer } from './web/coalesce';
 import { CryptoWasmLoader } from './web/cryptoWasm';
+import {
+  decryptAttachment,
+  encryptAttachment,
+  readAttachmentBytes,
+  toObjectUrl,
+} from './web/mediaTransfer';
 import {
   WebOidcLoginRequest,
   generateAuthorizationState,
@@ -584,12 +602,72 @@ class WebAlloChatClient implements AlloChatClient {
   ): Promise<AlloTimelineHandle> {
     const client = this.#requireSyncing('Opening a timeline');
     const room = this.#requireRoom(roomId, 'Opening a timeline');
-    const handle = new WebTimelineHandle(client, room, onChange, () => {
-      this.#timelines.delete(handle);
-    });
+    const handle = new WebTimelineHandle(
+      client,
+      room,
+      // The timeline is handed the *authoritative* answer rather than the local
+      // one. `roomEncryption` asks the homeserver when sync has not settled the
+      // question, and an attachment is exactly the case where the difference
+      // matters: see `sendAttachment`.
+      () => this.roomEncryption(room.roomId),
+      onChange,
+      () => {
+        this.#timelines.delete(handle);
+      },
+    );
     this.#timelines.add(handle);
     handle.attach();
     return handle;
+  }
+
+  /**
+   * Fetches an attachment and answers with an object URL a view can show.
+   *
+   * The two halves of the trip that the native SDK does inside Rust, done here
+   * by hand: download the blob from the media repository, and — when the ref
+   * names media from an encrypted room — decrypt it with the key that came
+   * inside the event. What the homeserver serves is ciphertext, so a view
+   * pointed straight at the mxc URL draws a broken image.
+   *
+   * The download is authenticated. Since Matrix 1.11 the media endpoints are
+   * behind the client's access token, and the unauthenticated ones are being
+   * withdrawn; an anonymous fetch works against some homeservers today and
+   * against fewer every release.
+   */
+  async downloadMedia(ref: AlloMediaRef): Promise<AlloMediaFile> {
+    const client = this.#requireClient('Downloading an attachment');
+    const { source, mimetype } = decodeMediaRef(ref);
+
+    const httpUrl = client.mxcUrlToHttp(
+      mxcUriOf(source),
+      undefined,
+      undefined,
+      undefined,
+      false,
+      true,
+      true,
+    );
+    if (httpUrl === null) {
+      throw new MatrixMediaUnreadableError(
+        `${mxcUriOf(source)} is not an address on this homeserver's media repository`,
+      );
+    }
+
+    const response = await fetch(httpUrl, {
+      headers: { Authorization: `Bearer ${client.getAccessToken() ?? ''}` },
+    });
+    if (!response.ok) {
+      throw new MatrixMediaUnreadableError(
+        `the homeserver refused to serve it (HTTP ${response.status})`,
+      );
+    }
+    const downloaded = new Uint8Array(await response.arrayBuffer());
+
+    const info = encryptionInfoOf(source);
+    return toObjectUrl(
+      info === undefined ? downloaded : decryptAttachment(downloaded, info),
+      mimetype,
+    );
   }
 
   async close(): Promise<void> {
@@ -1020,6 +1098,7 @@ class WebRoomListHandle implements AlloRoomListHandle {
 class WebTimelineHandle implements AlloTimelineHandle {
   readonly #client: MatrixClient;
   readonly #room: Room;
+  readonly #roomEncryption: () => Promise<AlloEncryptionState>;
   readonly #onChange: (items: readonly AlloTimelineItem[]) => void;
   readonly #onClose: () => void;
   readonly #coalescer: Coalescer;
@@ -1032,11 +1111,13 @@ class WebTimelineHandle implements AlloTimelineHandle {
   constructor(
     client: MatrixClient,
     room: Room,
+    roomEncryption: () => Promise<AlloEncryptionState>,
     onChange: (items: readonly AlloTimelineItem[]) => void,
     onClose: () => void,
   ) {
     this.#client = client;
     this.#room = room;
+    this.#roomEncryption = roomEncryption;
     this.#onChange = onChange;
     this.#onClose = onClose;
     this.#coalescer = new Coalescer(() => {
@@ -1081,6 +1162,101 @@ class WebTimelineHandle implements AlloTimelineHandle {
     // user's asterisks into formatting they did not ask for.
     await this.#client.sendMessage(this.#room.roomId, { msgtype: MsgType.Text, body });
   }
+
+  /**
+   * Uploads an attachment and sends the event that points at it.
+   *
+   * **This is the one place in Allo where a photograph could leave a device
+   * unencrypted, and the shape of it is what stops that.** `matrix-js-sdk` has
+   * no equivalent of the native SDK's `sendImage`: `uploadContent` uploads
+   * whatever it is given to a public URL, and `sendMessage` will put an
+   * `m.image` with a plaintext `url` into an encrypted room without a word.
+   * Every byte that goes up therefore passes through
+   * {@link resolveAttachmentSource}, which reads the room's encryption state
+   * and refuses to guess — see `web/attachments.ts`.
+   *
+   * The state is asked for **once** and used for both the attachment and its
+   * thumbnail. Asking twice would let a room that finished syncing in between
+   * produce an event with an encrypted picture and a thumbnail of it in the
+   * clear, which leaks the picture almost as well as the picture would.
+   */
+  async sendAttachment(attachment: AlloOutgoingAttachment): Promise<void> {
+    const encryption = await this.#roomEncryption();
+    const deps = { upload: this.#upload, encrypt: encryptAttachment };
+
+    const bytes = await readAttachmentBytes(attachment.uri);
+    const source = await resolveAttachmentSource(
+      { bytes, mimetype: attachment.mimetype, filename: attachment.filename },
+      encryption,
+      this.#room.roomId,
+      deps,
+    );
+
+    let thumbnail: OutgoingThumbnailSource | undefined;
+    if (attachment.thumbnail !== undefined) {
+      const small = attachment.thumbnail;
+      const thumbnailSource = await resolveAttachmentSource(
+        {
+          bytes: await readAttachmentBytes(small.uri),
+          mimetype: small.mimetype,
+          filename: `thumb-${attachment.filename}`,
+        },
+        encryption,
+        this.#room.roomId,
+        deps,
+      );
+      thumbnail = {
+        source: thumbnailSource,
+        mimetype: small.mimetype,
+        width: small.width,
+        height: small.height,
+      };
+    }
+
+    const content = toAttachmentContent(attachment, source, thumbnail, bytes.byteLength);
+    const roomId = this.#room.roomId;
+
+    // The `msgtype` is added here and not in `attachments.ts` because it is the
+    // SDK's own enum, and that module must not import a value from the SDK —
+    // its tests would drag the whole thing in. A switch and not a lookup table
+    // because `sendMessage` takes a union of four content shapes, one per
+    // msgtype, and only a narrowed literal picks an arm of it.
+    switch (attachment.kind) {
+      case 'image':
+        await this.#client.sendMessage(roomId, { ...content, msgtype: MsgType.Image });
+        return;
+      case 'video':
+        await this.#client.sendMessage(roomId, { ...content, msgtype: MsgType.Video });
+        return;
+      case 'audio':
+      case 'voice':
+        await this.#client.sendMessage(roomId, { ...content, msgtype: MsgType.Audio });
+        return;
+      case 'file':
+        await this.#client.sendMessage(roomId, { ...content, msgtype: MsgType.File });
+        return;
+    }
+  }
+
+  /**
+   * Hands bytes to the media repository.
+   *
+   * `includeFilename: false` for every upload, encrypted or not. The filename
+   * travels inside the event — which in an encrypted room is encrypted — and
+   * repeating it on the unauthenticated upload endpoint would put
+   * `passport-scan.jpg` in the homeserver's access log beside a blob that was
+   * encrypted precisely so it would not say what it is.
+   */
+  readonly #upload = async (payload: {
+    readonly bytes: Uint8Array;
+    readonly mimetype: string;
+  }): Promise<string> => {
+    const { content_uri: contentUri } = await this.#client.uploadContent(
+      new Blob([payload.bytes.slice().buffer], { type: payload.mimetype }),
+      { type: payload.mimetype, includeFilename: false },
+    );
+    return contentUri;
+  };
 
   /**
    * Adds the viewer's annotation, or redacts the one they already sent.

--- a/packages/frontend/lib/matrix/errors.ts
+++ b/packages/frontend/lib/matrix/errors.ts
@@ -192,6 +192,43 @@ export class MatrixBackupExistsOnServerError extends MatrixPortError {
 }
 
 /**
+ * An attachment was about to be sent to a room whose encryption state is not
+ * known yet.
+ *
+ * The one state that has to stop a send. `m.room.encryption` reaches a client
+ * through sync, so a room that has just been created — or one the app has only
+ * just heard of — honestly answers "not known yet", and both ways of guessing
+ * are wrong in different sizes. Guessing *encrypted* costs a failed send.
+ * Guessing *unencrypted* puts a photograph on a homeserver in the clear, in a
+ * conversation the user believes is private, and there is nothing on screen
+ * that looks any different afterwards. So the port refuses, and the caller's
+ * recovery — waiting a moment and sending again — is one the user understands.
+ */
+export class MatrixMediaEncryptionUnknownError extends MatrixPortError {
+  constructor(roomId: string) {
+    super(
+      `Allo will not upload an attachment to ${roomId} until it knows whether ` +
+        'the conversation is encrypted. Its state has not been synced yet; try ' +
+        'again in a moment.',
+    );
+  }
+}
+
+/**
+ * An attachment's bytes could not be read back from the media repository in a
+ * form this device can use.
+ *
+ * Covers both halves of the trip: an encrypted attachment whose event does not
+ * carry usable key material, and a download that came back as something other
+ * than the bytes that were asked for.
+ */
+export class MatrixMediaUnreadableError extends MatrixPortError {
+  constructor(reason: string) {
+    super(`This attachment cannot be read: ${reason}`);
+  }
+}
+
+/**
  * The homeserver described its secret storage key in a way the client will not
  * act on.
  *

--- a/packages/frontend/lib/matrix/native/media.ts
+++ b/packages/frontend/lib/matrix/native/media.ts
@@ -1,0 +1,263 @@
+import {
+  MessageType_Tags,
+  UploadSource,
+} from '@unomed/react-native-matrix-sdk';
+import type {
+  AudioInfo,
+  FileInfo,
+  ImageInfo,
+  MediaSourceLike,
+  MessageType,
+  ThumbnailInfo,
+  UploadParameters,
+  VideoInfo,
+} from '@unomed/react-native-matrix-sdk';
+
+import type {
+  AlloMediaContent,
+  AlloMediaRef,
+  AlloOutgoingAttachment,
+  AlloOutgoingThumbnail,
+} from '@/lib/matrix/types';
+
+/**
+ * Attachments, on the native half.
+ *
+ * Two directions, and they are not symmetrical. **Outgoing** is thin on purpose:
+ * `Timeline.sendImage` and its siblings do the whole job — read the file,
+ * encrypt it if the room is encrypted, upload it, and send the event — so
+ * everything here does is describe the file in the records the binding wants.
+ * Encryption is therefore not this module's decision and cannot be got wrong
+ * from here; the Rust SDK reads it from the room. **Incoming** is a translation
+ * of the binding's message content into the port's, plus the encoding of the
+ * opaque ref the UI carries around.
+ *
+ * Everything is a pure function of SDK records, so it is testable without a
+ * device — which is the same rule `native/translate.ts` follows and the reason
+ * the two are separate files rather than one.
+ */
+
+/**
+ * What the native half puts inside an {@link AlloMediaRef}.
+ *
+ * A serialized `MediaSource` and nothing else would not be enough:
+ * `Client.getMediaFile` needs a MIME type to name the file it writes, and the
+ * MIME type lives on the message's `info`, which the ref has to travel without.
+ */
+interface NativeMediaRef {
+  /** `MediaSource.toJson()`. Carries the mxc URI and, for encrypted media, the key. */
+  readonly source: string;
+  readonly mimetype: string;
+  readonly filename: string;
+}
+
+/** The fallback when a sender's client did not say what the bytes are. */
+const UNKNOWN_MIMETYPE = 'application/octet-stream';
+
+export function encodeMediaRef(
+  source: MediaSourceLike,
+  mimetype: string | undefined,
+  filename: string,
+): AlloMediaRef {
+  const ref: NativeMediaRef = {
+    source: source.toJson(),
+    mimetype: mimetype ?? UNKNOWN_MIMETYPE,
+    filename,
+  };
+  return JSON.stringify(ref);
+}
+
+/**
+ * Reads back what {@link encodeMediaRef} wrote.
+ *
+ * Validated rather than trusted even though this half wrote it: a ref survives
+ * in a React key and in a view model, so a ref from an older build of Allo — or
+ * one that crossed platforms — reaches here eventually, and the useful failure
+ * is one that says so.
+ */
+export function decodeMediaRef(ref: AlloMediaRef): NativeMediaRef {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(ref);
+  } catch {
+    throw new Error('This is not a media reference this device can read.');
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !hasString(parsed, 'source') ||
+    !hasString(parsed, 'mimetype') ||
+    !hasString(parsed, 'filename')
+  ) {
+    throw new Error('This media reference is missing the fields needed to fetch it.');
+  }
+  return { source: parsed.source, mimetype: parsed.mimetype, filename: parsed.filename };
+}
+
+function hasString<K extends string>(
+  value: object,
+  key: K,
+): value is Record<K, string> {
+  return key in value && typeof (value as Record<string, unknown>)[key] === 'string';
+}
+
+/**
+ * An attachment, from the binding's message content, or `undefined` for a
+ * message that is not one.
+ *
+ * `filename` comes from the binding's own computed field rather than from
+ * `body`: the SDK already resolves the spec's two spellings — `filename` when
+ * there is a caption, `body` when there is not — and reading `body` directly
+ * would show the caption as the filename on every captioned attachment.
+ */
+export function toMediaContent(msgType: MessageType): AlloMediaContent | undefined {
+  switch (msgType.tag) {
+    case MessageType_Tags.Image: {
+      const content = msgType.inner.content;
+      const info: ImageInfo | undefined = content.info;
+      return {
+        kind: 'image',
+        filename: content.filename,
+        caption: content.caption,
+        source: encodeMediaRef(content.source, info?.mimetype, content.filename),
+        thumbnail: toThumbnailRef(info?.thumbnailSource, info?.thumbnailInfo, content.filename),
+        width: toCount(info?.width),
+        height: toCount(info?.height),
+        durationMs: undefined,
+        size: toCount(info?.size),
+      };
+    }
+
+    case MessageType_Tags.Video: {
+      const content = msgType.inner.content;
+      const info: VideoInfo | undefined = content.info;
+      return {
+        kind: 'video',
+        filename: content.filename,
+        caption: content.caption,
+        source: encodeMediaRef(content.source, info?.mimetype, content.filename),
+        thumbnail: toThumbnailRef(info?.thumbnailSource, info?.thumbnailInfo, content.filename),
+        width: toCount(info?.width),
+        height: toCount(info?.height),
+        durationMs: info?.duration,
+        size: toCount(info?.size),
+      };
+    }
+
+    case MessageType_Tags.Audio: {
+      const content = msgType.inner.content;
+      const info: AudioInfo | undefined = content.info;
+      return {
+        // `voice` is present only when the sender's client marked the recording
+        // as a voice note (MSC3245). An ordinary audio file has the same
+        // msgtype and is not one, and the two are drawn differently.
+        kind: content.voice === undefined ? 'audio' : 'voice',
+        filename: content.filename,
+        caption: content.caption,
+        source: encodeMediaRef(content.source, info?.mimetype, content.filename),
+        thumbnail: undefined,
+        width: undefined,
+        height: undefined,
+        durationMs: info?.duration,
+        size: toCount(info?.size),
+      };
+    }
+
+    case MessageType_Tags.File: {
+      const content = msgType.inner.content;
+      const info: FileInfo | undefined = content.info;
+      return {
+        kind: 'file',
+        filename: content.filename,
+        caption: content.caption,
+        source: encodeMediaRef(content.source, info?.mimetype, content.filename),
+        thumbnail: toThumbnailRef(info?.thumbnailSource, info?.thumbnailInfo, content.filename),
+        width: undefined,
+        height: undefined,
+        durationMs: undefined,
+        size: toCount(info?.size),
+      };
+    }
+
+    default:
+      return undefined;
+  }
+}
+
+function toThumbnailRef(
+  source: MediaSourceLike | undefined,
+  info: ThumbnailInfo | undefined,
+  filename: string,
+): AlloMediaRef | undefined {
+  return source === undefined
+    ? undefined
+    : encodeMediaRef(source, info?.mimetype, `thumb-${filename}`);
+}
+
+/**
+ * A `u64` from the binding as a number.
+ *
+ * `undefined` for an absent value, and for zero: a picture zero pixels wide is
+ * a field the sender's client filled in with a default, and passing it on would
+ * have the UI lay out a bubble against it.
+ */
+function toCount(value: bigint | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const count = Number(value);
+  return count > 0 ? count : undefined;
+}
+
+/**
+ * The upload parameters for an outgoing attachment.
+ *
+ * `UploadSource.File` and not `UploadSource.Data`: it hands the SDK a path and
+ * lets Rust stream the file, so a video never exists as an `ArrayBuffer` in the
+ * JavaScript heap. The spike proved both variants work (`spikes/matrix-rn`,
+ * C6); this is the one that does not put a phone's whole camera roll through
+ * the bridge.
+ */
+export function toUploadParameters(attachment: AlloOutgoingAttachment): UploadParameters {
+  return {
+    source: new UploadSource.File({ filename: toFilesystemPath(attachment.uri) }),
+    caption: attachment.caption,
+  };
+}
+
+export function toThumbnailSource(
+  thumbnail: AlloOutgoingThumbnail | undefined,
+): UploadSource | undefined {
+  return thumbnail === undefined
+    ? undefined
+    : new UploadSource.File({ filename: toFilesystemPath(thumbnail.uri) });
+}
+
+export function toThumbnailInfo(
+  thumbnail: AlloOutgoingThumbnail | undefined,
+): ThumbnailInfo | undefined {
+  return thumbnail === undefined
+    ? undefined
+    : {
+        width: BigInt(thumbnail.width),
+        height: BigInt(thumbnail.height),
+        mimetype: thumbnail.mimetype,
+      };
+}
+
+/**
+ * The path the Rust SDK wants, from the URI the platform's picker gave.
+ *
+ * The binding takes filesystem paths, and everything on a phone hands over
+ * `file://` URIs. Passing one through unchanged fails inside Rust with an error
+ * about a file that does not exist — naming a path that visibly does.
+ */
+export function toFilesystemPath(uri: string): string {
+  if (!uri.startsWith('file://')) {
+    return uri;
+  }
+  // Percent-decoded, not passed through: a picker returns a URI, and a photo
+  // named `holiday #2.jpg` arrives as `holiday%20%232.jpg`. Rust would look for
+  // a file with those characters in its name.
+  return decodeURIComponent(uri.slice('file://'.length));
+}

--- a/packages/frontend/lib/matrix/native/translate.ts
+++ b/packages/frontend/lib/matrix/native/translate.ts
@@ -28,6 +28,8 @@ import type {
   AlloTimelineItem,
 } from '@/lib/matrix/types';
 
+import { toMediaContent } from './media';
+
 /**
  * Translation from the binding's model to Allo's view model.
  *
@@ -256,12 +258,17 @@ export function toEventContent(content: TimelineItemContent): AlloEventContent {
   switch (kind.tag) {
     case MsgLikeKind_Tags.Message: {
       const message = kind.inner.content;
-      if (message.msgType.tag !== MessageType_Tags.Text) {
-        // An image's `body` is its filename. Drawing it as the message text would
-        // be worse than admitting the row is not drawable yet.
-        return { kind: 'unsupported', description: `m.room.message:${message.msgType.tag}` };
+      if (message.msgType.tag === MessageType_Tags.Text) {
+        return { kind: 'text', body: message.body, isEdited: message.isEdited };
       }
-      return { kind: 'text', body: message.body, isEdited: message.isEdited };
+      const media = toMediaContent(message.msgType);
+      if (media !== undefined) {
+        return { kind: 'media', media };
+      }
+      // Emotes, notices, locations and whatever the binding grows next. Reported
+      // as themselves rather than as their `body`, which for several of them is
+      // a fallback string written for clients that cannot draw the real thing.
+      return { kind: 'unsupported', description: `m.room.message:${message.msgType.tag}` };
     }
 
     case MsgLikeKind_Tags.UnableToDecrypt:

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -174,7 +174,7 @@ export type AlloEventContent =
  * encrypted by the sending client before they are uploaded**, so the homeserver
  * stores an opaque blob and the key travels inside the encrypted event — the
  * same protection the message body already has, and the reason Allo does not
- * need an upload endpoint of its own. See `docs/matrix/data-model.md` §6.
+ * need an upload endpoint of its own. See `docs/matrix/ui-wiring.md` §7.
  * ------------------------------------------------------------------------- */
 
 /**

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -159,10 +159,148 @@ export type AlloEventKey =
  */
 export type AlloEventContent =
   | { readonly kind: 'text'; readonly body: string; readonly isEdited: boolean }
+  | { readonly kind: 'media'; readonly media: AlloMediaContent }
   | { readonly kind: 'undecryptable' }
   | { readonly kind: 'redacted' }
   /** An event Allo does not draw yet. `description` names the kind, for logs. */
   | { readonly kind: 'unsupported'; readonly description: string };
+
+/* ---------------------------------------------------------------------------
+ * Attachments
+ *
+ * Media in Matrix is two things that arrive separately: an event in the room,
+ * which is what the timeline carries, and bytes in the homeserver's media
+ * repository, which are fetched on demand. **In an encrypted room the bytes are
+ * encrypted by the sending client before they are uploaded**, so the homeserver
+ * stores an opaque blob and the key travels inside the encrypted event — the
+ * same protection the message body already has, and the reason Allo does not
+ * need an upload endpoint of its own. See `docs/matrix/data-model.md` §6.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * What an attachment is, in the vocabulary the protocol has for it.
+ *
+ * `voice` is not a sixth msgtype — it is an `m.audio` a client marked as a voice
+ * note — but it is a separate kind here because the two are drawn differently
+ * and the distinction is lost the moment it is collapsed.
+ */
+export type AlloMediaKind = 'image' | 'video' | 'audio' | 'voice' | 'file';
+
+/**
+ * Where bytes live, in a form only the implementation that produced it can read.
+ *
+ * **Opaque.** It is a string so it can be a React key and travel through view
+ * models that know nothing about Matrix, and that is the only thing anything
+ * outside `lib/matrix/` may do with it: never parse it, never build one by hand,
+ * never move one between platforms. What the native half writes into it — a
+ * serialized `MediaSource` — means nothing to the web half, which writes an mxc
+ * URI or a whole encrypted-file descriptor.
+ *
+ * It is deliberately *not* a URL. A URL implies something a view can fetch, and
+ * media in an encrypted room is exactly the case where that is false: what the
+ * homeserver serves at the underlying address is ciphertext. {@link
+ * AlloChatClient.downloadMedia} is the only way to turn one of these into
+ * something that can be displayed.
+ */
+export type AlloMediaRef = string;
+
+/** An attachment, as a timeline row carries it. */
+export interface AlloMediaContent {
+  readonly kind: AlloMediaKind;
+  /** The filename the sender's client computed. Never empty. */
+  readonly filename: string;
+  /**
+   * What the sender wrote alongside the attachment, if anything.
+   *
+   * Distinct from {@link filename}: a caption is prose the sender chose, and a
+   * filename is `IMG_4032.HEIC`. Drawing the second one as the first is the
+   * mistake this separation exists to prevent.
+   */
+  readonly caption: string | undefined;
+  readonly source: AlloMediaRef;
+  /**
+   * A smaller copy of the same picture, uploaded by the sender beside it.
+   *
+   * Absent whenever the sender's client made none, which is common. It is the
+   * sender's and not the server's on purpose: a homeserver can only thumbnail
+   * what it can read, so in an encrypted room the *only* thumbnail that exists
+   * is one the sending client encrypted and uploaded itself. Asking the server
+   * to thumbnail an encrypted upload yields a picture of ciphertext.
+   */
+  readonly thumbnail: AlloMediaRef | undefined;
+  /** Pixels. Absent when the sender's client did not say. */
+  readonly width: number | undefined;
+  readonly height: number | undefined;
+  /** Milliseconds, for audio and video. Absent for everything else. */
+  readonly durationMs: number | undefined;
+  /** Bytes, as the sender's client reported them. Not verified here. */
+  readonly size: number | undefined;
+}
+
+/** Bytes ready to be displayed, and the means to let go of them. */
+export interface AlloMediaFile {
+  /**
+   * A URI this app can hand to an image or a video view: a `file://` path on
+   * iOS and Android, a `blob:` URL on web.
+   */
+  readonly uri: string;
+  /**
+   * Releases what backs {@link uri}, after which it no longer resolves.
+   *
+   * Not optional housekeeping on either platform: a `blob:` URL pins its bytes
+   * in the tab's memory until it is revoked, and a decrypted file on a phone is
+   * plaintext sitting in the cache directory. Calling it more than once is safe.
+   */
+  release(): void;
+}
+
+/**
+ * A picture or a small copy of one, on its way out.
+ *
+ * `uri` is whatever the platform's picker handed over — a `file://` path on a
+ * phone, a `blob:` or `data:` URL in a browser — and each implementation reads
+ * it the way its own SDK wants. The UI does not have to know which.
+ */
+export interface AlloOutgoingThumbnail {
+  readonly uri: string;
+  readonly mimetype: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * An attachment on its way out.
+ *
+ * **There is no "encrypt this" option, and there must never be one.** Whether an
+ * attachment is encrypted is decided by the room it is being sent to, inside the
+ * implementation, from the room's own encryption state — never by a caller. A
+ * boolean here would be a way for one screen, one refactor or one default
+ * argument to put a photograph on a homeserver in the clear while every message
+ * around it stays encrypted, and nothing in the UI would look any different.
+ * See `AlloTimelineHandle.sendAttachment`.
+ */
+export interface AlloOutgoingAttachment {
+  readonly kind: AlloMediaKind;
+  /** Shown by clients that list attachments, and used to pick an extension. */
+  readonly filename: string;
+  readonly mimetype: string;
+  /** Where the bytes are now. See {@link AlloOutgoingThumbnail.uri}. */
+  readonly uri: string;
+  /** Prose to send with it. */
+  readonly caption?: string;
+  readonly width?: number;
+  readonly height?: number;
+  /** Bytes. Sent so receivers can decide before downloading. */
+  readonly size?: number;
+  /** Milliseconds. For audio and video. */
+  readonly durationMs?: number;
+  /**
+   * A small copy to send alongside, so receivers can draw the row without
+   * downloading the whole thing. See {@link AlloMediaContent.thumbnail} for why
+   * the sender is the only one who can make it.
+   */
+  readonly thumbnail?: AlloOutgoingThumbnail;
+}
 
 /** A row of a conversation. */
 export interface AlloTimelineItem {
@@ -424,6 +562,28 @@ export interface AlloTimelineHandle {
   sendText(body: string): Promise<void>;
 
   /**
+   * Uploads an attachment and sends the event that points at it.
+   *
+   * **In an encrypted room the bytes are encrypted before they leave the
+   * device, and this call is what guarantees it.** Whether to encrypt is read
+   * from the room, here, and not passed in: see
+   * {@link AlloOutgoingAttachment} for why there is no parameter for it.
+   *
+   * It **refuses to send** when the room's encryption state is
+   * {@link AlloEncryptionState `'unknown'`} — the state a room is in before
+   * sync has delivered `m.room.encryption`. That is the only safe reading of
+   * "not known yet": guessing `unencrypted` uploads a photograph in the clear,
+   * and the user has no way to tell that happened. Waiting a moment and trying
+   * again is the recovery, and it is the caller's.
+   *
+   * Resolves once the homeserver has the event. On iOS and Android the SDK's
+   * send queue owns the upload, so a failure after this resolves shows up as a
+   * failed row rather than a rejected promise; on web there is no queue and
+   * everything fails here.
+   */
+  sendAttachment(attachment: AlloOutgoingAttachment): Promise<void>;
+
+  /**
    * Adds the viewer's reaction, or takes it away if it is already there.
    *
    * One call and not two, because the protocol operation is not symmetric —
@@ -612,6 +772,20 @@ export interface AlloChatClient {
     roomId: string,
     onChange: (items: readonly AlloTimelineItem[]) => void,
   ): Promise<AlloTimelineHandle>;
+
+  /**
+   * Fetches an attachment's bytes and answers with something a view can show.
+   *
+   * **Decryption happens here**, when the ref names media from an encrypted
+   * room, which is why this exists at all instead of the port handing out URLs:
+   * what the homeserver serves at the underlying address is ciphertext, and a
+   * view given that address draws a broken image. See {@link AlloMediaRef}.
+   *
+   * On the client rather than on the timeline because a ref names bytes, not a
+   * room: a conversation can be closed while a picture from it is still open.
+   * The caller owns the result and must {@link AlloMediaFile.release} it.
+   */
+  downloadMedia(ref: AlloMediaRef): Promise<AlloMediaFile>;
 
   /**
    * How far this device has got with 4S. See {@link AlloRecoveryState}.

--- a/packages/frontend/lib/matrix/web/attachments.ts
+++ b/packages/frontend/lib/matrix/web/attachments.ts
@@ -1,0 +1,461 @@
+import type { IContent } from 'matrix-js-sdk';
+// Not exported from the root of `matrix-js-sdk@42`, only from this path inside
+// the package — the same deep import `client.web.ts` already documents for
+// `deriveRecoveryKeyFromPassphrase`, and a safer one: these are `import type`,
+// so nothing is pulled into the runtime and a path that moves is a compile
+// error rather than a silent break. Describing an `m.image` by hand instead
+// would be a second, drifting copy of the spec's own shapes.
+import type { EncryptedFile, VideoContent, VideoInfo } from 'matrix-js-sdk/lib/types.js';
+
+import {
+  MatrixMediaEncryptionUnknownError,
+  MatrixMediaUnreadableError,
+} from '@/lib/matrix/errors';
+import type {
+  AlloEncryptionState,
+  AlloMediaContent,
+  AlloMediaKind,
+  AlloMediaRef,
+  AlloOutgoingAttachment,
+} from '@/lib/matrix/types';
+
+/**
+ * Attachments, on the web half — where encrypting them is Allo's own job.
+ *
+ * This is the asymmetry that decides the shape of this file. On iOS and Android
+ * one call does everything: `Timeline.sendImage` reads the room's encryption
+ * state inside Rust, encrypts the bytes if it is set, uploads them and sends the
+ * event, and there is no argument to get wrong. `matrix-js-sdk` offers no such
+ * call. `uploadContent()` uploads whatever it is handed, to a public URL, and
+ * `sendMessage()` will happily put an `m.image` with a plaintext `url` into an
+ * encrypted room. Nothing warns, the event body is still encrypted, the bubble
+ * looks identical — and the picture is readable by anyone with the mxc URI.
+ *
+ * So the decision is made in one place, {@link resolveAttachmentSource}, and it
+ * is made from the room's own state:
+ *
+ * - `encrypted` — encrypt, then upload the ciphertext, and send a `file`.
+ * - `unencrypted` — upload as-is and send a `url`.
+ * - `unknown` — **refuse**. See {@link MatrixMediaEncryptionUnknownError}: it is
+ *   the ordinary state of a room sync has not delivered yet, and the plaintext
+ *   guess is the one whose damage the user cannot see.
+ *
+ * Everything here is a pure function of its arguments and its injected
+ * collaborators, which is what lets `__tests__/matrix/web/attachments.test.ts`
+ * assert on the exact bytes that would reach a homeserver.
+ */
+
+/**
+ * The MSC3245 marker that makes an `m.audio` a voice message.
+ *
+ * An empty object is the whole content the MSC defines; its presence is the
+ * signal. Sent without the companion waveform (`org.matrix.msc3246.audio`)
+ * because Allo's recorder samples no amplitudes, and a fabricated waveform is a
+ * drawing of audio nobody measured.
+ */
+const VOICE_MARKER = 'org.matrix.msc3245.voice';
+
+/** What Allo adds to the spec's media content. */
+interface VoiceMarker {
+  /** See {@link VOICE_MARKER}. Spelled out because a type cannot have a computed key. */
+  'org.matrix.msc3245.voice'?: Record<string, never>;
+}
+
+/**
+ * An attachment's event content, short of its `msgtype`.
+ *
+ * `VideoContent` is the widest of the spec's four media contents — its `info`
+ * carries dimensions, duration, size and both spellings of a thumbnail — so one
+ * shape covers a picture, a video, a recording and a document. The `msgtype` is
+ * added by the caller, which is what turns it into one of the four; it is left
+ * out here because it is the SDK's enum, and importing an enum is importing a
+ * value.
+ */
+export type AttachmentContent = Omit<VideoContent, 'msgtype'> & VoiceMarker;
+
+/** How an event points at bytes: one or the other, never both. */
+export type AttachmentSource =
+  | { readonly url: string }
+  | { readonly file: EncryptedFile };
+
+/** Bytes on their way out, already read off whatever URI held them. */
+export interface AttachmentBytes {
+  readonly bytes: Uint8Array;
+  readonly mimetype: string;
+  readonly filename: string;
+}
+
+/** Uploads bytes to the media repository and answers with the mxc URI. */
+export type UploadBytes = (payload: AttachmentBytes) => Promise<string>;
+
+/**
+ * Encrypts bytes and answers with the ciphertext and the key material.
+ *
+ * `info` is the crypto machine's JSON: `{ v, key, iv, hashes }`, which is an
+ * `EncryptedFile` short of its `url`.
+ */
+export type EncryptBytes = (plaintext: Uint8Array) => {
+  readonly ciphertext: Uint8Array;
+  readonly info: string;
+};
+
+export interface AttachmentUploadDeps {
+  readonly upload: UploadBytes;
+  readonly encrypt: EncryptBytes;
+}
+
+/**
+ * Uploads an attachment's bytes and answers with how the event should point at
+ * them.
+ *
+ * **The only place in the web half that hands bytes to the media repository.**
+ * Whether they are encrypted is decided here, from `encryption` and nothing
+ * else — no argument, no default, no caller's opinion.
+ *
+ * `roomId` is carried for the error message alone: a refusal that does not name
+ * the conversation sends the reader looking through all of them.
+ */
+export async function resolveAttachmentSource(
+  payload: AttachmentBytes,
+  encryption: AlloEncryptionState,
+  roomId: string,
+  deps: AttachmentUploadDeps,
+): Promise<AttachmentSource> {
+  switch (encryption) {
+    case 'unknown':
+      throw new MatrixMediaEncryptionUnknownError(roomId);
+
+    case 'unencrypted': {
+      const url = await deps.upload(payload);
+      return { url };
+    }
+
+    case 'encrypted': {
+      const { ciphertext, info } = deps.encrypt(payload.bytes);
+      // The ciphertext is uploaded, and its MIME type is deliberately not the
+      // picture's: what lands on the homeserver is a blob, and telling the
+      // server it is a JPEG invites it to thumbnail, transcode or sniff
+      // something that is not one.
+      const url = await deps.upload({
+        bytes: ciphertext,
+        mimetype: 'application/octet-stream',
+        filename: payload.filename,
+      });
+      return { file: { ...parseEncryptionInfo(info), url } };
+    }
+  }
+}
+
+/**
+ * The key material, checked rather than trusted.
+ *
+ * It comes out of the crypto machine as a JSON string, so it arrives here as
+ * `unknown`. A field missing from it would otherwise produce an `EncryptedFile`
+ * nobody can open, and the failure would land on the **receiver** — days later,
+ * on another device, with nothing to point at the sender.
+ */
+function parseEncryptionInfo(info: string): Omit<EncryptedFile, 'url'> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(info);
+  } catch {
+    throw new MatrixMediaUnreadableError(
+      'the encryption machine did not describe the key as JSON',
+    );
+  }
+  const material = toKeyMaterial(parsed);
+  if (material === undefined) {
+    throw new MatrixMediaUnreadableError(
+      'the key material is missing one of v, key, iv or hashes',
+    );
+  }
+  return material;
+}
+
+export interface OutgoingThumbnailSource {
+  readonly source: AttachmentSource;
+  readonly mimetype: string;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * The `m.room.message` content for an attachment whose bytes are already up.
+ *
+ * `body` is the caption when there is one and the filename otherwise, with
+ * `filename` always set alongside. That is the spec's own arrangement: a client
+ * that understands captions reads `filename` and shows `body` as prose, and one
+ * that does not shows the filename it always showed.
+ */
+export function toAttachmentContent(
+  attachment: AlloOutgoingAttachment,
+  source: AttachmentSource,
+  thumbnail: OutgoingThumbnailSource | undefined,
+  size: number,
+): AttachmentContent {
+  const caption = attachment.caption?.trim();
+  const hasCaption = caption !== undefined && caption !== '';
+
+  const content: AttachmentContent = {
+    body: hasCaption ? caption : attachment.filename,
+    filename: attachment.filename,
+    info: toAttachmentInfo(attachment, thumbnail, size),
+    ...source,
+  };
+  if (attachment.kind === 'voice') {
+    content[VOICE_MARKER] = {};
+  }
+  return content;
+}
+
+/**
+ * What the event says about the bytes without opening them.
+ *
+ * Fields nothing measured are left out rather than set to `undefined`. A `"w"`
+ * in an event is a claim about the picture's width and other clients lay out
+ * against it; an absent key is the honest way to say nothing.
+ */
+function toAttachmentInfo(
+  attachment: AlloOutgoingAttachment,
+  thumbnail: OutgoingThumbnailSource | undefined,
+  size: number,
+): VideoInfo {
+  const info: VideoInfo = { mimetype: attachment.mimetype, size };
+  if (attachment.width !== undefined) {
+    info.w = attachment.width;
+  }
+  if (attachment.height !== undefined) {
+    info.h = attachment.height;
+  }
+  if (attachment.durationMs !== undefined) {
+    info.duration = attachment.durationMs;
+  }
+  if (thumbnail !== undefined) {
+    info.thumbnail_info = {
+      mimetype: thumbnail.mimetype,
+      w: thumbnail.width,
+      h: thumbnail.height,
+    };
+    // A thumbnail lives under its own keys — and under the encrypted one when
+    // the attachment is encrypted, because a thumbnail of a private photograph
+    // gives it away just as well as the photograph.
+    if ('url' in thumbnail.source) {
+      info.thumbnail_url = thumbnail.source.url;
+    } else {
+      info.thumbnail_file = thumbnail.source.file;
+    }
+  }
+  return info;
+}
+
+/* ---------------------------------------------------------------------------
+ * Incoming
+ * ------------------------------------------------------------------------- */
+
+/** What the web half puts inside an {@link AlloMediaRef}. See the native one. */
+interface WebMediaRef {
+  readonly source: AttachmentSource;
+  readonly mimetype: string;
+}
+
+const UNKNOWN_MIMETYPE = 'application/octet-stream';
+
+export function encodeMediaRef(
+  source: AttachmentSource,
+  mimetype: string | undefined,
+): AlloMediaRef {
+  const ref: WebMediaRef = { source, mimetype: mimetype ?? UNKNOWN_MIMETYPE };
+  return JSON.stringify(ref);
+}
+
+/**
+ * Reads back what {@link encodeMediaRef} wrote.
+ *
+ * Validated for the same reason the native half validates its own: a ref lives
+ * on in a React key and in a view model, so one written by an older build — or
+ * by the other platform — reaches here eventually, and the useful failure says
+ * so rather than dereferencing `undefined`.
+ */
+export function decodeMediaRef(ref: AlloMediaRef): WebMediaRef {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(ref);
+  } catch {
+    throw new MatrixMediaUnreadableError('it is not a reference this browser wrote');
+  }
+  const record = asRecord(parsed);
+  if (record === undefined || typeof record.mimetype !== 'string') {
+    throw new MatrixMediaUnreadableError('the reference does not say what the bytes are');
+  }
+  const decoded = asRecord(record.source);
+  const source = decoded === undefined ? undefined : toSource(decoded.url, decoded.file);
+  if (source === undefined) {
+    throw new MatrixMediaUnreadableError(
+      'the reference names neither an unencrypted URL nor an encrypted file',
+    );
+  }
+  return { source, mimetype: record.mimetype };
+}
+
+/**
+ * The key material an encrypted source carries, in the shape the crypto machine
+ * takes it back in — or `undefined` for a source that is not encrypted.
+ */
+export function encryptionInfoOf(source: AttachmentSource): string | undefined {
+  if ('url' in source) {
+    return undefined;
+  }
+  const { url: _url, ...info } = source.file;
+  return JSON.stringify(info);
+}
+
+/** The mxc URI to fetch, whichever kind of source this is. */
+export function mxcUriOf(source: AttachmentSource): string {
+  return 'url' in source ? source.url : source.file.url;
+}
+
+/**
+ * An attachment, from an `m.room.message` content, or `undefined` for a message
+ * that is not one.
+ *
+ * `content` is whatever the homeserver sent — `matrix-js-sdk` types it with an
+ * index signature of `any` — so every field is read through `unknown` and
+ * checked. That is not ceremony: an event arrives from another user's client
+ * over the network, and `info.w` being a string is enough to lay out a bubble
+ * against nonsense.
+ */
+export function toMediaContent(content: IContent): AlloMediaContent | undefined {
+  const kind = KIND_BY_MSGTYPE[asString(content.msgtype) ?? ''];
+  if (kind === undefined) {
+    return undefined;
+  }
+  const source = toSource(content.url, content.file);
+  if (source === undefined) {
+    return undefined;
+  }
+
+  const info = asRecord(content.info) ?? {};
+  const filename = asString(content.filename) ?? asString(content.body) ?? 'attachment';
+  // The spec's own rule for captions: a `filename` that differs from `body`
+  // means `body` is prose. Equal, or absent, means `body` is the name.
+  const body = asString(content.body);
+  const caption =
+    body !== undefined && body !== '' && body !== filename ? body : undefined;
+
+  return {
+    // A voice note and an audio file share a msgtype; only the marker tells
+    // them apart, and the sender is the only one who can set it.
+    kind: kind === 'audio' && content[VOICE_MARKER] !== undefined ? 'voice' : kind,
+    filename,
+    caption,
+    source: encodeMediaRef(source, asString(info.mimetype)),
+    thumbnail: toThumbnailRef(info),
+    width: asCount(info.w),
+    height: asCount(info.h),
+    durationMs: asCount(info.duration),
+    size: asCount(info.size),
+  };
+}
+
+const KIND_BY_MSGTYPE: Readonly<Partial<Record<string, AlloMediaKind>>> = {
+  'm.image': 'image',
+  'm.video': 'video',
+  'm.audio': 'audio',
+  'm.file': 'file',
+};
+
+function toThumbnailRef(info: Record<string, unknown>): AlloMediaRef | undefined {
+  const source = toSource(info.thumbnail_url, info.thumbnail_file);
+  if (source === undefined) {
+    return undefined;
+  }
+  const thumbnailInfo = asRecord(info.thumbnail_info) ?? {};
+  return encodeMediaRef(source, asString(thumbnailInfo.mimetype));
+}
+
+/**
+ * One source from an event's two spellings of it.
+ *
+ * `file` wins when both are present, which is the spec's instruction and the
+ * safe reading besides: an event carrying both is one where the plaintext `url`
+ * cannot be trusted to hold the same bytes.
+ *
+ * **An encrypted attachment whose key material is malformed yields nothing**,
+ * rather than falling through to `url`. That fallback would be the silent
+ * plaintext path this whole module exists to prevent — and there is no
+ * plaintext at that URL to fall back to anyway.
+ */
+function toSource(url: unknown, file: unknown): AttachmentSource | undefined {
+  const encrypted = asRecord(file);
+  if (encrypted !== undefined) {
+    const material = toKeyMaterial(encrypted);
+    return material === undefined || typeof encrypted.url !== 'string'
+      ? undefined
+      : { file: { ...material, url: encrypted.url } };
+  }
+  return typeof url === 'string' ? { url } : undefined;
+}
+
+/**
+ * The four fields that open an encrypted attachment, checked one by one.
+ *
+ * The JWK inside is checked field by field too. It is the key: a `k` that is
+ * not a string, or `key_ops` that is not an array of them, produces an object
+ * the crypto machine rejects deep inside WebAssembly with an error that names
+ * none of this.
+ */
+function toKeyMaterial(value: unknown): Omit<EncryptedFile, 'url'> | undefined {
+  const record = asRecord(value);
+  if (record === undefined) {
+    return undefined;
+  }
+  const { v, iv, hashes } = record;
+  const key = asRecord(record.key);
+  if (
+    typeof v !== 'string' ||
+    typeof iv !== 'string' ||
+    !isStringMap(hashes) ||
+    key === undefined ||
+    typeof key.alg !== 'string' ||
+    typeof key.kty !== 'string' ||
+    typeof key.k !== 'string' ||
+    typeof key.ext !== 'boolean' ||
+    !isStringArray(key.key_ops)
+  ) {
+    return undefined;
+  }
+  return {
+    v,
+    iv,
+    hashes,
+    key: { alg: key.alg, kty: key.kty, k: key.k, ext: key.ext, key_ops: key.key_ops },
+  };
+}
+
+function isStringMap(value: unknown): value is Record<string, string> {
+  const record = asRecord(value);
+  return (
+    record !== undefined && Object.values(record).every((entry) => typeof entry === 'string')
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? { ...value }
+    : undefined;
+}
+
+/** A positive whole number, or nothing. See the native half's `toCount`. */
+function asCount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.round(value)
+    : undefined;
+}

--- a/packages/frontend/lib/matrix/web/mediaTransfer.ts
+++ b/packages/frontend/lib/matrix/web/mediaTransfer.ts
@@ -1,0 +1,114 @@
+import { Attachment, EncryptedAttachment } from '@matrix-org/matrix-sdk-crypto-wasm';
+
+import { MatrixMediaUnreadableError } from '@/lib/matrix/errors';
+import type { AlloMediaFile } from '@/lib/matrix/types';
+
+/**
+ * The browser-facing half of attachments: bytes in, bytes out, and the crypto
+ * machine in between.
+ *
+ * Kept apart from `attachments.ts` on purpose. That file decides *what* to send
+ * and is a pure function of its arguments, so its tests can assert on the exact
+ * bytes that would reach a homeserver without a browser or 7.8 MB of
+ * WebAssembly. This one touches `fetch`, `Blob`, `URL` and the wasm module, and
+ * cannot be tested without them.
+ *
+ * The encryption itself is the Rust crypto machine's, through
+ * `@matrix-org/matrix-sdk-crypto-wasm` — the same code that encrypts
+ * attachments on iOS and Android, compiled differently. Allo does not implement
+ * AES-CTR, does not choose an IV and does not compute the SHA-256, which is the
+ * only acceptable amount of attachment cryptography for an app to write.
+ */
+
+/**
+ * Reads an attachment's bytes off whatever URI the picker handed over.
+ *
+ * `fetch` covers all three shapes a browser produces — `blob:`, `data:` and an
+ * ordinary URL — and is the reason the port takes a URI rather than a `File`:
+ * the same field means a filesystem path on a phone, and neither caller has to
+ * know which platform it is on.
+ */
+export async function readAttachmentBytes(uri: string): Promise<Uint8Array> {
+  const response = await fetch(uri);
+  if (!response.ok) {
+    throw new MatrixMediaUnreadableError(
+      `the browser could not read the chosen file (HTTP ${response.status})`,
+    );
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/**
+ * Encrypts an attachment, and answers with the ciphertext and the key material.
+ *
+ * The `EncryptedAttachment` is freed before returning. It holds its buffers in
+ * WebAssembly memory, which no JavaScript garbage collector can see, so a tab
+ * that sends a few videos without this leaks their whole size.
+ */
+export function encryptAttachment(plaintext: Uint8Array): {
+  readonly ciphertext: Uint8Array;
+  readonly info: string;
+} {
+  const encrypted = Attachment.encrypt(plaintext);
+  try {
+    const ciphertext = encrypted.encryptedData;
+    const info = encrypted.mediaEncryptionInfo;
+    if (info === undefined) {
+      throw new MatrixMediaUnreadableError(
+        'the encryption machine produced no key for the attachment it encrypted',
+      );
+    }
+    return { ciphertext, info };
+  } finally {
+    encrypted.free();
+  }
+}
+
+/**
+ * Decrypts an attachment downloaded from the media repository.
+ *
+ * The key material is consumed by the decryption — the machine's own warning is
+ * that an `EncryptedAttachment` "can be used only once" — which is why a fresh
+ * one is built here from the event's `file` block on every call rather than
+ * kept around.
+ */
+export function decryptAttachment(ciphertext: Uint8Array, info: string): Uint8Array {
+  const encrypted = new EncryptedAttachment(ciphertext, info);
+  try {
+    return Attachment.decrypt(encrypted);
+  } catch (error) {
+    throw new MatrixMediaUnreadableError(
+      `the key in the event did not open it (${describe(error)})`,
+    );
+  } finally {
+    encrypted.free();
+  }
+}
+
+/**
+ * Wraps decrypted bytes in something an `<img>` or a `<video>` can point at.
+ *
+ * `release()` is not optional housekeeping: an object URL pins its bytes in the
+ * tab for as long as the document lives, whether or not anything still refers
+ * to it, and these bytes are a photograph from an encrypted conversation.
+ */
+export function toObjectUrl(bytes: Uint8Array, mimetype: string): AlloMediaFile {
+  // `slice()` because a Blob must own a plain ArrayBuffer, and the array here
+  // may be a view onto a larger one.
+  const uri = URL.createObjectURL(new Blob([bytes.slice().buffer], { type: mimetype }));
+  let released = false;
+  return {
+    uri,
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      URL.revokeObjectURL(uri);
+    },
+  };
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/frontend/lib/matrix/web/translate.ts
+++ b/packages/frontend/lib/matrix/web/translate.ts
@@ -13,6 +13,8 @@ import type {
   AlloTimelineItem,
 } from '@/lib/matrix/types';
 
+import { toMediaContent } from './attachments';
+
 /**
  * Translation from `matrix-js-sdk`'s model to Allo's view model.
  *
@@ -484,8 +486,14 @@ export function toEventContent(event: TimelineEventFields): AlloEventContent {
 
   const content = event.getContent();
   if (content.msgtype !== TEXT_MESSAGE_TYPE) {
-    // An image's `body` is its filename. Drawing it as the message text would be
-    // worse than admitting the row is not drawable yet.
+    const media = toMediaContent(content);
+    if (media !== undefined) {
+      return { kind: 'media', media };
+    }
+    // Emotes, notices, locations, and an attachment whose event does not
+    // actually point at any bytes. Reported as itself rather than as its
+    // `body`, which for several of them is a fallback string written for
+    // clients that cannot draw the real thing.
     return { kind: 'unsupported', description: `${ROOM_MESSAGE_EVENT_TYPE}:${String(content.msgtype)}` };
   }
   if (typeof content.body !== 'string') {


### PR DESCRIPTION
## Summary

Attachments over the Matrix media repository, on both platform halves. Media has **never** worked in Allo — the six `AttachmentMenu` handlers were TODOs, there was no upload endpoint, and the old schema embedded file ciphertext in the message document against a 16 MB BSON limit. This is not a migration; it is the feature existing for the first time.

The web half is where encrypting is Allo's own job: the native SDK's `Timeline.sendImage` reads the room's encryption state inside Rust and encrypts accordingly, but the JS path does not, so encryption is decided explicitly from the room's state and nothing else — `encrypted` encrypts then uploads the ciphertext and sends a `file`; `unencrypted` uploads as-is and sends a `url`; **unknown refuses**, rather than guessing and silently shipping a private photograph in the clear.

## Test plan

- `bunx jest --watchAll=false` in `packages/frontend`: **40 suites, 573 tests, 573 passed** (baseline on `fd4bfc8` was 36 / 498).
- `tsc --noEmit`: 0 errors.
- **Mutation-tested** on the security property that matters:
  | Mutation | Result |
  |---|---|
  | unknown-encryption room uploads in the clear instead of throwing | 3 failed |
  | encrypted room uploads the plaintext bytes | 11 failed |
  | restored | 573 passed |
- No `as any`, `@ts-ignore`, `!`, `console.log`, `useEffect` or TODO in the diff.

## What this does NOT do

Recorded in `docs/matrix/ui-wiring.md` rather than left implied — the transport works, several consumers do not exist yet:

- An attachment cannot be opened full-size; the bubble draws the thumbnail and there is no viewer (new UI for both backends, not wiring for this one).
- A voice note sends and arrives as `m.audio` with its attachment, but there is no player.
- A video recorded in Allo goes without a thumbnail: `expo-image-manipulator` reads images, not frames.
- Documents, location, contact and poll remain unimplemented in `AttachmentMenu` — the port can already send an `m.file`.
- Nobody calls `createRoom`, and an externally revoked session is not noticed until the next start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)