### PR TITLE
feat(deploy): ship Allo against its own homeserver

### DIFF
--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -31,40 +31,37 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
-          # EXPO_PUBLIC_* is substituted at build time, so anything set here is
-          # baked into the bundle and cannot be changed without another build.
+          # EXPO_PUBLIC_* is substituted at build time, so these are baked
+          # into the bundle and cannot be changed without another build.
           #
-          # THE MATRIX CLIENT IS BUILT AND NOT TURNED ON. Setting
-          # EXPO_PUBLIC_CHAT_BACKEND to `matrix` needs a homeserver, and the
-          # only one available today would be somebody else's.
+          # Matrix, on our own homeserver. The Express backend it replaces
+          # encrypts with static ECDH and no KDF, encrypts groups only for the
+          # first participant, and never had working media — see
+          # docs/encryption.mdx for what it actually does versus what its
+          # filenames claim.
+          EXPO_PUBLIC_CHAT_BACKEND: matrix
+          # allo.you, not matrix.allo.you: `server_name` is what decides the
+          # MXIDs, and allo.you/.well-known/matrix/server — served from
+          # public/ in this repository — is what points the world at the host
+          # below. That is why accounts here read @someone:allo.you.
           #
-          # It was pointed at matrix.org for about an hour and taken back off on
-          # purpose. `server_name` is permanent per room and per event, so every
-          # account and conversation made against a foreign homeserver is one
-          # that cannot be moved to allo.you afterwards — the identity is the
-          # point of this migration, not a detail of it. An hour of working
-          # chat is not worth a family's account history landing somewhere it
-          # can never leave.
+          # This value is the client-server API host, which is a different
+          # thing from the server name and must not be confused with it.
+          EXPO_PUBLIC_MATRIX_HOMESERVER: https://matrix.allo.you
           #
-          # To turn it on, add both of these and nothing else:
+          # No OIDC client id: MAS advertises a registration_endpoint and the
+          # client registers itself, holding no secret. The one secret in this
+          # system belongs to MAS, which is a confidential client of Oxy and
+          # runs in ECS. The redirect URI defaults to
+          # https://allo.you/matrix-oidc-callback.html, a real file in public/
+          # and deliberately not a route of the app — a route would boot a
+          # second copy of Allo in the popup, and two MatrixClients on one
+          # IndexedDB is the crypto-store corruption the SDK warns about.
           #
-          #   EXPO_PUBLIC_CHAT_BACKEND: matrix
-          #   EXPO_PUBLIC_MATRIX_HOMESERVER: https://<host serving the CS API>
-          #
-          # No OIDC client id is needed (dynamic registration is exercised and
-          # works) and the redirect URI defaults to
-          # https://allo.you/matrix-oidc-callback.html, a real file in public/.
-          #
-          # The homeserver does NOT have to live at matrix.allo.you, and does
-          # not even have to be in AWS. `server_name` is what decides the MXIDs,
-          # and delegation from allo.you/.well-known/matrix/server — a file this
-          # repository serves — is what points the world at wherever it runs.
-          # What is genuinely missing is a running Synapse + MAS, nothing else.
-          #
-          # Verify the result rather than the exit code: build once with
-          # `--clear`, because Metro caches transforms and will happily produce
-          # a bundle where neither variable was substituted, and then check that
-          # the entry chunk really calls parseChatBackend("matrix").
+          # If you change either value, verify the OUTPUT rather than the exit
+          # code: Metro caches transforms and will happily produce a bundle
+          # where neither was substituted. CI installs from scratch so it has
+          # no such cache; a local `bun run build` does, and needs `--clear`.
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary

`matrix.allo.you` serves the client-server API. `auth.allo.you` serves MAS with Oxy as its upstream identity provider. Both answer from the public internet with an ISSUED certificate, and the OIDC metadata advertises a `registration_endpoint`.

Accounts read **`@someone:allo.you`** — `allo.you/.well-known/matrix/server` delegates to that host, and `server_name` is what decides the MXID.

This turns the client on. What it replaces encrypts with static ECDH and no KDF, encrypts a group only for its first participant, and never had working media.

## Two values, no secret

```
EXPO_PUBLIC_CHAT_BACKEND: matrix
EXPO_PUBLIC_MATRIX_HOMESERVER: https://matrix.allo.you
```

No OIDC client id: MAS advertises a `registration_endpoint` and the client registers itself, holding no secret. The one secret in this system belongs to MAS, which is a *confidential* client of Oxy and runs in ECS.

The redirect URI defaults to `https://allo.you/matrix-oidc-callback.html` — a real file in `public/`, deliberately not a route of the app. A route would boot a second copy of Allo inside the popup, and two `MatrixClient`s on one IndexedDB is the crypto-store corruption the SDK warns about.

## Note for whoever changes these next

Verify the **output**, not the exit code. Metro caches transforms and will happily produce a bundle where neither value was substituted — `parseChatBackend(undefined)` silently selects the old backend while the build looks entirely correct. CI installs from scratch so it has no such cache; a local `bun run build` does, and needs `--clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
