### PR TITLE
fix(web): our own crypto-wasm entry, because none of theirs bundles

### DIFF
--- a/packages/frontend/lib/matrix/web/cryptoWasmEntry.js
+++ b/packages/frontend/lib/matrix/web/cryptoWasmEntry.js
@@ -1,0 +1,73 @@
+/**
+ * The web entry for `@matrix-org/matrix-sdk-crypto-wasm`.
+ *
+ * Neither entry the package ships can be bundled by Metro, and both fail at
+ * MODULE SCOPE — before any of our code runs, so no argument passed to
+ * `initAsync` can prevent it:
+ *
+ *   index.mjs  `new URL("./pkg/…wasm", import.meta.url)`
+ *              Metro gives `import.meta.url` no usable value on web.
+ *              -> TypeError: Failed to construct 'URL': Invalid base URL
+ *
+ *   index.cjs  `require.resolve("./pkg/…wasm")`
+ *              Metro's runtime `require` has no `resolve`.
+ *              -> TypeError: r.resolve is not a function
+ *
+ * Both surfaced identically in production, as "Allo could not start its Matrix
+ * client", with nothing naming the SDK.
+ *
+ * This is index.mjs with the one hazardous line removed. Everything else is
+ * upstream's, including the import-object key `WebAssembly.instantiateStreaming`
+ * is given, which must match the name the wasm was compiled against.
+ *
+ * The difference: `initAsync` takes the URL and has no default. There is nothing
+ * to compute at import time, so there is nothing to go wrong before a caller
+ * arrives. `lib/matrix/web/cryptoWasm.ts` is that caller and already passes an
+ * explicit URL.
+ *
+ * `metro.config.js` maps the package to this file, and the bare specifier below
+ * to the package's generated wrappers — the package's `exports` map declares
+ * only `.`, so neither path can be written directly.
+ *
+ * When upstream is bundleable, delete this file and both mappings. Check
+ * whether that line still evaluates at module scope before doing so.
+ */
+
+// eslint-disable-next-line import/no-unresolved -- resolved by metro.config.js
+import * as bindings from 'matrix-sdk-crypto-wasm-bindings';
+
+/** @type {Promise<void> | null} */
+let modPromise = null;
+
+/**
+ * @param {URL | string} url
+ * @returns {Promise<void>}
+ */
+async function loadModuleAsync(url) {
+  const { instance } = await WebAssembly.instantiateStreaming(fetch(url), {
+    './matrix_sdk_crypto_wasm_bg.js': bindings,
+  });
+
+  bindings.__wbg_set_wasm(instance.exports);
+  instance.exports.__wbindgen_start();
+}
+
+/**
+ * Loads the WebAssembly module, once. Concurrent callers share one download.
+ *
+ * @param {URL | string} url Required, unlike upstream — see the note above.
+ * @returns {Promise<void>}
+ */
+export async function initAsync(url) {
+  if (url === undefined || url === '') {
+    throw new Error(
+      'initAsync needs the URL of matrix_sdk_crypto_wasm_bg.wasm. There is no ' +
+        'default here on purpose: computing one is what makes the upstream ' +
+        'entries fail to bundle.',
+    );
+  }
+  if (!modPromise) modPromise = loadModuleAsync(url);
+  await modPromise;
+}
+
+export * from 'matrix-sdk-crypto-wasm-bindings';

--- a/packages/frontend/metro.config.js
+++ b/packages/frontend/metro.config.js
@@ -18,44 +18,38 @@ for (const ext of ['woff2', 'woff']) {
   }
 }
 
-// `@matrix-org/matrix-sdk-crypto-wasm` cannot be loaded through its ESM entry
-// here. `index.mjs` evaluates, at module scope:
+// `@matrix-org/matrix-sdk-crypto-wasm` ships two entries and Metro can bundle
+// neither. Both fail at MODULE SCOPE, before any of our code runs, so no
+// argument to `initAsync` can prevent it:
 //
-//   const defaultURL = new URL("./pkg/matrix_sdk_crypto_wasm_bg.wasm", import.meta.url);
+//   index.mjs  `new URL("./pkg/…wasm", import.meta.url)` — Metro gives
+//              `import.meta.url` no usable value on web.
+//              -> Failed to construct 'URL': Invalid base URL
+//   index.cjs  `require.resolve("./pkg/…wasm")` — Metro's runtime `require`
+//              has no `resolve`.
+//              -> r.resolve is not a function
 //
-// Metro's web output gives `import.meta.url` no usable value, so that line throws
-// `Failed to construct 'URL': Invalid base URL` the moment the module is
-// imported — before `initAsync` is reached, which means passing an explicit URL
-// to `initAsync` does not avoid it. In production this surfaced as "Allo could
-// not start its Matrix client", with nothing pointing at the SDK.
+// Both reached production as "Allo could not start its Matrix client".
 //
-// `index.cjs` is the same bindings without that line: its default is a
-// `require.resolve`, which Metro answers with a module id it never has to parse
-// as a URL. `lib/matrix/web/cryptoWasm.ts` passes the real URL explicitly, so
-// the default is never used either way.
-//
-// `.wasm` joins `assetExts` because that `require.resolve` has to resolve at
-// bundle time. The file Metro emits from it is unused — the copy the app
-// actually fetches is placed in `public/` by `scripts/copy-matrix-wasm.js`,
-// which every web script runs first.
-if (!config.resolver.assetExts.includes('wasm')) {
-  config.resolver.assetExts.push('wasm');
-}
-
+// Web therefore uses our own entry, which is upstream's minus that one line.
+// Two mappings are needed rather than one because the package's `exports` map
+// declares only `.`: neither `<pkg>/index.cjs` nor `<pkg>/pkg/…_bg.js` can be
+// imported by path, and asking for either raises ERR_PACKAGE_PATH_NOT_EXPORTED.
+// Resolving the entry and walking up from it sidesteps the map.
+const path = require('path');
 const CRYPTO_WASM = '@matrix-org/matrix-sdk-crypto-wasm';
-// Composed from the package directory rather than asked for as a subpath: the
-// package's `exports` map declares only `.`, so `require.resolve` of
-// `<pkg>/index.cjs` fails with ERR_PACKAGE_PATH_NOT_EXPORTED. Resolving the
-// entry and taking its directory sidesteps the map — `node.cjs` and `index.cjs`
-// are siblings at the package root.
-const CRYPTO_WASM_CJS = require('path').join(
-  require('path').dirname(require.resolve(CRYPTO_WASM)),
-  'index.cjs',
-);
+const CRYPTO_WASM_BINDINGS = 'matrix-sdk-crypto-wasm-bindings';
+const cryptoWasmDir = path.dirname(require.resolve(CRYPTO_WASM));
+const cryptoWasmTargets = {
+  [CRYPTO_WASM]: path.join(__dirname, 'lib/matrix/web/cryptoWasmEntry.js'),
+  [CRYPTO_WASM_BINDINGS]: path.join(cryptoWasmDir, 'pkg/matrix_sdk_crypto_wasm_bg.js'),
+};
+
 const upstreamResolveRequest = config.resolver.resolveRequest;
 config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (platform === 'web' && moduleName === CRYPTO_WASM) {
-    return context.resolveRequest(context, CRYPTO_WASM_CJS, platform);
+  const target = platform === 'web' ? cryptoWasmTargets[moduleName] : undefined;
+  if (target !== undefined) {
+    return context.resolveRequest(context, target, platform);
   }
   return (upstreamResolveRequest ?? context.resolveRequest)(context, moduleName, platform);
 };


### PR DESCRIPTION
## Summary

The previous attempt (#85) traded one module-scope failure for another. All three of `@matrix-org/matrix-sdk-crypto-wasm`'s entries fail before any of our code runs, so **no argument to `initAsync` can prevent any of them**:

| entry | line | under Metro |
|---|---|---|
| `index.mjs` | `new URL("./pkg/…wasm", import.meta.url)` | `import.meta` becomes `globalThis.__ExpoImportMetaRegistry`, which has no `url` → **Failed to construct 'URL': Invalid base URL** |
| `index.cjs` | `require.resolve("./pkg/…wasm")` | Metro's runtime `require` has no `resolve` → **r.resolve is not a function** |
| `index-wasm-esm.mjs` | `await import("./pkg/…wasm")` | wasm-as-ES-module, which Metro does not implement |

Both of the first two reached production as *"Allo could not start its Matrix client"*, with nothing naming the SDK.

## Why this shape, and what I rejected

This is a workaround in a consuming app, which is normally the wrong answer. Two alternatives were considered first:

- **Populate `globalThis.__ExpoImportMetaRegistry` before the SDK loads.** Three lines and no duplicated code — but it depends on an undocumented Expo internal *and* on import ordering, since `client.web.ts:1` imports `initAsync` statically. Fragile in two directions at once.
- **`index-wasm-esm.mjs`.** Clean and needs no shim, but requires a bundler that treats `.wasm` as an ES module. Metro is not one.

So: upstream's `index.mjs` with the one hazardous line removed, and `initAsync` taking a **required** URL — nothing is computed at import time, so nothing can fail before a caller arrives. `lib/matrix/web/cryptoWasm.ts` already passes an explicit URL.

Two Metro mappings rather than one, because the package's `exports` map declares only `.`: neither `<pkg>/index.cjs` nor `<pkg>/pkg/…_bg.js` can be imported by path without `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## This should not be permanent

The real fix is upstream and small: make `defaultURL` lazy, inside `initAsync`, instead of computing it at module scope. I will raise that with the package. The file says so, and says to delete it and both mappings when upstream is bundleable.

## Verification

Production web export with the real flags: build succeeds, no `import.meta.url` anywhere in the output, shim present in the bundle. Suite unchanged at 76 / 1076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
