### PR TITLE
fix(deps): restore the workspace links a --no-cache install dropped from bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2887,6 +2887,10 @@
 
     "zxing-wasm": ["zxing-wasm@3.1.0", "", { "dependencies": { "@types/emscripten": "^1.41.5", "type-fest": "^5.7.0" } }, "sha512-5+3V1wPRx4gvbeLH2jB7n2cKrYJ1q4i3QgjnBUtrDPeqxJSi6BdzKJg4y6aF6bgW8zfntnYJyrkqFMevDhL2NA=="],
 
+    "@allo/backend/@allo/shared-types": ["@allo/shared-types@file:packages/shared-types", { "devDependencies": { "@types/node": "^24.9.2", "typescript": "^5.9.3" } }],
+
+    "@allo/frontend/@allo/shared-types": ["@allo/shared-types@file:packages/shared-types", { "devDependencies": { "@types/node": "^24.9.2", "typescript": "^5.9.3" } }],
+
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@babel/core/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],


### PR DESCRIPTION
`Deploy Frontends` and `Deploy to AWS` both die at `bun install --frozen-lockfile`:

```
error: lockfile had changes, but lockfile is frozen
```

The lockfile committed with the Bloom 0.84.0 bump is missing two workspace-link entries — `@allo/backend/@allo/shared-types` and `@allo/frontend/@allo/shared-types` — so CI's reproduction of it does not match.

## Cause

The install that produced it: `bun install --no-cache`, used so bun would see a version published seconds earlier. Bypassing the cache also changes how it records `file:` workspace links.

This is invisible locally — every gate I ran used the already-populated tree, and `bun install --frozen-lockfile` was not among them. A plain `bun install` writes both entries back.

## Attribution, measured not assumed

`--frozen-lockfile` **passes** on the two commits before the bump and **fails** on the bump itself. That is what identifies it as introduced here rather than pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)