### PR TITLE
revert(deploy): do not ship Allo against somebody else's homeserver

### DIFF
--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -31,26 +31,40 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
-          # EXPO_PUBLIC_* is substituted at build time, so these are baked into
-          # the bundle here and cannot be changed without another build.
+          # EXPO_PUBLIC_* is substituted at build time, so anything set here is
+          # baked into the bundle and cannot be changed without another build.
           #
-          # Matrix, not the Express backend. The old transport's encryption is
-          # static ECDH with no KDF (docs/encryption.mdx) and its groups,
-          # multi-device and media never worked; this is the cut.
-          EXPO_PUBLIC_CHAT_BACKEND: matrix
-          # matrix.org, NOT our homeserver — that one is blocked on an IAM trust
-          # policy (oxy-infra, design doc §11.3 step 3). The trade is written
-          # down in docs/matrix/interim-homeserver.md and the important half is:
-          # `server_name` is permanent per room and per event, so accounts and
-          # conversations made here DO NOT migrate to allo.you later.
+          # THE MATRIX CLIENT IS BUILT AND NOT TURNED ON. Setting
+          # EXPO_PUBLIC_CHAT_BACKEND to `matrix` needs a homeserver, and the
+          # only one available today would be somebody else's.
           #
-          # This is the `m.homeserver.base_url` matrix.org publishes, not the
-          # apex. Dynamic client registration against it was exercised with this
-          # client's own payload shape and returned HTTP 201, so no
-          # EXPO_PUBLIC_MATRIX_OIDC_CLIENT_ID is needed; the redirect URI
-          # defaults to https://allo.you/matrix-oidc-callback.html, which is a
-          # real file in public/ and deliberately not a route of the app.
-          EXPO_PUBLIC_MATRIX_HOMESERVER: https://matrix-client.matrix.org
+          # It was pointed at matrix.org for about an hour and taken back off on
+          # purpose. `server_name` is permanent per room and per event, so every
+          # account and conversation made against a foreign homeserver is one
+          # that cannot be moved to allo.you afterwards — the identity is the
+          # point of this migration, not a detail of it. An hour of working
+          # chat is not worth a family's account history landing somewhere it
+          # can never leave.
+          #
+          # To turn it on, add both of these and nothing else:
+          #
+          #   EXPO_PUBLIC_CHAT_BACKEND: matrix
+          #   EXPO_PUBLIC_MATRIX_HOMESERVER: https://<host serving the CS API>
+          #
+          # No OIDC client id is needed (dynamic registration is exercised and
+          # works) and the redirect URI defaults to
+          # https://allo.you/matrix-oidc-callback.html, a real file in public/.
+          #
+          # The homeserver does NOT have to live at matrix.allo.you, and does
+          # not even have to be in AWS. `server_name` is what decides the MXIDs,
+          # and delegation from allo.you/.well-known/matrix/server — a file this
+          # repository serves — is what points the world at wherever it runs.
+          # What is genuinely missing is a running Synapse + MAS, nothing else.
+          #
+          # Verify the result rather than the exit code: build once with
+          # `--clear`, because Metro caches transforms and will happily produce
+          # a bundle where neither variable was substituted, and then check that
+          # the entry chunk really calls parseChatBackend("matrix").
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary

I pointed production at `matrix.org` an hour ago (#77) to get chat working today. **That was the wrong trade**, and the owner said so immediately.

`server_name` is permanent per room and per event. Every account and conversation created against a foreign homeserver cannot be moved to `allo.you` afterwards. So the price of an hour of working chat is a family's account history landing somewhere it can never leave — and the `allo.you` identity is the *point* of this migration, not a detail of it. I optimised for "working soon" against what was actually asked for.

This puts the app back where it was this morning: the Express backend, still broken, but no longer accumulating accounts that have to be thrown away.

## One correction worth keeping

The replacement comment fixes something I had been repeating: **the homeserver does not have to live at `matrix.allo.you`, and does not have to be in AWS.**

`server_name` is what decides the MXIDs, and delegation from `allo.you/.well-known/matrix/server` — a static file *this repository serves* — is what points the world at wherever it actually runs. So the missing piece is narrower than "the Terraform apply, DNS and certificates": it is a running Synapse + MAS, anywhere reachable. Everything else is a file I can write.

Turning it back on is two variables, documented in place, with the note that Metro's transform cache will silently produce a bundle where neither was substituted unless the build is run with `--clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)