### PR TITLE
fix(appearance): ask for a route the backend actually has

### DIFF
--- a/packages/frontend/__tests__/appearanceEndpoint.test.ts
+++ b/packages/frontend/__tests__/appearanceEndpoint.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The appearance store asked for `profile/design/:userId`, a route the backend
+ * has never had. It 404ed for every user on every render, and the catch around
+ * it returned null — which is exactly what "this user has no custom appearance"
+ * looks like, so nothing ever surfaced it. It reached production and stayed.
+ *
+ * A unit test cannot catch that: mock the client and a wrong URL passes. What
+ * catches it is comparing the two sides, so this reads the store's calls and the
+ * backend's routes and asserts every path the store asks for is one the backend
+ * serves.
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const STORE = join(REPO_ROOT, 'packages/frontend/stores/appearanceStore.ts');
+const ROUTES = join(REPO_ROOT, 'packages/backend/src/routes/profileSettings.ts');
+
+/** Every `api.<verb>('profile/...')` the store performs, as a path. */
+function pathsTheStoreCalls(): string[] {
+  const source = readFileSync(STORE, 'utf8');
+  const calls = source.matchAll(/api\.\w+<[^>]*>\(\s*[`'"]([^`'"]+)[`'"]/g);
+  return [...calls].map(([, path]) => path);
+}
+
+/** Every path `profileSettings.ts` registers, mounted under `/profile`. */
+function pathsTheBackendServes(): string[] {
+  const source = readFileSync(ROUTES, 'utf8');
+  const routes = source.matchAll(/router\.\w+\(\s*'([^']+)'/g);
+  return [...routes].map(([, path]) => `profile${path}`);
+}
+
+/** `profile/settings/${userId}` and `profile/settings/:userId` are the same route. */
+function normalise(path: string): string {
+  return path.replace(/\$\{[^}]+\}/g, ':param').replace(/:[A-Za-z_]\w*/g, ':param');
+}
+
+describe('the appearance store only asks for routes that exist', () => {
+  it('finds calls and routes to compare', () => {
+    // Guards the test itself: a regex that silently matches nothing would make
+    // every assertion below vacuously true.
+    expect(pathsTheStoreCalls().length).toBeGreaterThanOrEqual(3);
+    expect(pathsTheBackendServes().length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('has a backend route for every path it requests', () => {
+    const served = new Set(pathsTheBackendServes().map(normalise));
+    const missing = pathsTheStoreCalls().filter((p) => !served.has(normalise(p)));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('reads another user by their id, not by a route that never existed', () => {
+    const calls = pathsTheStoreCalls().map(normalise);
+
+    expect(calls).toContain('profile/settings/:param');
+    expect(calls.some((p) => p.includes('design'))).toBe(false);
+  });
+});

--- a/packages/frontend/stores/appearanceStore.ts
+++ b/packages/frontend/stores/appearanceStore.ts
@@ -103,7 +103,12 @@ export const useAppearanceStore = create<AppearanceStore>((set, get) => ({
       const cached = get().byUserId[userId];
       if (cached && !forceRefresh) return cached;
       
-      const res = await api.get<UserAppearance>(`profile/design/${userId}`);
+      // `settings`, not `design`. There has never been a /profile/design route
+      // on the backend, so this 404ed for every user on every render — and the
+      // catch below returned null, which is indistinguishable from "this user
+      // has no custom appearance". `ensureUserSettings` creates a default, so
+      // the real endpoint answers 200 for anyone.
+      const res = await api.get<UserAppearance>(`profile/settings/${userId}`);
       const doc = unwrapApiData<UserAppearance>(res.data);
       
       if (doc) {
@@ -114,6 +119,12 @@ export const useAppearanceStore = create<AppearanceStore>((set, get) => ({
       
       return doc ?? null;
     } catch (e) {
+      // Appearance is decoration: a caller that cannot read it draws the
+      // default and the conversation still works, so this returns null rather
+      // than propagating. It does not stay quiet about it — swallowing the
+      // failure is what let a permanently wrong URL look like "no custom
+      // appearance" for as long as it did.
+      console.warn(`[Appearance] Could not load appearance for ${userId}:`, getErrorMessage(e));
       return null;
     }
   },


### PR DESCRIPTION
## Summary

```
api.allo.you/api/profile/design/6981c9178fcdefaf81988ffb  404
api.allo.you/api/profile/design/69b2d3df5d12f58c9800d651  404
```

`loadForUser` fetched `profile/design/:userId`. **No such route has ever existed.** `profileSettings.ts` serves `/settings/me`, `/settings/:userId`, `/settings`, `/blocks` and `/restricts` — nothing named `design`. So it 404ed for every user on every render, and `useAvatarShape` calls it once per avatar.

It survived because the `catch` returned `null`, which is exactly what *"this user has no custom appearance"* looks like. The store's other two calls (`profile/settings/me`, `profile/settings`) were right all along; this one was the odd one out.

`/settings/:userId` returns what `UserAppearance` declares — the model carries `appearance` and `profileCustomization` — and `ensureUserSettings` creates a default, so it answers 200 for anyone rather than 404ing for someone who has never set one.

The catch still returns `null`, because appearance is decoration and a conversation works without it, but it no longer does so silently.

## Test plan

The test **compares the two sides** instead of mocking one: it reads the paths the store requests and the routes the backend registers, and asserts every requested path is served. A unit test could not have caught this — mock the client and any URL passes.

- 3 new tests, including one that guards the test itself (a regex matching nothing would make the others vacuously true).
- **Mutation-verified**: putting `design` back fails 2 of the 3.
- Full frontend suite: **76 suites / 1076 tests** passing.
- `tsc --noEmit`: no errors in touched files; the 13 pre-existing ones are the broken navigation targets already reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
