### PR TITLE
feat(web): serve the Matrix delegation for allo.you

### DIFF
--- a/packages/frontend/public/.well-known/matrix/client
+++ b/packages/frontend/public/.well-known/matrix/client
@@ -1,0 +1,7 @@
+{
+  "m.homeserver": { "base_url": "https://matrix.allo.you" },
+  "org.matrix.msc2965.authentication": {
+    "issuer": "https://auth.allo.you/",
+    "account": "https://auth.allo.you/account/"
+  }
+}

--- a/packages/frontend/public/.well-known/matrix/server
+++ b/packages/frontend/public/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{ "m.server": "matrix.allo.you:443" }

--- a/packages/frontend/public/_headers
+++ b/packages/frontend/public/_headers
@@ -9,3 +9,21 @@
 # ETag makes a repeat visit a conditional request, not another download.
 /matrix_sdk_crypto_wasm_bg.wasm
   Cache-Control: public, max-age=0, must-revalidate
+
+# The Matrix delegation files have no extension, so nothing infers a type for
+# them and they would go out as octet-stream. The spec asks for JSON, and a
+# federating server that cannot parse the answer falls through to the SRV
+# record — which does not exist here.
+#
+# `_redirects` sends unmatched paths to index.html, but real assets are served
+# before that rule is consulted, so these files win. They did not exist until
+# now, which is why that path used to answer 200 with HTML.
+/.well-known/matrix/server
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600
+
+/.well-known/matrix/client
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600

--- a/packages/frontend/public/_redirects
+++ b/packages/frontend/public/_redirects
@@ -1,28 +1,21 @@
 # Expo Router is a single-page app: every route is resolved in the browser, so
 # any path that is not a real file has to be answered with the shell.
 #
-# BEFORE FEDERATION IS OPENED, READ THIS.
+# The Matrix delegation is no longer a trap here, and this note stays so it does
+# not become one again.
 #
 # `server_name` is `allo.you` while the homeserver answers at `matrix.allo.you`,
-# so remote servers resolve it by requesting
+# so a remote server resolves it by requesting
 # `https://allo.you/.well-known/matrix/server` — a path served by THIS project,
-# not by the homeserver's load balancer.
+# not by the homeserver's load balancer. Both delegation files now exist under
+# `public/.well-known/matrix/`, and `public/_headers` gives them
+# `Content-Type: application/json`, which they need because neither has an
+# extension for anything to infer a type from.
 #
-# The rule below answers it with `index.html` and status **200**. That is worse
-# than serving nothing: the server-server resolution algorithm falls through to
-# the `_matrix-fed._tcp` SRV record when the well-known request fails, and a 200
-# carrying HTML is not a failure it can detect cleanly — it is a successful
-# response that happens not to be the JSON anyone wanted. The homeserver design
-# doc reasons from "on a non-200 it falls through", which does not hold here.
-#
-# So opening federation means adding, ABOVE this rule, a real
-# `/.well-known/matrix/server` returning `{"m.server":"matrix.allo.you:443"}`
-# with `Content-Type: application/json` — as a static file, a `_worker.js`, or a
-# Cloudflare redirect rule. Serving it on 443 through the existing ALB means
-# port 8448 is never needed.
-#
-# `/.well-known/matrix/client` is not needed by Allo itself, which is told where
-# its homeserver is by `EXPO_PUBLIC_MATRIX_HOMESERVER` and never asks. It is
-# needed only if a third-party Matrix client should be able to sign in to an
-# `@…:allo.you` account.
+# Real assets are served before the rule below is consulted, so those files win.
+# Delete them and this rule answers those paths with `index.html` and status
+# **200**, which is worse than serving nothing: server-server resolution falls
+# through to the `_matrix-fed._tcp` SRV record when the well-known request
+# *fails*, and a 200 carrying HTML is a success that happens not to be the JSON
+# anyone wanted. There is no SRV record to fall through to.
 /*  /index.html  200


### PR DESCRIPTION
## Summary

`server_name` is `allo.you` while the homeserver answers at `matrix.allo.you`, so both remote servers and third-party clients resolve it by asking **this project** — not the homeserver's load balancer. Until now those paths answered with `index.html` and status 200, because the SPA rule catches anything that is not a real file, and there was no real file.

- `.well-known/matrix/server` — `{"m.server": "matrix.allo.you:443"}`. This is what makes `@someone:allo.you` addressable from outside once federation opens.
- `.well-known/matrix/client` — homeserver base URL plus the MSC2965 authentication block pointing at `auth.allo.you`. Allo itself does not need it (it is told where its homeserver is at build time and never asks); it is what lets a third-party Matrix client sign in to an `allo.you` account.

`_headers` gives both `Content-Type: application/json` — neither has an extension for anything to infer a type from — plus a permissive CORS header so a browser-based client can read the client document.

## On the SPA rule

Real assets are served before `_redirects` is consulted, so these files win. The note there is rewritten to say so, and to keep saying why deleting them would be worse than never having added them: server-server resolution falls through to `_matrix-fed._tcp` when the well-known request *fails*, and a 200 carrying HTML is a success that happens not to be JSON. There is no SRV record to fall through to.

## Verification

Production `expo export`: both files land in `dist/.well-known/matrix/` with their content intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
