### PR TITLE
docs: rebuild the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,279 +1,206 @@
 # Allo
 
-> A modern, cross-platform chat app built with Expo, React Native, TypeScript, and a Node.js/Express backend in a monorepo structure.
+<p align="center">
+  <b>A cross platform chat app with end to end encrypted direct messages.</b><br>
+  One Expo codebase for iOS, Android and web, an Express and MongoDB backend, and identity from Oxy.
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="MIT" src="https://img.shields.io/badge/license-MIT-440151?style=flat-square"></a>
+  <img alt="Expo" src="https://img.shields.io/badge/Expo-57-440151?style=flat-square&logo=expo&logoColor=white">
+  <img alt="React Native" src="https://img.shields.io/badge/React%20Native-0.86-440151?style=flat-square&logo=react&logoColor=white">
+  <img alt="Bun" src="https://img.shields.io/badge/bun-1.0+-440151?style=flat-square&logo=bun&logoColor=white">
+  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-strict-440151?style=flat-square&logo=typescript&logoColor=white">
+</p>
 
 ---
 
-## Table of Contents
-- [About](#about)
-- [Project Structure](#project-structure)
-- [Getting Started](#getting-started)
-- [Development Scripts](#development-scripts)
-- [API Documentation](#api-documentation)
-- [Contributing](#contributing)
-- [License](#license)
+<table>
+<tr>
+<td valign="top" width="50%">
 
----
+### 🔐 Encrypted where it counts
 
-## About
+Direct messages are encrypted on the device before they leave it. The server stores
+ciphertext and public keys, never private key material.
 
-**Allo** is a chat platform for mobile and web with **end-to-end encrypted direct messages** and a **device-first architecture**. It features offline support and a clean, modern UI. Built with Expo, React Native, and a Node.js backend in a modern monorepo structure, it supports file-based routing, multi-language support, and a modern UI.
+Private keys live in the iOS Keychain and the Android Keystore through
+`expo-secure-store`. Only the public half of a device bundle ever reaches the backend.
 
-### Moving to Matrix
+</td>
+<td valign="top" width="50%">
+
+### 📱 Device first
+
+Messages are written locally first and the cloud is secondary. Cloud sync is a setting
+the user controls, not a requirement.
+
+Mutations made offline are queued and replayed on reconnect, so the app keeps working
+without a network.
+
+</td>
+</tr>
+</table>
+
+> [!WARNING]
+> **Read the crypto claims carefully before trusting them.** Allo uses a static ECDH
+> (P-256) agreement between long lived identity keys plus AES-256-GCM. There is no KDF
+> and no ratchet, so the AES key for a pair of identity keys is constant and only the IV
+> changes per message. There is **no forward secrecy**. Group chats, multi device and
+> media are not covered, and when a recipient has no registered device the message is
+> sent in plaintext rather than blocked.
+>
+> The module is named `signalProtocol.ts` for historical reasons only. It does not
+> implement the Signal Protocol: no X3DH, no Double Ratchet. The generated pre-keys are
+> never used to encrypt, and the pre-key signature is never verified.
+>
+> [`docs/encryption.mdx`](docs/encryption.mdx) documents all of this, including the gaps.
+
+## Packages
+
+The repo is a Bun workspace monorepo. Everything lives under `packages/`.
+
+| Package | What it is |
+|---|---|
+| [`@allo/frontend`](packages/frontend/) | The Expo app for iOS, Android and web. Expo Router, NativeWind, Zustand, TanStack Query |
+| [`@allo/backend`](packages/backend/) | Express API and Socket.IO server on MongoDB via Mongoose |
+| [`@allo/shared-types`](packages/shared-types/) | TypeScript types shared by both |
+
+Identity and sessions come from the Oxy platform rather than from a login system in this
+repo: [`@oxyhq/services`](https://github.com/OxyHQ/oxy) on the frontend,
+`@oxyhq/core/server` for the backend's auth, CORS and rate limit middleware, and
+`@oxyhq/bloom` for shared UI.
+
+There is no `controllers/`, `middleware/` or `sockets/` directory in the backend. Routes
+hold their own handlers and the Socket.IO wiring sits directly in `server.ts`.
+
+## Quick start
+
+You need Node 20.19+, Bun, and a MongoDB instance. The root `engines` field pins Node
+`>=20.19.0` and Bun `>=1.0.0`.
+
+```bash
+bun install          # postinstall builds @allo/shared-types for you
+bun run dev          # frontend and backend together
+```
+
+Or one at a time:
+
+```bash
+bun run dev:frontend   # Expo on Metro port 8140, then press w, i or a
+bun run dev:backend    # nodemon + ts-node with hot reload
+```
+
+iOS needs macOS and Xcode. Android needs Android Studio. The per platform scripts have no
+root aliases, so reach them through the workspace filter:
+
+```bash
+bun run --filter @allo/frontend web     # or ios, or android
+```
+
+Before opening a pull request, run what CI runs:
+
+```bash
+bun run typecheck && bun run test
+```
+
+<details>
+<summary><b>Every script, by package</b></summary>
+
+<br>
+
+**Root**
+
+| Script | What it does |
+|---|---|
+| `bun run dev` | Start every package in dev mode |
+| `bun run dev:frontend` / `dev:backend` | Start one of them |
+| `bun run build` | Build every package |
+| `bun run build:shared-types` / `build:frontend` / `build:backend` | Build one of them |
+| `bun run typecheck` | `tsc --noEmit` over backend then frontend |
+| `bun run test` | Tests across all packages |
+| `bun run start:frontend` / `start:backend` | Production start |
+| `bun run clean` | Remove build artifacts and `node_modules` |
+
+**`@allo/frontend`**: `start`, `dev`, `android`, `ios`, `web`, `build`, `build-web`,
+`test` (Jest), `lint` (`expo lint`), `clean`, plus `copy-matrix-wasm`, `clear-cache` and
+`reset-project`. The dev, start, web and build scripts run `copy-matrix-wasm` first.
+
+**`@allo/backend`**: `dev`, `start`, `build`, `test` (Vitest, which starts a real MongoDB
+replica set), `clean`.
+
+**`@allo/shared-types`**: `build`, `dev` (watch), `lint`, `clean`.
+
+There are no database migrations. The Mongoose schemas are applied on connect.
+
+</details>
+
+> [!NOTE]
+> The root `lint` script does not work end to end. The backend declares no `lint` script,
+> and `shared-types` declares one without shipping ESLint or a config, so it fails with
+> "ESLint couldn't find an eslint.config.js". Only the frontend is lintable today, via
+> `bun run --filter @allo/frontend lint`.
+
+## Moving to Matrix
 
 Allo is migrating to [Matrix](https://matrix.org) and will stop carrying its own
-transport. The design work lives in [`docs/matrix/`](./docs/matrix/) and comes
-before the code on purpose.
+transport. The design work is deliberately ahead of the code.
 
-Nothing has switched over yet. The messaging that works today is the one
-described below and in [`docs/`](./docs/): REST plus Socket.IO against
-`@allo/backend`, with the encryption in [Encryption](./docs/encryption.mdx).
-A Matrix client port exists at `packages/frontend/lib/matrix/` — an interface, a
-native implementation, and a web half that throws on purpose — but no screen in
-the app imports it.
+**Nothing has switched over yet.** What ships today is REST plus Socket.IO against
+`@allo/backend`. A Matrix client port exists under
+[`packages/frontend/lib/matrix/`](packages/frontend/lib/matrix/), with separate native and
+web implementations, but no screen in the app imports it.
 
-### Key Security Features
+<details>
+<summary><b>Design notes and the spikes that informed them</b></summary>
 
-- 🔐 **End-to-End Encryption** - Direct messages are encrypted client-side with static ECDH (P-256) between identity keys + AES-256-GCM. There is no KDF and no forward secrecy — see [Encryption](./docs/encryption.mdx) for what that means and for known gaps (group chats, multi-device, plaintext fallback)
-- 📱 **Device-First Architecture** - Messages stored locally first, cloud is secondary
-- ☁️ **Optional Cloud Sync** - Users can enable/disable cloud backup in settings
-- 🔑 **Automatic Key Management** - Device keys generated and registered with the backend automatically
-- ⚠️ **Plaintext Fallback** - If encryption isn't possible (e.g. the recipient has no registered device), the message is sent unencrypted rather than blocked
+<br>
 
-## Project Structure
+Design only, no implementation proposed yet:
 
-This is a **monorepo** using Bun workspaces with the following structure:
+| Note | Subject |
+|---|---|
+| [`data-model.md`](docs/matrix/data-model.md) | How Allo conversations map onto Matrix rooms, and what the mapping costs |
+| [`client-strategy.md`](docs/matrix/client-strategy.md) | Which SDK on which platform, and why |
+| [`bridges.md`](docs/matrix/bridges.md) | Bridge topology and its constraints |
+| [`interim-homeserver.md`](docs/matrix/interim-homeserver.md) | Homeserver plan for the transition |
+| [`linked-accounts.md`](docs/matrix/linked-accounts.md) | Tying Matrix identities to Oxy accounts |
+| [`ephemeral.md`](docs/matrix/ephemeral.md) | Typing notifications and receipts |
+| [`push.md`](docs/matrix/push.md) | Push notification routing |
+| [`ui-wiring.md`](docs/matrix/ui-wiring.md) | Connecting the client port to screens |
 
-```
-/
-├── packages/            # All code packages
-│   ├── frontend/        # Expo React Native app (Allo)
-│   │   ├── app/         # Expo Router file-based routes
-│   │   │   ├── (auth)/      # Sign-in
-│   │   │   ├── (chat)/      # Conversation list, settings, c/[id] thread, u/[id] profile
-│   │   │   ├── calls.tsx    # Calls screen (renders mock data)
-│   │   │   └── ...
-│   │   ├── components/  # UI components
-│   │   ├── assets/      # Images, icons, fonts
-│   │   ├── constants/   # App-wide constants
-│   │   ├── context/     # React context providers
-│   │   ├── hooks/       # Custom React hooks
-│   │   ├── lib/         # Library code
-│   │   │   ├── signalProtocol.ts  # End-to-end encryption (static ECDH + AES-256-GCM)
-│   │   │   ├── offlineStorage.ts  # Offline message storage
-│   │   │   ├── offlineQueue/       # Queued mutations, replayed on reconnect
-│   │   │   ├── p2pMessaging.ts     # Peer-to-peer scaffolding (not functional)
-│   │   │   ├── matrix/             # Matrix client port — not wired to the UI yet
-│   │   │   └── ...
-│   │   ├── locales/     # i18n translation files (en, es, it)
-│   │   ├── plugins/     # Expo config plugins
-│   │   ├── scripts/     # Utility scripts
-│   │   ├── stores/      # State management (Zustand)
-│   │   │   ├── messagesStore.ts    # Encrypted message store
-│   │   │   ├── deviceKeysStore.ts  # Device key management
-│   │   │   └── ...
-│   │   ├── styles/      # Global styles and colors
-│   │   ├── types/       # TypeScript types
-│   │   ├── utils/       # Utility functions
-│   │   ├── __mocks__/   # Jest manual mocks (the Matrix native binding)
-│   │   └── __tests__/   # Jest suites
-│   ├── backend/         # Node.js/Express API server
-│   │   ├── server.ts    # Entry point: Express app + Socket.IO + route mounting
-│   │   ├── src/
-│   │   │   ├── config/      # CrowdSource moderation config
-│   │   │   ├── models/      # MongoDB models
-│   │   │   │   ├── Conversation.ts  # Chat conversations
-│   │   │   │   ├── Message.ts       # Encrypted messages
-│   │   │   │   ├── Device.ts        # Device public key bundles
-│   │   │   │   └── ...
-│   │   │   ├── routes/      # Express routers
-│   │   │   │   ├── conversations.ts # Conversation endpoints
-│   │   │   │   ├── messages.ts      # Message endpoints
-│   │   │   │   ├── devices.ts       # Device key management
-│   │   │   │   ├── reports.ts       # Account reports
-│   │   │   │   └── ...
-│   │   │   ├── services/    # Moderation pipeline (CrowdSource)
-│   │   │   ├── types/       # TypeScript types
-│   │   │   ├── utils/       # Utility functions
-│   │   │   └── __tests__/   # Vitest suites
-│   │   ├── Dockerfile   # linux/arm64 image built by the AWS deploy workflow
-│   │   └── ...
-│   └── shared-types/    # Shared TypeScript types
-│       ├── src/         # Type definitions
-│       └── dist/        # Compiled types
-├── docs/                # Project documentation (see below)
-│   └── matrix/          # Design notes for the Matrix migration
-├── spikes/              # Throwaway apps that validated the Matrix decisions
-├── package.json         # Root package.json with workspaces
-├── tsconfig.json        # Root TypeScript config
-└── ...
-```
+`spikes/` holds the throwaway apps that tested the risky assumptions first. They are not
+workspaces and no root script builds them.
 
-There is no `controllers/`, `middleware/` or `sockets/` directory in the
-backend: routes hold their own handlers, the auth / CORS / rate-limit middleware
-comes from `@oxyhq/core/server`, and the Socket.IO wiring lives directly in
-`server.ts`.
+- [`spikes/matrix-web/`](spikes/matrix-web/) runs `matrix-js-sdk` and
+  `matrix-sdk-crypto-wasm` under a production Expo web export. Its `RESULTS.md` records
+  what it proved and what it did not.
+- [`spikes/matrix-rn/`](spikes/matrix-rn/) runs `@unomed/react-native-matrix-sdk` on a
+  physical Android device. It needs ARM hardware, because the native library ships only
+  `armeabi-v7a` and `arm64-v8a`, so an x86_64 emulator installs and then crashes. The
+  generated `android/` project is not committed, so run `expo prebuild` first.
 
-## Getting Started
-
-### Prerequisites
-- Node.js 20.19+ and Bun 1.3+ (the root `engines` field pins both; CI and the backend Dockerfile use bun 1.3.14)
-- MongoDB instance
-- Expo CLI for mobile development
-
-### Initial Setup
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/OxyHQ/Allo.git
-   cd Allo
-   ```
-
-2. **Install all dependencies**
-   ```bash
-   bun install
-   ```
-
-### Development
-
-#### Start All Services
-```bash
-bun run dev
-```
-
-#### Start Individual Services
-```bash
-# Frontend only
-bun run dev:frontend
-
-# Backend only
-bun run dev:backend
-```
-
-#### Frontend Development
-The frontend is an Expo React Native app that can run on Web, iOS and Android.
-Start it with `bun run dev:frontend` from the root and press `w`, `i` or `a`.
-
-The per-platform scripts live in `packages/frontend` (there are no root aliases
-for them), so run them with a filter or from that directory:
-
-```bash
-bun run --filter @allo/frontend web      # or ios / android
-```
-
-iOS requires macOS and Xcode; Android requires Android Studio.
-
-#### Backend Development
-The backend runs on the development server with hot reload:
-```bash
-bun run dev:backend
-```
-
-## Development Scripts
-
-### Root Level (Monorepo)
-- `bun run dev` — Start all services in development mode
-- `bun run dev:frontend` — Start frontend development server
-- `bun run dev:backend` — Start backend development server
-- `bun run build` — Build all packages
-- `bun run build:shared-types` — Build shared types package
-- `bun run build:frontend` — Build frontend for production
-- `bun run build:backend` — Build backend for production
-- `bun run typecheck` — Typecheck backend then frontend (no emit)
-- `bun run test` — Run tests across all packages
-- `bun run clean` — Clean all build artifacts
-- `bun install` — Install dependencies for all packages
-
-A root `lint` script exists but does not work end to end: the backend declares
-no `lint` script, and `shared-types` declares one without shipping eslint or an
-eslint config, so it fails with "ESLint couldn't find an eslint.config.js". Only
-`packages/frontend` is lintable today (`bun run --filter @allo/frontend lint`).
-
-### Frontend (`@allo/frontend`)
-- `bun run start` — Start Expo development server
-- `bun run android` — Run on Android device/emulator
-- `bun run ios` — Run on iOS simulator
-- `bun run web` — Run in web browser
-- `bun run build-web` — Build static web output
-- `bun run lint` — Lint codebase
-- `bun run clean` — Clean build artifacts
-
-### Backend (`@allo/backend`)
-- `bun run dev` — Start development server with hot reload
-- `bun run build` — Build the project
-- `bun run start` — Start production server
-- `bun run test` — Run the vitest suite (starts a real MongoDB replica set)
-- `bun run clean` — Clean build artifacts
-
-There are no migration scripts. The backend has never had one, and the Mongoose
-schemas are applied on connect.
-
-### Shared Types (`@allo/shared-types`)
-- `bun run build` — Build TypeScript types
-- `bun run dev` — Watch and rebuild types
-- `bun run clean` — Clean build artifacts
+</details>
 
 ## Documentation
 
-### Project Documentation
+Describing the system as it runs today:
 
-All project documentation is available in the [`docs/`](./docs/) folder:
+| Doc | Subject |
+|---|---|
+| [Overview](docs/index.mdx) | What Allo is and how the pieces fit together |
+| [Architecture](docs/architecture.mdx) | Packages, data flow, and the realtime transport |
+| [Encryption](docs/encryption.mdx) | Device keys, static ECDH derivation, and what is not implemented |
+| [API reference](docs/api.mdx) | The REST and Socket.IO surface |
 
-These describe the system as it runs today:
-
-- [Overview](./docs/index.mdx) - What Allo is and how the pieces fit together
-- [Architecture](./docs/architecture.mdx) - Packages, data flow, and real-time transport
-- [Encryption](./docs/encryption.mdx) - Device keys, static ECDH derivation, and what isn't implemented
-- [API Reference](./docs/api.mdx) - REST and Socket.IO surface
-
-These describe where it is going — design only, no implementation proposed yet:
-
-- [Matrix Migration: Data Model](./docs/matrix/data-model.md) - How Allo's conversations map onto Matrix rooms, and what the mapping costs
-- [Matrix Migration: Bridges](./docs/matrix/bridges.md) - Bridge topology and its constraints
-- [Matrix Migration: Client Strategy](./docs/matrix/client-strategy.md) - Which SDK on which platform, and why
-
-### Spikes
-
-`spikes/` holds the throwaway apps that tested the risky assumptions before the
-design committed to them. They are not part of the workspaces and are not built
-by any root script.
-
-- `spikes/matrix-web/` — `matrix-js-sdk` + `matrix-sdk-crypto-wasm` under a
-  production Expo web export. Has its own [README](./spikes/matrix-web/README.md)
-  and a [RESULTS.md](./spikes/matrix-web/RESULTS.md) recording what it proved and
-  what it did not.
-- `spikes/matrix-rn/` — `@unomed/react-native-matrix-sdk` on a physical Android
-  device. Its [README](./spikes/matrix-rn/README.md) covers how to run the C1–C8
-  checks and how to read them. Needs ARM hardware: the native library ships only
-  `armeabi-v7a` and `arm64-v8a`, so an x86_64 emulator installs and then crashes.
-  The generated `android/` project is not committed — run `expo prebuild`.
-
-### API Documentation
-
-The Allo API is a backend service built with Express.js and TypeScript, providing messaging functionality, device key management, authentication, and real-time communications. Direct messages that the client can encrypt arrive as opaque ciphertext (static ECDH + AES-256-GCM); the server never has the keys to read them. See [Encryption](./docs/encryption.mdx) for the full model, including the plaintext fallback and other known gaps.
-
-For detailed API information, see:
-- [Backend README](packages/backend/README.md) - Complete API documentation
-- [Frontend README](packages/frontend/README.md) - Frontend implementation details
-
-### Security Documentation
-
-- **End-to-End Encryption**: Static ECDH (P-256) between identity keys + AES-256-GCM, no forward secrecy — see [Encryption](./docs/encryption.mdx) for the full model and known gaps (group chats, multi-device, P2P, media)
-- **Device-First**: Messages stored locally, cloud sync is optional
-- **Key Exchange**: Automatic device key registration and exchange
-- **Offline Support**: Full functionality without internet connection
-- **Peer-to-Peer**: Scaffolded (`lib/p2pMessaging.ts`) but not yet functional — every message currently goes through the server relay
+Per package detail lives in [`packages/backend/README.md`](packages/backend/README.md) and
+[`packages/frontend/README.md`](packages/frontend/README.md).
 
 ## Contributing
 
-Contributions are welcome! Please open issues or pull requests for bug fixes, features, or improvements.
-
-### Development Workflow
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run the checks CI runs: `bun run typecheck && bun run test`
-5. Submit a pull request
+Issues and pull requests are welcome. Fork, branch, make the change, run
+`bun run typecheck && bun run test`, then open a pull request.
 
 ## License
 
-This project is licensed under the MIT License.
+[MIT](LICENSE). Copyright (c) 2024-present OxyHQ.


### PR DESCRIPTION
Rewrites the root `README.md` only. No code, config or other docs are touched.

## What was wrong

The old README was factually careful but structurally unusable as a landing page. It opened with a table of contents, then a sixty line ASCII directory tree duplicating what `packages/` already shows, and buried the two things that actually change a reader's decisions:

- **the real shape of the encryption**, spread thin across three separate sections
- **that the Matrix migration has not started**, several screens down

It also listed only three of the eight design notes under `docs/matrix/`.

## What changed

- House style: centred intro, badge row, two column summary, foldable detail, so the page opens short
- The encryption caveats are promoted into a single warning callout. No forward secrecy, no KDF, no ratchet, plaintext fallback, and the fact that `signalProtocol.ts` is not the Signal Protocol are things a reader should hit *before* trusting the app
- The Matrix section states plainly that nothing has switched over, and lists all eight design notes
- Packages, scripts and docs are tables with real paths
- Records where identity comes from, since there is no login system in this repo: `@oxyhq/services` on the frontend, `@oxyhq/core/server` on the backend
- No em dashes or en dashes

The two known rough edges are kept, because both still hold and both save a contributor time: the root `lint` script does not work end to end, and there are no database migrations.

## Verification

- Every claim re-derived from `package.json`, the `LICENSE` file and `docs/encryption.mdx`
- All 21 relative links checked to resolve on disk
- Grepped clean for `—` and `–`

🤖 Generated with [Claude Code](https://claude.com/claude-code)