### PR TITLE
ci: ask whether the deploy role can widen its own trust policy

### DIFF
--- a/.github/workflows/iam-trust-probe.yml
+++ b/.github/workflows/iam-trust-probe.yml
@@ -1,0 +1,96 @@
+# Temporary: can this role widen its own trust policy?
+#
+# `oxy-github-deploy` trusts repo:OxyHQ/Allo:* and not repo:OxyHQ/oxy-infra:*,
+# which is the single thing blocking the Allo Matrix homeserver from being
+# applied. The owner asked for that change to be made for them, so this asks the
+# only question that decides whether it can be: does the role this repository
+# already assumes have iam:GetRole and iam:UpdateAssumeRolePolicy on itself?
+#
+# `read` changes nothing. `add-oxy-infra` is strictly additive — it reads the
+# current policy, appends one `sub` value, and writes it back. It never replaces
+# the document, because dropping repo:OxyHQ/Allo:* would lock this repository
+# out of its own deploys.
+#
+# Note for whoever finds this later: a deploy role being able to edit its own
+# trust policy is a privilege-escalation path, not a convenience. If the answer
+# below is yes, that is a finding to fix, not a tool to keep.
+name: IAM trust probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'read inspects only. add-oxy-infra edits the trust policy.'
+        type: choice
+        options: [read, add-oxy-infra]
+        default: read
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (OIDC, no stored keys)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
+          aws-region: us-west-2
+
+      - name: Can it read its own role?
+        id: read
+        run: |
+          if aws iam get-role --role-name oxy-github-deploy \
+               --query 'Role.AssumeRolePolicyDocument' --output json > policy.json 2>err.txt; then
+            echo "readable=true" >> "$GITHUB_OUTPUT"
+            echo "iam:GetRole — ALLOWED"
+            python3 - <<'PY'
+          import json
+          d = json.load(open('policy.json'))
+          for s in d.get('Statement', []):
+              for op, conds in (s.get('Condition') or {}).items():
+                  for k, v in conds.items():
+                      if k.endswith(':sub'):
+                          print(f'  {op} {k} = {v}')
+          PY
+          else
+            echo "readable=false" >> "$GITHUB_OUTPUT"
+            echo "iam:GetRole — DENIED"
+            sed 's/[A-Za-z0-9]\{20,\}/<redacted>/g' err.txt
+          fi
+
+      - name: Add repo:OxyHQ/oxy-infra:* to the trust policy
+        if: inputs.action == 'add-oxy-infra' && steps.read.outputs.readable == 'true'
+        run: |
+          python3 - <<'PY'
+          import json
+          d = json.load(open('policy.json'))
+          want = 'repo:OxyHQ/oxy-infra:*'
+          changed = False
+          for s in d.get('Statement', []):
+              for op, conds in (s.get('Condition') or {}).items():
+                  for k, v in list(conds.items()):
+                      if not k.endswith(':sub'):
+                          continue
+                      vals = v if isinstance(v, list) else [v]
+                      if want in vals:
+                          print('already present, nothing to do')
+                          continue
+                      conds[k] = vals + [want]
+                      changed = True
+                      print('adding to', k, '->', conds[k])
+          if not changed:
+              raise SystemExit('no :sub condition to extend — refusing to guess at the shape')
+          json.dump(d, open('new-policy.json', 'w'))
+          PY
+          if aws iam update-assume-role-policy --role-name oxy-github-deploy \
+               --policy-document file://new-policy.json 2>err.txt; then
+            echo "iam:UpdateAssumeRolePolicy — ALLOWED, trust policy widened"
+          else
+            echo "iam:UpdateAssumeRolePolicy — DENIED"
+            sed 's/[A-Za-z0-9]\{20,\}/<redacted>/g' err.txt
+            exit 1
+          fi


### PR DESCRIPTION
Read-only by default. Answers the one question blocking the homeserver: can `oxy-github-deploy`, which this repository already assumes via OIDC, edit its own trust policy to also trust `repo:OxyHQ/oxy-infra:*`?

If yes, the Matrix homeserver can be applied without anyone opening the AWS console — and that answer is *also* a security finding worth fixing, since a deploy role rewriting its own trust policy is a privilege-escalation path.

The edit is strictly additive: it reads the current document, appends one `sub` value, writes it back, and refuses if it cannot find a `:sub` condition to extend. Replacing the document would drop `repo:OxyHQ/Allo:*` and lock this repository out of its own deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)