### PR TITLE
fix(api): read the status the Oxy client actually wrote

### DIFF
--- a/packages/frontend/__tests__/circuitBreaker.test.ts
+++ b/packages/frontend/__tests__/circuitBreaker.test.ts
@@ -147,3 +147,41 @@ describe('CircuitBreaker', () => {
     });
   });
 });
+
+/**
+ * The Oxy client writes the status in two places and not every path writes both.
+ * A breaker that cannot read one of them counts an ordinary 404 as an outage —
+ * which is exactly what took `profile/design/:id` down in production.
+ */
+describe('CircuitBreaker against real Oxy client error shapes', () => {
+  /** `HttpService` sets both `status` and `response` on the thrown Error. */
+  function oxyHttpError(status: number): Error {
+    return Object.assign(new Error(`HTTP ${status}: `), {
+      status,
+      response: { status, statusText: '' },
+    });
+  }
+
+  /** The XHR upload path carries only `status`; there is no `response` beside it. */
+  function oxyStatusOnlyError(status: number): Error {
+    return Object.assign(new Error(`HTTP ${status}: `), { status });
+  }
+
+  it('stays closed through 404s that carry both status and response', async () => {
+    const breaker = makeBreaker();
+    await failWith(breaker, oxyHttpError(404), THRESHOLD * 2);
+    expect(breaker.getState()).toBe('closed');
+  });
+
+  it('stays closed through 404s that carry only status', async () => {
+    const breaker = makeBreaker();
+    await failWith(breaker, oxyStatusOnlyError(404), THRESHOLD * 2);
+    expect(breaker.getState()).toBe('closed');
+  });
+
+  it('still opens on a 503 that carries only status', async () => {
+    const breaker = makeBreaker();
+    await failWith(breaker, oxyStatusOnlyError(503), THRESHOLD);
+    expect(breaker.getState()).toBe('open');
+  });
+});

--- a/packages/frontend/components/ContactDetails.tsx
+++ b/packages/frontend/components/ContactDetails.tsx
@@ -50,7 +50,8 @@ function ParticipantItem({
       if (participant.username) {
         usersStore.ensureByUsername(participant.username, (u: string) => oxyServices.getProfileByUsername(u));
       } else if (participant.id) {
-        usersStore.ensureById(participant.id, (id: string) => oxyServices.getProfileByUsername(id));
+        // By id, so `getUserById`. The by-username endpoint 404s on an account id.
+        usersStore.ensureById(participant.id, (id: string) => oxyServices.getUserById(id));
       }
     }
   }, [participant.username, participant.id, participantUser, usersStore, oxyServices]);
@@ -195,7 +196,8 @@ export function ContactDetails({
       if (otherParticipant.username) {
         usersStore.ensureByUsername(otherParticipant.username, (u) => oxyServices.getProfileByUsername(u));
       } else if (otherParticipant.id) {
-        usersStore.ensureById(otherParticipant.id, (id) => oxyServices.getProfileByUsername(id));
+        // By id, so `getUserById`. The by-username endpoint 404s on an account id.
+        usersStore.ensureById(otherParticipant.id, (id) => oxyServices.getUserById(id));
       }
     }
   }, [isGroup, otherParticipant, contactUser, usersStore, oxyServices]);

--- a/packages/frontend/hooks/useSenderInfo.ts
+++ b/packages/frontend/hooks/useSenderInfo.ts
@@ -16,8 +16,10 @@ export function useSenderInfo(
     if (conversation?.participants) {
       conversation.participants.forEach((p) => {
         if (p.id && p.id !== user?.id) {
-          // Try to fetch by ID (assuming getProfileByUsername handles IDs as per docs)
-          usersStore.ensureById(p.id, (id) => oxyServices.getProfileByUsername(id));
+          // `getUserById`, not `getProfileByUsername`. A participant id is an
+          // Oxy account id, and the by-username endpoint 404s on one — which it
+          // did, once per participant per render, in production.
+          usersStore.ensureById(p.id, (id) => oxyServices.getUserById(id));
         }
       });
     }

--- a/packages/frontend/utils/errors.ts
+++ b/packages/frontend/utils/errors.ts
@@ -8,6 +8,7 @@
 
 /** Shape of an Axios-like HTTP error response (only the fields we read). */
 interface HttpErrorShape {
+  status?: number;
   response?: {
     status?: number;
     data?: { message?: string } | unknown;
@@ -21,11 +22,30 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-/** Returns the HTTP status code from an Axios-like error, or undefined. */
+/**
+ * Returns the HTTP status code from an HTTP error, or undefined.
+ *
+ * Two places, because the Oxy client writes two. `HttpService` sets `status` on
+ * the error AND a `response` object beside it, but not every path through it
+ * builds both — the XHR upload path carries only `status`. Reading `response`
+ * alone therefore reports "no status" for a request that failed with a perfectly
+ * ordinary 404, and a caller that treats a missing status as "not a client
+ * error" then draws the opposite conclusion from the truth.
+ *
+ * That is not hypothetical: it opened the circuit breaker on
+ * `profile/design/:id` in production, taking out an endpoint the server was
+ * answering correctly. `error.status` is checked first because it is the one
+ * every path sets. Homiio's `savedPropertiesApi` reads both for the same reason.
+ */
 export function getHttpStatus(error: unknown): number | undefined {
   const record = asRecord(error);
-  const response = record ? asRecord(record.response) : null;
-  const status = response?.status;
+  if (!record) {
+    return undefined;
+  }
+  if (typeof record.status === 'number') {
+    return record.status;
+  }
+  const status = asRecord(record.response)?.status;
   return typeof status === 'number' ? status : undefined;
 }
 


### PR DESCRIPTION
## Summary

Production log:

```
[Circuit Breaker] Opened for profile/design/:id after 6 failures. Last error: HTTP 404
```

An endpoint the server was answering correctly, taken out of service by its own answers. #65 added per-endpoint breakers *and* the rule that a 4xx is not an outage. The first worked — the key in that message is the new one. The second did not fire, and this is why.

**`getHttpStatus` read `error.response.status` only.** `HttpService` (in `@oxyhq/core`) sets `status` on the thrown error **and** a `response` object beside it — but not every path through it builds both; the XHR path carries only `status`. So the breaker saw "no status", could not conclude this was an ordinary client error, and counted it as a service failure. Six of those and the circuit opened.

Homiio's `savedPropertiesApi` already reads both (`error?.status === 404 || error?.response?.status === 404`) against the same client. This does the same, checking `error.status` first because it is the one every path sets.

## Also fixed: the 404s themselves

The same log shows the storm that fed the breaker:

```
GET https://api.oxy.so/profiles/username/69d17f33fcb7737ee4b03ddf 404
```

That is an **account id** being handed to a **by-username** lookup. `usersStore.ensureById` takes a caller-supplied loader, and three call sites passed `getProfileByUsername` — under a comment reading *"assuming getProfileByUsername handles IDs as per docs"*. It does not. Fires once per participant per render.

`app/(chat)/c/[id].tsx:89` already used `getUserById`; `hooks/useSenderInfo.ts` and both branches in `components/ContactDetails.tsx` now match it.

## Test plan

- 3 new tests built from the **two real error shapes** the Oxy client throws, not an idealised one: status+response, and status-only.
- **Mutation-verified**: restoring the `response`-only read fails the status-only 404 case and nothing else — the production bug exactly. (`1 failed, 19 passed` → restored `20 passed`.)
- Full frontend suite: **66 suites / 915 tests** passing (was 66 / 912).
- `tsc --noEmit`: no errors in any touched file. 13 pre-existing errors remain elsewhere — the broken navigation targets already reported, which CI structurally cannot see because `.expo/types/router.d.ts` is generated and gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)