### PR TITLE
fix(chat): do not offer the sign-in that just started

### DIFF
--- a/packages/frontend/components/matrix/MatrixSignInGate.tsx
+++ b/packages/frontend/components/matrix/MatrixSignInGate.tsx
@@ -45,6 +45,14 @@ export function MatrixSignInGate({ children }: { children: React.ReactNode }) {
     signInToMatrix();
   }
 
+  // Starting it does not move the phase within this render, so without this the
+  // pass that begins the sign-in still draws the screen offering to begin it —
+  // the exact screen the automatic start exists to remove, shown for as long as
+  // the runtime takes to react. The phase leaves `signed-out` on its own, to
+  // `authorizing` when the browser opens or `failed` when it cannot, and both
+  // are handled below.
+  const startingItself = attempted.current && runtime.phase === 'signed-out';
+
   const styles = useMemo(
     () =>
       StyleSheet.create({
@@ -92,7 +100,7 @@ export function MatrixSignInGate({ children }: { children: React.ReactNode }) {
     return <>{children}</>;
   }
 
-  if (runtime.phase === 'idle' || runtime.phase === 'starting') {
+  if (runtime.phase === 'idle' || runtime.phase === 'starting' || startingItself) {
     return (
       <View style={styles.container}>
         <ActivityIndicator style={styles.spinner} color={theme.colors.primary} />


### PR DESCRIPTION
## Summary

Starting the sign-in does not move the runtime's phase within the same render, so the pass that *began* it fell through and drew **"Connect your chat"** with a Continue button — the exact screen the automatic start exists to remove. Shown for as long as the runtime took to react, and indefinitely if it never did.

That pass now renders the connecting state. The phase leaves `signed-out` on its own — to `authorizing` when the browser opens, or `failed` when it cannot — and both branches already existed.

The screen with the button is still right where it belongs: no Oxy session to inherit, or an attempt that failed and owes an explanation.

Verified `user?.id` is how the rest of the app reads the Oxy session (34 call sites), so the condition that decides whether to start at all is reading the right thing.

Suite unchanged at 77 suites / 1085 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
