### PR TITLE
fix(web): load the crypto wasm through an entry Metro can bundle

### DIFF
--- a/packages/frontend/metro.config.js
+++ b/packages/frontend/metro.config.js
@@ -18,6 +18,48 @@ for (const ext of ['woff2', 'woff']) {
   }
 }
 
+// `@matrix-org/matrix-sdk-crypto-wasm` cannot be loaded through its ESM entry
+// here. `index.mjs` evaluates, at module scope:
+//
+//   const defaultURL = new URL("./pkg/matrix_sdk_crypto_wasm_bg.wasm", import.meta.url);
+//
+// Metro's web output gives `import.meta.url` no usable value, so that line throws
+// `Failed to construct 'URL': Invalid base URL` the moment the module is
+// imported — before `initAsync` is reached, which means passing an explicit URL
+// to `initAsync` does not avoid it. In production this surfaced as "Allo could
+// not start its Matrix client", with nothing pointing at the SDK.
+//
+// `index.cjs` is the same bindings without that line: its default is a
+// `require.resolve`, which Metro answers with a module id it never has to parse
+// as a URL. `lib/matrix/web/cryptoWasm.ts` passes the real URL explicitly, so
+// the default is never used either way.
+//
+// `.wasm` joins `assetExts` because that `require.resolve` has to resolve at
+// bundle time. The file Metro emits from it is unused — the copy the app
+// actually fetches is placed in `public/` by `scripts/copy-matrix-wasm.js`,
+// which every web script runs first.
+if (!config.resolver.assetExts.includes('wasm')) {
+  config.resolver.assetExts.push('wasm');
+}
+
+const CRYPTO_WASM = '@matrix-org/matrix-sdk-crypto-wasm';
+// Composed from the package directory rather than asked for as a subpath: the
+// package's `exports` map declares only `.`, so `require.resolve` of
+// `<pkg>/index.cjs` fails with ERR_PACKAGE_PATH_NOT_EXPORTED. Resolving the
+// entry and taking its directory sidesteps the map — `node.cjs` and `index.cjs`
+// are siblings at the package root.
+const CRYPTO_WASM_CJS = require('path').join(
+  require('path').dirname(require.resolve(CRYPTO_WASM)),
+  'index.cjs',
+);
+const upstreamResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (platform === 'web' && moduleName === CRYPTO_WASM) {
+    return context.resolveRequest(context, CRYPTO_WASM_CJS, platform);
+  }
+  return (upstreamResolveRequest ?? context.resolveRequest)(context, moduleName, platform);
+};
+
 // Enable NativeWind (v5) CSS support. `inlineVariables: false` keeps CSS custom
 // properties as runtime variables (required so Bloom's `BloomColorScope` token
 // aliases resolve at runtime instead of being inlined at build time); `inlineRem`


### PR DESCRIPTION
## Summary

Production:

```
[Allo] [ERROR] [chat] Allo could not start its Matrix client
TypeError: Failed to construct 'URL': Invalid base URL
```

Nothing in that message points at the SDK. The cause is `@matrix-org/matrix-sdk-crypto-wasm`'s ESM entry, which evaluates **at module scope**:

```js
const defaultURL = new URL("./pkg/matrix_sdk_crypto_wasm_bg.wasm", import.meta.url);
```

Metro's web output gives `import.meta.url` no usable value, so that line throws the moment the module is imported — **before `initAsync` is reached**. Passing an explicit URL to `initAsync`, which `lib/matrix/web/cryptoWasm.ts` already does, cannot avoid it: the default is computed whether or not it is used.

That file's own header anticipated a wasm-URL hazard and named the wrong one — it described a file fetched from a path that does not exist, which is an `initAsync` problem. This is a constructor at import time.

## Fix

Web resolves the package to `index.cjs`: the same bindings, whose default is a `require.resolve` — a module id Metro never has to parse as a URL.

The path is composed from the package directory rather than requested as a subpath, because the `exports` map declares only `.` and asking for `<pkg>/index.cjs` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `.wasm` joins `assetExts` so that `require.resolve` resolves at bundle time; the asset Metro emits from it is unused, since the copy the app actually fetches is placed in `public/` by `scripts/copy-matrix-wasm.js`.

## Verification

Production web export with the real flags: build succeeds, **no `import.meta.url` survives anywhere in the output**, and the wasm bindings are present in the bundle. Suite unchanged at 76 / 1076; typecheck adds no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
