### PR TITLE
chore(deps): bloom 0.84.0 — four seeds retuned, and a brand can insist on a white label

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "allo",
       "dependencies": {
-        "@oxyhq/bloom": "^0.83.0",
+        "@oxyhq/bloom": "^0.84.0",
         "@oxyhq/contracts": "^0.24.0",
         "@oxyhq/core": "^19.1.2",
         "@oxyhq/services": "^27.1.3",
@@ -69,7 +69,7 @@
         "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@oxyhq/bloom": "^0.83.0",
+        "@oxyhq/bloom": "^0.84.0",
         "@oxyhq/contracts": "^0.24.0",
         "@oxyhq/core": "^19.1.2",
         "@oxyhq/expo-splash": "^0.1.0",
@@ -177,7 +177,7 @@
   },
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.3",
@@ -603,7 +603,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.83.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-SDpNU4wG8uN2NUmsDxnYX6NWXLPQpZyslZHJFpIAWTagKUGg4yL+8QMkcqOOSud0lU0GnylOX5y/BOvh/MeNBw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.84.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-P3kC+VbHSZB4FQJ3fIEZcw+QubnY3qLG44bTZqXJ67uQYMpdhe6H8kx6H5PI9AoPB9jCCMeV+k0U4uE63Nmiig=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.24.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-tAd+5USb1T+4CTZIUKBlkr/8WsRG/dyTFXPHwDd/4EQw5GW2GmgcvRnIHKt9+52JxMRTLKwi/sxNnor60036LA=="],
 
@@ -2886,10 +2886,6 @@
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "zxing-wasm": ["zxing-wasm@3.1.0", "", { "dependencies": { "@types/emscripten": "^1.41.5", "type-fest": "^5.7.0" } }, "sha512-5+3V1wPRx4gvbeLH2jB7n2cKrYJ1q4i3QgjnBUtrDPeqxJSi6BdzKJg4y6aF6bgW8zfntnYJyrkqFMevDhL2NA=="],
-
-    "@allo/backend/@allo/shared-types": ["@allo/shared-types@file:packages/shared-types", { "devDependencies": { "@types/node": "^24.9.2", "typescript": "^5.9.3" } }],
-
-    "@allo/frontend/@allo/shared-types": ["@allo/shared-types@file:packages/shared-types", { "devDependencies": { "@types/node": "^24.9.2", "typescript": "^5.9.3" } }],
 
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/services": "^27.1.3",
@@ -22,7 +22,7 @@
   ],
   "resolutions": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/services": "^27.1.3",
@@ -60,7 +60,7 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/services": "^27.1.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -53,7 +53,7 @@
     "@noble/ciphers": "^2.2.0",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@oxyhq/bloom": "^0.83.0",
+    "@oxyhq/bloom": "^0.84.0",
     "@oxyhq/contracts": "^0.24.0",
     "@oxyhq/core": "^19.1.2",
     "@oxyhq/expo-splash": "^0.1.0",


### PR DESCRIPTION
Bumps `@oxyhq/bloom` to 0.84.0.

Four preset seeds retuned — `yellow` (#ffd400), `orange` (#ff7a00), `pink` (#f91880), `blue` (#1d9bf0) — all carrying a **white** label in both modes.

`yellow` needed a mechanism, not just a seed. Dark's split used to be decided by seed lightness alone, and that rule cannot separate `yellow` (seed tone 86), which wants to become a deep gold with white on it, from `faircoin` (tone 90), which wants to stay a bright lime with black on it. Four tones apart, opposite answers, and nothing in either hex says which. So a preset can now **declare** `label: 'white'` and forgo the exemption.

The declaration is read from the seed hex rather than threaded as a parameter — a named preset is a fixed seed fed through the same policy, so seeding a scope with `preset.hex` has to reproduce the preset exactly. The first version passed it down from one caller and silently gave every other path a different yellow; Bloom's parity suites caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Verification** (against the published package): tests green in all 3 packages · typecheck reports the same 13 PRE-EXISTING expo-router route-type errors measured before this change, none from the bump.