### PR TITLE
fix(docker): ship the patches directory, so the backend image can install at all

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -37,6 +37,14 @@ COPY packages/backend/package.json ./packages/backend/
 COPY packages/shared-types/package.json ./packages/shared-types/
 COPY packages/frontend/package.json ./packages/frontend/
 
+# The root manifest's `patchedDependencies` is read and RESOLVED before --filter
+# narrows anything, so every patch file it names must exist even when the patched
+# package belongs to a workspace this image never installs. `expo` is exactly
+# that: a frontend dependency, filtered out below, whose patch file bun still
+# insists on finding — without this line the install dies with
+# "Couldn't find patch file: 'patches/expo@57.0.6.patch'".
+COPY patches ./patches/
+
 # shared-types source must exist before install: the root "postinstall" script
 # builds it (bun run build:shared-types) as part of `bun install`.
 COPY packages/shared-types ./packages/shared-types/


### PR DESCRIPTION
The backend image has not built since the `expo` patch was introduced. Every `Deploy to AWS` run fails at `bun install --frozen-lockfile`:

```
error: Couldn't find patch file: 'patches/expo@57.0.6.patch'
```

Three consecutive deploys, going back before the recent dependency bumps.

## Why it happens

The root manifest's `patchedDependencies` is read and **resolved before `--filter` narrows anything**, so a patch file must exist even when the package it patches belongs to a workspace the image deliberately never installs. `expo` is exactly that case.

That is what makes the omission easy to make: the Dockerfile already copies every workspace manifest *because* `--frozen-lockfile` validates against all of them. The patch file needed the same reasoning applied one step further.

## Verification

Built the **real image** both ways:

- with `COPY patches ./patches/` → build completes through `bun run --cwd packages/shared-types build`
- with it reverted → dies at the same step with the identical CI error

Architecture is not a factor — the file is simply absent from the build context — so a native build proves the arm64 one.

`.dockerignore` does not exclude `patches/`, so no change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)