### PR TITLE
feat(deploy): ship the Matrix client, against matrix.org for now

### DIFF
--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -31,6 +31,26 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
+          # EXPO_PUBLIC_* is substituted at build time, so these are baked into
+          # the bundle here and cannot be changed without another build.
+          #
+          # Matrix, not the Express backend. The old transport's encryption is
+          # static ECDH with no KDF (docs/encryption.mdx) and its groups,
+          # multi-device and media never worked; this is the cut.
+          EXPO_PUBLIC_CHAT_BACKEND: matrix
+          # matrix.org, NOT our homeserver — that one is blocked on an IAM trust
+          # policy (oxy-infra, design doc §11.3 step 3). The trade is written
+          # down in docs/matrix/interim-homeserver.md and the important half is:
+          # `server_name` is permanent per room and per event, so accounts and
+          # conversations made here DO NOT migrate to allo.you later.
+          #
+          # This is the `m.homeserver.base_url` matrix.org publishes, not the
+          # apex. Dynamic client registration against it was exercised with this
+          # client's own payload shape and returned HTTP 201, so no
+          # EXPO_PUBLIC_MATRIX_OIDC_CLIENT_ID is needed; the redirect URI
+          # defaults to https://allo.you/matrix-oidc-callback.html, which is a
+          # real file in public/ and deliberately not a route of the app.
+          EXPO_PUBLIC_MATRIX_HOMESERVER: https://matrix-client.matrix.org
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary

Five phases of client work are merged and **none of it has ever run**: `EXPO_PUBLIC_CHAT_BACKEND` was unset, so every build shipped the Express backend — the one whose encryption is static ECDH with no KDF, whose groups encrypt only for the first participant, and whose media never worked. This turns the Matrix client on.

**The homeserver is `matrix.org`, not ours.** Ours is blocked on an IAM trust policy nobody on the development side can grant (`oxy-github-deploy` does not trust `repo:OxyHQ/oxy-infra:*` — confirmed by the single run of `build-allo-matrix.yml` failing on assume-role). The client never required the homeserver to be ours.

**What it costs**, in full in `docs/matrix/interim-homeserver.md`: `server_name` is permanent per room and per event, so accounts and conversations created now **do not migrate to `allo.you` later**. No Oxy SSO. Metadata on their server. MXID-anchored moderation stops resolving to Oxy accounts.

Two variables; no code changes. No OIDC client id is needed — dynamic registration against `account.matrix.org` was exercised with this client's own payload shape and returned `HTTP 201` — and the redirect URI defaults to `https://allo.you/matrix-oidc-callback.html`, a real file in `public/` and deliberately not a route of the app.

## Verification, and why it mattered

Built the web export with these values and **read the output** instead of trusting the exit code:

- entry chunk contains `matrix-client.matrix.org`
- it calls `parseChatBackend("matrix")` — the substituted literal, not the `undefined` that falls back to `allo-api`
- `dist/matrix-oidc-callback.html` and the 7.8 MB `matrix_sdk_crypto_wasm_bg.wasm` are both present

**The first build passed, exported cleanly, and inlined neither value.** Metro had cached the transforms from a build made before these variables existed, so the bundle would have called `parseChatBackend(undefined)` and quietly selected the old backend while looking entirely correct. CI checks out fresh and installs from scratch so it has no such cache; a local `bun run build` does, and needs `--clear`.

## What is still unproven

The OIDC **code exchange**. It needs a person consenting in a browser and cannot be exercised from a terminal. This deploy is how it gets exercised — expect the first failure there, not in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)