### PR TITLE
chore(licensing): apply the Breathe License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,592 @@
-MIT License
+# The Breathe License, Version 1.0
 
-Copyright (c) 2024-present The Oxy Collective Inc
+**Free to breathe, paid to bottle.**
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+<!--
+  THIS FILE LICENSES THIS WORK.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  Unlike the template published at
+  https://github.com/OxyHQ/.github/blob/main/LICENSE-BREATHE.md, this copy has
+  its Parameters filled in, so these terms govern the work named in them.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  WHAT THIS LICENSE IS:
+
+    - SOURCE AVAILABLE, NOT OPEN SOURCE. The Breathe License is NOT approved
+      by the Open Source Initiative and is NOT approved by the Free Software
+      Foundation. It does not appear on the SPDX license list. GitHub will
+      display a repository using it as "Other" or "custom", and automated
+      license scanners will report it as unknown.
+
+      It is worth being precise about WHY it is not open source. It is NOT
+      because of the copyleft; the AGPL is copyleft and is OSI approved. It is
+      because Section 2 makes commercial use conditional on a paid license,
+      which is discrimination against a field of endeavour under clause 6 of
+      the Open Source Definition. Anyone who calls software under this license
+      "open source" is using the wrong words. See licensing/README.md.
+
+    - NOT COMPATIBLE WITH THE GPL OR THE AGPL. Code under the GPL or the AGPL
+      cannot be combined into a work licensed under these terms, and a work
+      licensed under these terms cannot be combined into a GPL or AGPL work.
+      This is a hard constraint, not a preference. It is one reason Oxy
+      publishes its SDK and client libraries under Apache-2.0 instead. The
+      other reason is simpler: if integrating Oxy login cost money, nobody
+      would integrate it.
+
+    - COPYLEFT, INCLUDING OVER A NETWORK, FOR EVERYONE. If you deploy this
+      software or anything derived from it, you publish the corresponding
+      source. That applies to every user without exception, including paying
+      commercial licensees. It cannot be bought out of. The obligation is
+      modelled on the AGPL-3.0, but this is an original text and is not the
+      AGPL. The Free Software Foundation neither endorses it nor is
+      associated with it.
+
+    - ATTRIBUTION IS MANDATORY AND CANNOT BE WAIVED. It applies to every copy,
+      every derivative, and every network deployment, including those made by
+      paying commercial licensees. Paying does not buy anonymity.
+
+    - IT IS NOT RETROACTIVE. Any version of this work published under an
+      earlier license stays under that license, permanently, for anyone who
+      already has it. These terms bind this version and later ones.
+
+  THIS DOCUMENT HAS NOT BEEN REVIEWED BY A LAWYER. It was drafted from
+  established templates, which is not legal advice and is no substitute for
+  it. Have a qualified lawyer in the relevant jurisdiction review these terms
+  before applying them to any work that matters commercially.
+-->
+
+## Preamble
+
+This preamble explains the intent of the license. It is not part of the terms
+and creates no rights or obligations.
+
+Oxy is named for oxygen, because oxygen is essential and shared. This license
+tries to work the same way, and it asks for two things in return.
+
+The first is that the software stays open. It was published in the open, and it
+stays that way in every hand it passes through. Anyone may read it, run it,
+study it, change it, and pass it on, and anyone who deploys it or a changed
+version of it publishes the source of what they deployed. **That obligation is
+not for sale.** There is no version of this license under which someone takes
+this work private, and no fee that buys the right to. Everyone breathes the same
+air.
+
+The second is that people who make money with it pay for it. Using it, learning
+from it, and building on it are free. Building a revenue generating business on
+top of somebody else's work, contributing nothing back to it, is not. That is
+the line, and buying a commercial license is the whole of what crosses it: it
+buys the right to use this software commercially. It does not buy secrecy, and
+it does not buy silence about where the software came from.
+
+Cooperatives, nonprofits, educational institutions, and public bodies pay
+nothing. They publish their source and give credit like everyone else. They are
+exempt from the fee, and from nothing else.
+
+Free to breathe, paid to bottle. Breathing is using, studying, changing, and
+sharing in the open, and it is free. Bottling it to sell is the part that costs
+money.
+
+## Parameters
+
+Fill these in for each work. Terms in **bold** are defined in Section 15.
+
+| Parameter | Value |
+| --- | --- |
+| **Licensor** | The Oxy Collective, Inc., incorporated in `<JURISDICTION OF INCORPORATION: NOT YET SUPPLIED>` under registration number `<REGISTRATION NUMBER: NOT YET SUPPLIED>` |
+| **The Software** | `OxyHQ/Allo`, and each version of it the Licensor makes available under these terms |
+| Copyright notice | Copyright (c) 2024-present The Oxy Collective, Inc. |
+| License identifier | `LicenseRef-Breathe-1.0` |
+| **Commercial Terms** | <https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md> |
+| **Exemption Policy** | <https://github.com/OxyHQ/.github/blob/main/licensing/EXEMPTIONS.md> |
+| Commercial licensing contact | licensing@oxy.so |
+| **Governing Law** | `<GOVERNING LAW: NOT YET SUPPLIED>` |
+
+## 1. Acceptance
+
+To get any license under these terms, you must agree to them as both strict
+obligations and conditions on every license they grant you. If you do not agree
+to them, you have no license to the Software.
+
+## 2. Copyright license
+
+The Licensor grants you a worldwide, royalty free, non exclusive copyright
+license to do everything with the Software that would otherwise infringe the
+Licensor's copyright in it, for any **Permitted Purpose**.
+
+That includes running it, studying it, copying it, modifying it, making
+**Modified Versions** and other works based on it, publicly performing and
+displaying it, **Conveying** it, and making it available to others through
+**Remote Interaction**, in each case for a Permitted Purpose.
+
+This license is granted for as long as you comply with Section 3. It does not
+expire, the Licensor cannot revoke it while you comply, and no fee is payable
+for it.
+
+### 2.1 Permitted Purpose
+
+A **Permitted Purpose** is any purpose that is not **Commercial Use**.
+
+**Commercial Use is not licensed under this document.** To use the Software
+commercially you must take the **Commercial Terms** identified in the Parameters
+table. See Section 4.
+
+### 2.2 Permitted Purposes specifically include
+
+For the avoidance of doubt, each of the following is a Permitted Purpose:
+
+- **(a)** using the Software personally, on your own behalf, where your use is
+  not connected to **Revenue**;
+- **(b)** private study, research, and experiment, whether or not you publish
+  the results;
+- **(c)** teaching, and use by a student or a member of faculty in that
+  capacity;
+- **(d)** academic and non commercial research, including research funded by
+  grants that are not consideration for goods or services;
+- **(e)** evaluating the Software, for up to ninety days, to decide whether to
+  take the Commercial Terms, including evaluation inside an organization that
+  would otherwise need them;
+- **(f)** developing, testing, reporting bugs in, and contributing to the
+  Software itself, including maintaining a fork of it;
+- **(g)** Conveying the Software or a Modified Version to others at no charge,
+  where you derive no Revenue from doing so; and
+- **(h)** use by a hobbyist, a volunteer project, or a community group that
+  generates no Revenue.
+
+### 2.3 Commercial Use specifically includes
+
+Each of the following is Commercial Use and requires the Commercial Terms:
+
+- **(a)** incorporating the Software, in whole or in part, into a product or
+  service **Your Organization** offers for a fee, whether the fee is for a
+  license, a subscription, hosting, support, consulting, or anything else;
+- **(b)** operating the Software, or a Modified Version, as a hosted or managed
+  service that others pay to access;
+- **(c)** using the Software internally to produce, deliver, operate, support,
+  or administer goods or services Your Organization offers for a fee, including
+  internal tooling, back office systems, and infrastructure. **Internal use is
+  not automatically exempt.** If Your Organization earns Revenue and the
+  Software is used in the course of earning it, that is Commercial Use;
+- **(d)** using the Software in a product or service offered at no charge from
+  which Your Organization derives Revenue by other means, including advertising,
+  data licensing, and referral fees; and
+- **(e)** Conveying the Software as part of a paid distribution, appliance,
+  device, or bundle.
+
+The test is the connection between your use and Revenue. It does not matter
+whether the Software itself is the thing being sold.
+
+### 2.4 The Commercial Terms do not change Section 3
+
+Taking the Commercial Terms adds the right to use the Software commercially. It
+changes nothing else. Every condition in Section 3 continues to apply to you in
+full, including publishing source and giving Attribution. See Section 4.
+
+## 3. Conditions
+
+**These conditions apply to everyone using the Software, without exception, and
+whether or not you hold the Commercial Terms.** They are not obligations that
+can be bought out of, and the Licensor does not offer, and will not offer, any
+license that releases anyone from them.
+
+### 3.1 Attribution
+
+**Attribution is mandatory and cannot be waived, by agreement or by payment.**
+
+Wherever you Convey the Software or a Modified Version, or make either available
+through Remote Interaction, you must give **Attribution**.
+
+Attribution means preserving the copyright notice and a copy of these terms in
+the source you Convey, and presenting the following line in at least one place
+your users can reach:
+
+> Built on `OxyHQ/Allo` by The Oxy Collective, Inc., <https://oxy.so>. Licensed under the Breathe License 1.0.
+
+A reachable "About", "Credits", "Licenses", or "Open source" screen satisfies
+this. So does the documentation, or a `NOTICE` file shipped with the work, if
+the work has no user interface.
+
+**One place is enough, and once per work is enough.** You are not required to
+put Attribution on a home page, a splash screen, a login screen, a marketing
+page, or anywhere else your users have not chosen to look. You are not required
+to name the Licensor in advertising. You may not remove or obscure the
+Licensor's existing copyright and license notices in the source.
+
+**No commercial license, order form, purchase agreement, or other arrangement
+removes this requirement.** A holder of the Commercial Terms owes Attribution on
+exactly the same terms as everybody else. Any provision of any other document
+purporting to waive this Section is void.
+
+### 3.2 Source availability on conveyance
+
+If you Convey the Software or a Modified Version, in source or object form, you
+must make the **Corresponding Source** for what you Conveyed available to every
+recipient, at no charge beyond your reasonable cost of doing so, either by
+including it with what you Convey or by a written offer, valid for at least
+three years, telling recipients where to get it.
+
+### 3.3 Source availability on network use
+
+If you make the Software or a Modified Version available to anyone through
+Remote Interaction, you must offer every user who so interacts with it a
+prominent, no charge way to obtain the Corresponding Source of the version they
+are interacting with, through a network server or another readily accessible
+means.
+
+This condition applies whether or not you also Convey the work, whether or not
+you charge for access, and **whether or not you hold the Commercial Terms**.
+There is no way to pay to avoid it.
+
+**This condition does not reach your separate work.** Section 3.5 says what
+counts as a Modified Version and what does not.
+
+### 3.4 Notices
+
+Anyone who gets any part of the Software or a Modified Version from you must
+also get a copy of these terms, or the URL for them, together with any plain
+text lines beginning with `Required Notice:` that the Licensor supplied with the
+Software.
+
+If you Convey a Modified Version, you must carry prominent notices stating that
+you changed it and the date you changed it. You may add your own copyright
+notice for your own contributions. You may not misrepresent the origin of the
+Software.
+
+### 3.5 What is a Modified Version, and what is not
+
+Using the Software only through its **Documented Public Interfaces** does not by
+itself make your program a Modified Version, and does not put your program under
+these terms. Your own program remains yours, under whatever license you choose,
+and you are not required to publish its source.
+
+For the avoidance of doubt, none of the following makes your program a Modified
+Version:
+
+- **(a)** calling the Software's Documented Public Interfaces, whether in the
+  same process, in a separate process, or across a network;
+- **(b)** importing, linking against, or bundling a client library or SDK
+  published by the Licensor in order to communicate with the Software, where
+  your program uses only that library's Documented Public Interfaces;
+- **(c)** writing a plugin, extension, theme, adapter, or driver that the
+  Software loads through an interface the Software documents for that purpose;
+- **(d)** sending data to, or receiving data from, the Software or a service
+  operated with it;
+- **(e)** deploying the Software alongside your own separate programs, or
+  distributing it with them on the same medium or in the same image, where the
+  programs are independent works that are merely aggregated; or
+- **(f)** configuring, theming, or supplying data to the Software without
+  altering its source.
+
+Your program **is** a Modified Version if you alter the Software's source, copy
+source code out of the Software into your program, or incorporate the Software
+into your program other than through its Documented Public Interfaces.
+
+Section 3.5 concerns only what must be published. It does not affect Section
+2.1: running the Software commercially requires the Commercial Terms even where
+your own separate program stays yours.
+
+### 3.6 No further restrictions
+
+You may not impose any term on a recipient of the Software or a Modified Version
+that restricts the rights these terms grant them, and you may not condition
+their exercise of those rights on the payment of a royalty to you for the
+Software itself. You may charge for your own work, for distribution, for
+support, and for services, subject to Section 2.1.
+
+## 4. The Commercial Terms
+
+If your use is Commercial Use, you need the **Commercial Terms** identified in
+the Parameters table. They are a separate license granted by the Licensor as
+copyright holder, and they are the only way to use the Software commercially.
+
+**What they give you.** The right to use the Software for Commercial Use. That
+is all, and it is deliberate.
+
+**What they do not give you, and what no Oxy license will ever give anyone:**
+
+- **They do not release you from publishing source.** Sections 3.2 and 3.3 apply
+  to commercial licensees in full. If you deploy the Software or a Modified
+  Version, you publish the Corresponding Source, exactly as a non paying user
+  does.
+- **They do not release you from Attribution.** Section 3.1 applies to
+  commercial licensees in full.
+- **They do not permit you to make the Software, or your changes to it,
+  proprietary.** There is no arrangement, at any price, under which the Licensor
+  will agree otherwise. This is a design choice, not an opening negotiating
+  position.
+
+The Licensor grants the Commercial Terms at no charge to **Exempt
+Organizations**. See Section 5.
+
+## 5. Exempt Organizations
+
+The Licensor grants the Commercial Terms at no charge to any **Exempt
+Organization**, on the terms of the published **Exemption Policy**.
+
+**The exemption is from the fee, and from nothing else.** An Exempt Organization
+using the Software commercially is bound by every condition in Section 3 in
+full, including publishing Corresponding Source and giving Attribution, exactly
+as a paying commercial licensee is.
+
+An Exempt Organization may begin Commercial Use immediately in reliance on this
+Section, without waiting for written confirmation from the Licensor. The
+Exemption Policy explains how to obtain written confirmation if you want it for
+your own records.
+
+Many Exempt Organizations will find they do not need the Commercial Terms at
+all, because their use is not Commercial Use in the first place. Section 2.2
+already covers them.
+
+A change to the Exemption Policy does not retroactively withdraw a grant already
+made.
+
+## 6. Third party components
+
+**These terms cover only the parts of the Software that the Licensor owns.**
+
+The Software may contain, bundle, depend on, vendor, or link to components
+authored by third parties and licensed under their own terms. Those components
+remain governed by their own licenses. Nothing in these terms:
+
+- **(a)** overrides, replaces, supersedes, or modifies the license of any third
+  party component;
+- **(b)** reduces, restricts, or conditions any right that a third party
+  component's own license grants you;
+- **(c)** purports to license to you any right in a third party component that
+  the Licensor does not itself hold and is not entitled to grant; or
+- **(d)** creates any obligation for you in respect of a third party component
+  beyond what that component's own license requires.
+
+Where a third party component's license conflicts with these terms in respect of
+that component, that component's license governs it. In particular, a component
+licensed permissively remains usable by you commercially under its own terms,
+whether or not you hold the Commercial Terms for the Software.
+
+**Where to look.** A work licensed under these terms that carries third party
+components lists them in a `NOTICE` or `THIRD-PARTY-LICENSES` file at its root,
+naming each component, its license, and where the full license text can be
+found. Read it. The absence of such a file is not a representation that the work
+carries no third party components; dependency manifests and lockfiles are also
+authoritative.
+
+**What this clause does not do.** It resolves the case where the Software merely
+*contains* separately licensed files alongside the Licensor's own code. It does
+**not** rescue a work that is a **derivative** of copyleft licensed code. If code
+under the GPL, the AGPL, or another copyleft license is combined into the
+Software such that the combination is a derivative or covered work of that code,
+then that copyleft license governs the whole combination, and no third party
+components clause can carve the Licensor's own contributions back out of it. In
+that case the Licensor cannot license the combination under these terms at all,
+because the Licensor does not hold the right to do so.
+
+## 7. Patent license
+
+The Licensor grants you a patent license for the Software covering patent claims
+the Licensor can license, or becomes able to license, that you would infringe by
+using the Software as these terms permit. This patent license runs for as long
+as your copyright license under Section 2 does, and extends to Commercial Use
+only while you hold the Commercial Terms.
+
+No other patent rights are granted, by implication, estoppel, or otherwise.
+
+## 8. Patent defense
+
+If you make any written claim that the Software infringes or contributes to the
+infringement of any patent, your patent license under Section 7 ends
+immediately. If Your Organization makes such a claim, your patent license ends
+immediately for work done on behalf of Your Organization.
+
+## 9. Trademarks
+
+These terms grant you no right to use the Licensor's names, logos, trade names,
+service marks, or product names, including "Oxy" and "Breathe", except as
+Section 3.1 requires in order to state the origin of the Software accurately,
+and except for nominative fair use permitted by law.
+
+You may say your product is built on the Software. You may not say or imply that
+it is published, endorsed, certified, sponsored, or supported by the Licensor
+unless it is.
+
+## 10. Termination and cure
+
+If you violate these terms, your licenses end. But the first time the Licensor
+notifies you in writing of a violation, your licenses are reinstated if you come
+into full compliance, and take practical steps to correct the violation, within
+32 days of receiving that notice. After a first cured violation, further
+violations end your licenses immediately on notice.
+
+If your licenses end, the rights of anyone who received the Software or a
+Modified Version from you are not affected, as long as they comply themselves.
+
+If your Commercial Terms end, for any reason including non payment, your license
+under Section 2 for Permitted Purposes continues, provided you comply with
+Section 3. **You must stop Commercial Use.**
+
+## 11. Severability and partial exclusion
+
+If any part of the Software cannot lawfully be licensed under these terms,
+whether because a third party holds rights in it, because a copyleft obligation
+governs it, or for any other reason, that part is excluded from these terms and
+continues under whatever terms actually govern it. The rest of the Software
+continues under these terms, unaffected.
+
+If any provision of these terms is held invalid, illegal, or unenforceable by a
+court of competent jurisdiction, that provision is severed and the remaining
+provisions continue in full force, with the severed provision replaced by a
+valid provision that comes as close as the law permits to the original intent.
+
+If a condition in Section 3 cannot be enforced against you as a matter of law in
+your jurisdiction, your licenses under Section 2 end rather than continuing
+without that condition.
+
+## 12. No warranty
+
+***As far as the law allows, the Software comes as is, without warranty or
+condition of any kind, express or implied, including any warranty of
+merchantability, fitness for a particular purpose, title, or non infringement.
+The entire risk as to the quality and performance of the Software is with
+you.***
+
+## 13. Limitation of liability
+
+***As far as the law allows, the Licensor will not be liable to you for any
+damages arising out of these terms or out of the use or nature of the Software,
+under any kind of legal claim, including direct, indirect, special, incidental,
+and consequential damages, and including lost profits and lost data, even if the
+Licensor has been advised of the possibility of them.***
+
+Nothing in these terms excludes or limits liability that cannot lawfully be
+excluded or limited, including liability for death or personal injury caused by
+negligence, or for fraud.
+
+## 14. Governing law
+
+These terms are governed by the law of the jurisdiction named in the Parameters
+table, without regard to its conflict of law rules. The courts of that
+jurisdiction have exclusive jurisdiction over any dispute arising out of these
+terms, except that either party may seek injunctive relief in any court of
+competent jurisdiction to protect its intellectual property.
+
+## 15. Definitions
+
+**Licensor** is the entity named in the Parameters table, being the entity that
+holds the copyright in the Licensor authored parts of the Software or that has
+been granted the rights necessary to license them under both these terms and the
+Commercial Terms.
+
+**The Software** is the software and other material identified in the Parameters
+table that the Licensor makes available under these terms, including each
+version the Licensor so makes available.
+
+**You** means the individual or legal entity exercising rights under these
+terms.
+
+**Your Organization** means any legal entity, sole proprietorship, cooperative,
+association, foundation, or other organization you work for or on behalf of,
+together with every organization that controls it, is controlled by it, or is
+under common control with it. **Control** means ownership of more than fifty
+percent of the voting interests or of substantially all the assets of an entity,
+or the power to direct its management and policies by vote, contract, or
+otherwise, whether direct or indirect.
+
+**Permitted Purpose** has the meaning given in Section 2.1.
+
+**Commercial Use** means any use of the Software by or for Your Organization
+that is connected to **Revenue**, whether or not the Software is itself sold.
+Section 2.3 enumerates cases that are Commercial Use. Section 2.2 enumerates
+cases that are not.
+
+**Revenue** means all consideration of any kind received by Your Organization
+from third parties, in cash or in kind, recognized under the accounting
+standards Your Organization ordinarily applies, before deduction of costs. It
+includes subscription fees, license fees, transaction fees, advertising revenue,
+and payments for support or professional services. It excludes grants and
+donations that are not consideration for goods or services, capital raised by
+issuing shares or debt, and proceeds from the sale of capital assets.
+
+**Convey** means any act of propagating the Software that enables another party
+to make or receive copies, including distributing it in source or object form,
+publishing it, and shipping it inside a product or device. Merely interacting
+with users over a network, without transferring a copy, is not Conveying.
+
+**Remote Interaction** means allowing a user to interact with the Software, or
+with a Modified Version, over a computer network, without that user receiving a
+copy. Providing the Software as a hosted or managed service is Remote
+Interaction.
+
+**Modified Version** means a work that is a Modified Version under Section 3.5.
+
+**Corresponding Source** means all the source code needed to generate, install,
+and run the version in question, and to modify it, including the source of the
+work itself, interface definition files associated with it, build scripts,
+configuration needed to reproduce the build, and scripts controlling
+installation. It does not include the Software's own dependencies where those
+are generally available under their own licenses, standard system libraries,
+compilers, or general purpose tools used to produce the build. It does not
+include your credentials, keys, secrets, personal data, or user data.
+
+**Documented Public Interfaces** means the application programming interfaces,
+network protocols, message formats, command line interfaces, plugin interfaces,
+and extension points that the Licensor documents for use by others, in the
+Software's published documentation, its type definitions, or its public package
+exports. An interface the Licensor marks internal, private, unstable, or
+experimental is not a Documented Public Interface.
+
+**Attribution** has the meaning given in Section 3.1.
+
+**Commercial Terms** means the document identified in the Parameters table.
+
+**Exempt Organization** means Your Organization, where Your Organization is any
+of the following. The test applies to Your Organization as a whole, not to a
+department, subsidiary, or project within it.
+
+- **(a) A cooperative.** An entity registered as a cooperative, a mutual, or an
+  equivalent form under the law of its jurisdiction, or whose governing
+  documents bind it to all four of: membership is open and voluntary; members
+  control the entity democratically, with voting power not allocated in
+  proportion to capital contributed; any surplus is returned to members in
+  proportion to their transactions or participation, retained by the entity, or
+  applied to purposes the members approve, rather than distributed to outside
+  investors in proportion to capital; and the entity is not controlled by an
+  entity that is not itself an Exempt Organization.
+
+- **(b) A nonprofit organization.** An entity established on a not for profit
+  basis under the law of its jurisdiction, whose governing documents prohibit
+  distributing profits or assets to members, directors, officers, or
+  shareholders other than as reasonable compensation for services actually
+  rendered, and whose assets on dissolution must pass to another not for profit
+  or public purpose entity. Entities recognized under section 501(c)(3) of the
+  United States Internal Revenue Code, entities on the register of the Charity
+  Commission for England and Wales or its equivalent elsewhere, and entities
+  constituted as an `asociación`, `fundación`, `association loi 1901`, `Verein`,
+  `stichting`, or equivalent, qualify where they meet this test.
+
+- **(c) An educational institution.** A school, college, university, or other
+  institution whose primary purpose is education or academic research, together
+  with its students and faculty acting in that capacity.
+
+- **(d) A public body.** A government, public authority, public health service,
+  or public research institution, acting in a public capacity and not in
+  competition with commercial providers of the Software.
+
+- **(e) A worker owned business.** An entity in which the people performing
+  substantially all of its work also hold substantially all of its voting
+  control, whether directly or through a trust or foundation constituted for
+  that purpose.
+
+An entity does not stop being an Exempt Organization merely because it charges
+for goods or services, earns Revenue, pays market salaries, holds reserves, or
+receives grants or public funding. An entity is not an Exempt Organization if it
+is controlled by an entity that is not one, or if its exempt form is used
+principally to hold or route the economic benefit of the Software to persons or
+entities that would not themselves qualify.
+
+**Exemption Policy** means the document identified in the Parameters table, as
+published by the Licensor from time to time.
+
+**Governing Law** means the jurisdiction named in the Parameters table.
+
+## 16. How to apply these terms
+
+See [`licensing/README.md`](licensing/README.md) for the full procedure: which
+Oxy works use these terms and which use Apache-2.0, the file layout, the license
+identifier, the `package.json` `license` field, the source header, and the
+`NOTICE` file.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,26 @@
+=============================================================================
+ NOTICE
+ OxyHQ/Allo
+ Copyright (c) 2024-present The Oxy Collective, Inc.
+=============================================================================
+
+This product is licensed under the Breathe License 1.0
+(`LicenseRef-Breathe-1.0`). See the LICENSE file. Commercial terms are
+available; see
+<https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md>.
+
+Attribution under Section 3.1 of the Breathe License is required of everyone,
+including paying commercial licensees, and cannot be waived.
+
+-----------------------------------------------------------------------------
+ THIRD PARTY COMPONENTS
+-----------------------------------------------------------------------------
+
+This repository contains no vendored third party source. Its dependencies are
+resolved and installed by the package manager and remain governed by their own
+licenses.
+
+This work must not take on a GPL or AGPL dependency that is linked in process:
+the Breathe License is not compatible with either, in either direction. If you
+are adding one, stop and read
+https://github.com/OxyHQ/.github/blob/main/licensing/README.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "allo",
   "version": "2.0.0",
+  "license": "SEE LICENSE IN LICENSE",
   "description": "allo Monorepo - Frontend and Backend",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
`OxyHQ/Allo` moves to the **Breathe License 1.0** (`LicenseRef-Breathe-1.0`), from **MIT**.

This was blocked until now for one reason, and the reason is gone. Every Parameters table in the org named **The Oxy Foundation, Inc.**, an entity that is not registered, and a licence granted by an entity that does not exist grants nothing. The licensor is now **The Oxy Collective, Inc.**, which exists today.

## What the licence does

| | |
| --- | --- |
| Non commercial use | Free, perpetual, irrevocable while you comply |
| Commercial use | **Requires a paid licence.** The trigger is revenue, and it includes purely internal use inside a business that earns revenue |
| Deploying it, or a modified version | **You publish the corresponding source.** Binds everyone, paying customers included. Cannot be bought out of |
| Attribution | **Required of everyone**, cannot be waived by agreement or by payment |
| Cooperatives, nonprofits, education, public bodies, worker owned businesses | **No fee.** They publish source and give credit like anyone else |

**This is source available, not open source**, and it is worth being precise about why, because the obvious guess is wrong. It is not the copyleft: the AGPL is copyleft and is OSI approved. It fails **clause 6 of the Open Source Definition**, no discrimination against fields of endeavour, because commercial use is conditional on payment. Automated scanners will report it as unknown and GitHub shows it as "Other". Nobody should call this repository open source.

## It is not retroactive, and it could not be

Every version of this work already published under MIT **stays MIT permanently** for anyone who has it. They may keep using it commercially, for free, indefinitely, and may fork it. A licence change binds future versions only.

This is worth stating plainly in the announcement too, because a narrowing like this is easy to misread as a revocation. It is not one, and it could not be one.

## Files

- `LICENSE`: the full Breathe License text with its Parameters filled in. The operative text from Section 1 onward is asserted byte identical to the org template at `OxyHQ/.github`; only the Parameters, the Section 3.1 attribution example, and the header comment differ. The header no longer says "this is a template and licenses nothing", because in this file it does.
- `NOTICE`: attribution, copyright **The Oxy Collective, Inc.**, and the standing rule that this work must never take a GPL or AGPL dependency linked in process.
- `package.json`: `"license": "SEE LICENSE IN LICENSE"`.
## What is still outstanding

**Three Parameters are visible placeholders, not guesses:** jurisdiction of
incorporation, registration number, and governing law. They read
`NOT YET SUPPLIED` in the licence. The licence grant itself works without them,
because the Licensor is now a real entity, but **the commercial arm cannot
invoice until they are filled in.**

**No CLA is switched on.** The agreement text is settled and now names
The Oxy Collective, Inc., with a successor clause so that moving the work to a
foundation later does not force every signatory to sign again
([OxyHQ/.github#7](https://github.com/OxyHQ/.github/pull/7)). But no bot is
installed and no signature has been taken, and that is deliberate: it changes
the contribution flow on every pull request. **Until it is on, one merged
outside contribution to this repository permanently breaks its commercial arm**,
because Oxy cannot offer commercial terms over somebody else's copyright.

## The merge-order prerequisite is already satisfied

The Breathe License is not compatible with the AGPL in either direction, so this
could not have merged while the SDK packages this repository depends on were
AGPL on npm. **They no longer are.** The Apache-2.0 layer was merged and
published while this work was in progress, and I verified it against the
registry rather than assuming:

| Package | npm today |
| --- | --- |
| `@oxyhq/core` | `20.0.0`, **Apache-2.0** |
| `@oxyhq/services` | `28.0.0`, **Apache-2.0** |
| `@oxyhq/contracts` | `0.25.0`, **Apache-2.0** |
| `@oxyhq/bloom` | `0.87.0`, **Apache-2.0** |

Apache-2.0 into Breathe is fine: permissive inbound is exactly what the two
layer split is for. So there is no ordering constraint left on this PR.

**Opened as a draft on purpose.** The org convention is that green CI means
merge; this one needs a decision and an ordering, not an automatic merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)