### PR TITLE
fix(chat): prove the store on disk is the session's before opening it

### DIFF
--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -70,6 +70,7 @@ lib/chat/
   matrixRuntime.ts       el cliente y su ciclo de vida, fuera de React
   matrixSession.ts       la sesión guardada: versión, validación, homeserver
   matrixSessionStorage.ts dónde vive: llavero en nativo, localStorage en web
+  matrixStoreOwner.ts    de quién es el almacén del disco, apuntado fuera de él
   roomListSource.ts      la lista de salas como external store
   timelineSource.ts      un timeline por sala, ídem, más paginar y enviar
   mediaCache.ts          adjuntos ya bajados y descifrados, ídem
@@ -143,6 +144,13 @@ el historial de los demás. Lo que lo evita son dos hechos, ambos en
   que se escribió en el login caduca en menos de una hora. `observeSession` es
   cómo el puerto lo cuenta —delegado del constructor en nativo, callback del
   `TokenRefresher` en web— y el runtime está suscrito mientras el cliente viva.
+- **y el almacén dice de quién es.** Los dos puntos de arriba no decían nada del
+  arranque que *sí* encuentra sesión, y ahí estaba el fallo: la sesión y el
+  almacén se escriben en momentos distintos y se abrían juntos sólo porque los
+  dos estaban ahí. Ahora una sesión sólo se reinstala si el almacén está apuntado
+  como suyo, y si no se borran los dos. **Ver §11**, que es donde está la regla
+  entera, qué pasa con lo que ya había en el disco y por qué un borrado que falla
+  para el arranque.
 
 **El vocabulario no cambió: `Conversation` y `Message`.** `MessageBubble`,
 `DaySeparator`, las filas de la lista, el layout de tres paneles y los temas por
@@ -826,3 +834,74 @@ un miembro es un `mxc://`, que no es algo que una vista pueda pedir — el mismo
 problema por el que existe `AlloMediaRef` (§7.1) — así que un campo ahí sería una
 URL que dibuja una imagen rota en todas las filas. Hasta que los avatares de
 miembro pasen por `downloadMedia`, la lista honesta son los nombres.
+
+---
+
+## 11. De quién es lo que hay en el disco
+
+Un dispositivo lo usa más de una persona, y una cuenta se cambia. Lo que había
+hasta ahora no lo tenía en cuenta: la sesión vivía bajo una clave fija
+(`allo.matrix.session`), el almacén sincronizado y el almacén de cripto bajo un
+nombre fijo, y el runtime abría los dos juntos con el único argumento de que
+ambos estaban ahí. Cambia la cuenta y eso es un cliente autenticado como una
+identidad leyendo el estado sincronizado de la anterior y con sus claves de
+descifrado en la mano. No es una pantalla que no se refresca: es un fallo de
+privacidad.
+
+### 11.1 La regla
+
+`matrixStoreOwner.ts` apunta de quién es el almacén —MXID, id de dispositivo y
+homeserver— **fuera** del almacén, porque decidir si se abre es justo lo que hay
+que hacer antes de abrirlo. Y `matrixRuntime.ts` aplica una sola regla al
+principio de cada arranque:
+
+> Una sesión guardada sólo se reinstala si el almacén del disco está apuntado
+> como de esa misma sesión. Si no, se borran los dos.
+
+Una rama, y todos los casos caen en ella: un almacén que no es de nadie, un
+almacén de otra cuenta, una sesión sin almacén, un almacén sin sesión, y un
+cierre de sesión que se quedó a medias. Se borran **los dos** y no sólo el
+almacén: un dispositivo de Matrix sin sus claves no descifra nada y no se puede
+volver a verificar, así que reinstalar la sesión sólo daría un dispositivo roto
+en vez de uno nuevo.
+
+### 11.2 Lo que ya estaba en el disco no es de nadie
+
+Todo almacén escrito antes de esta regla no lleva dueño, y **no se le adjudica a
+la siguiente identidad que entre** — eso es exactamente el fallo. Tampoco se
+adivina a partir de la sesión que esté guardada al lado, porque que estén al lado
+es precisamente lo que se daba por hecho y no era cierto. Se borra, y la sesión
+que estaba junto a él se va con él. El coste es un inicio de sesión, una vez,
+para quien ya estuviera usando el backend de Matrix.
+
+Lo mismo vale en iOS por otro motivo: el llavero puede sobrevivir a desinstalar
+la app y el directorio de documentos no. Una Allo reinstalada encontraba una
+sesión válida de un dispositivo cuyas claves ya no existían en ninguna parte.
+Ahora encuentra una sesión cuyo almacén no es de nadie, que es un estado que el
+runtime sabe resolver.
+
+### 11.3 Un borrado que falla para el arranque
+
+`store.web.ts` y `store.native.ts` lanzan `MatrixStoreNotErasedError` en vez de
+dar por bueno un borrado que no ocurrió — en web una base que IndexedDB se niega
+a borrar, en nativo un directorio que sigue ahí después de `delete()`. Los dos
+intentan todo lo que tenían que borrar antes de lanzar, y lo que lanzan nombra lo
+que quedó.
+
+El runtime no lo captura: el arranque termina en `failed` y **sin cliente**. Un
+almacén que no se ha podido vaciar no puede abrirlo la identidad siguiente; para
+eso se vaciaba.
+
+### 11.4 El trabajo en vuelo tampoco cruza la frontera
+
+El cliente no se suelta hasta el final de `signOut`, así que entre borrar la
+sesión y soltarlo el runtime sigue suscrito a las rotaciones de token del SDK —
+dos `await`, uno de ellos un viaje al homeserver. Una rotación que aterrizaba ahí
+volvía a escribir la sesión **después** de que el cierre la hubiera borrado, y el
+arranque siguiente reinstalaba una sesión que la persona había terminado.
+
+`#sessionEpoch` es la respuesta: se abre cuando se instala una sesión y se cierra
+en cuanto el runtime deja de querer conservarla. Todo lo que espera y luego
+escribe lo lee antes y lo vuelve a comprobar después —dentro de la operación
+encolada, no sólo al encolarla, porque una escritura espera detrás de lo que ya
+hubiera en la cola.

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -5,6 +5,12 @@ import type {
 import { MatrixRuntime, type MatrixRuntimeDependencies } from '@/lib/chat/matrixRuntime';
 import { encodeStoredSession } from '@/lib/chat/matrixSession';
 import type { MatrixSessionStorage } from '@/lib/chat/matrixSessionStorage';
+import type { MatrixSignInAttempt } from '@/lib/chat/matrixSignInAttempt';
+import {
+  storeOwnerOf,
+  type MatrixStoreOwner,
+  type MatrixStoreOwnerStorage,
+} from '@/lib/chat/matrixStoreOwner';
 import type { MatrixPushRegistration } from '@/lib/chat/pushRegistration';
 import type {
   AlloChatClient,
@@ -134,6 +140,72 @@ class FakeSessionStorage implements MatrixSessionStorage {
     return this.value === undefined
       ? undefined
       : (JSON.parse(this.value) as { session: AlloSession }).session;
+  }
+}
+
+/**
+ * The record of whose the store on disk is.
+ *
+ * Its own fake rather than a field on {@link FakeSessionStorage}, because the two
+ * being separate is the point: they are written at different moments and either
+ * can be there without the other, and every one of those combinations is a case
+ * below. Its calls go into the same event log, so the ORDER the runtime clears,
+ * erases and claims in can be asserted — that order is what makes an interrupted
+ * launch converge instead of leaving a half-deleted store recorded as intact.
+ */
+class FakeStoreOwnerStorage implements MatrixStoreOwnerStorage {
+  readonly events: string[];
+
+  value: MatrixStoreOwner | undefined;
+  readFails: Error | undefined;
+  writeFails: Error | undefined;
+  clearFails: Error | undefined;
+
+  constructor(events: string[] = []) {
+    this.events = events;
+  }
+
+  async read(): Promise<MatrixStoreOwner | undefined> {
+    this.events.push('readOwner');
+    if (this.readFails !== undefined) {
+      throw this.readFails;
+    }
+    return this.value;
+  }
+
+  async write(owner: MatrixStoreOwner): Promise<void> {
+    this.events.push('writeOwner');
+    if (this.writeFails !== undefined) {
+      throw this.writeFails;
+    }
+    this.value = owner;
+  }
+
+  async clear(): Promise<void> {
+    this.events.push('clearOwner');
+    if (this.clearFails !== undefined) {
+      throw this.clearFails;
+    }
+    this.value = undefined;
+  }
+}
+
+/** The one-automatic-sign-in-per-run marker, as much of it as the runtime touches. */
+class FakeSignInAttempt implements MatrixSignInAttempt {
+  attempted = false;
+  forgets = 0;
+
+  started(): boolean {
+    return this.attempted;
+  }
+
+  record(): void {
+    this.attempted = true;
+  }
+
+  forget(): void {
+    this.forgets += 1;
+    this.attempted = false;
   }
 }
 
@@ -421,6 +493,10 @@ interface Harness {
   /** Every client ever built, oldest first. */
   readonly clients: FakeChatClient[];
   readonly storage: FakeSessionStorage;
+  /** The record of whose the store on disk is. */
+  readonly owner: FakeStoreOwnerStorage;
+  /** The one-automatic-sign-in-per-run marker. */
+  readonly signInAttempt: FakeSignInAttempt;
   /**
    * Everything the runtime did, in order, across storage, the store and the
    * client. What most of these tests are actually about is this sequence.
@@ -439,12 +515,33 @@ function harness(
     createClientFails?: () => Error | undefined;
     storage?: FakeSessionStorage;
     eraseStoreFails?: Error;
+    /**
+     * The store on disk is recorded as belonging to nobody.
+     *
+     * Every store written before ownership was recorded, and the state an
+     * interrupted erase leaves. Without this the harness records the store as
+     * belonging to whatever session was left in storage, because that is what a
+     * previous launch of the real app leaves behind and it is what the tests
+     * written before this rule existed were describing.
+     */
+    unownedStore?: boolean;
+    /** The store on disk is recorded as belonging to this session's identity. */
+    storeOwnedBy?: AlloSession;
     /** The authorization response this launch arrives with. Web only. */
     callbackUrl?: string;
   } = {},
 ): Harness {
   const storage = overrides.storage ?? new FakeSessionStorage();
   const events = storage.events;
+  const owner = new FakeStoreOwnerStorage(events);
+  const previousSession = storage.storedSession();
+  owner.value =
+    overrides.storeOwnedBy !== undefined
+      ? storeOwnerOf(overrides.storeOwnedBy)
+      : overrides.unownedStore === true || previousSession === undefined
+        ? undefined
+        : storeOwnerOf(previousSession);
+  const signInAttempt = new FakeSignInAttempt();
   // One client up front, so a test can arm its failures before the runtime asks
   // for it. Every rebuild after that gets a new one.
   const clients: FakeChatClient[] = [new FakeChatClient(events)];
@@ -465,6 +562,8 @@ function harness(
     },
     clients,
     storage,
+    owner,
+    signInAttempt,
     events,
     opened,
     erased,
@@ -492,6 +591,8 @@ function harness(
         }
       },
       sessionStorage: storage,
+      storeOwner: owner,
+      signInAttempt,
       pushRegistration,
       pendingAuthorization,
       authorize: async (url) => {
@@ -1151,6 +1252,262 @@ describe('MatrixRuntime session persistence', () => {
     await settle();
 
     expect(JSON.stringify(context.runtime.getState())).not.toContain('secret-');
+  });
+});
+
+describe('MatrixRuntime store ownership', () => {
+  /**
+   * The rule: a stored session may only be reinstated when the store on disk is
+   * recorded as belonging to exactly that session.
+   *
+   * This is the identity boundary, and it is here rather than in a React
+   * provider because the store and the session are on disk and React is not.
+   * What it exists to stop is a client authenticating as one account while
+   * reading the last account's synced state and holding its decryption keys.
+   */
+
+  /** The account that comes second on a shared device. */
+  const OTHER_SESSION: AlloSession = {
+    ...SESSION,
+    userId: '@lena:matrix.example',
+    deviceId: 'OTHERDEVICE',
+  };
+
+  it('reinstates a session whose store is recorded as its own', async () => {
+    // The ordinary launch, and the case every other one is measured against.
+    const context = harness({ storage: stored() });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.client().restoredWith).toEqual(SESSION);
+    expect(context.erased).toEqual([]);
+  });
+
+  it('refuses a session whose store belongs to another account, and erases both', async () => {
+    // The defect, in one case. Somebody signed in, somebody else's session is
+    // what is in storage, and the data on disk is the first one's. Restoring
+    // would hand the second account the first account's keys.
+    const context = harness({ storage: stored(), storeOwnedBy: OTHER_SESSION });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.client().restoredWith).toBeUndefined();
+    expect(context.storage.value).toBeUndefined();
+    expect(context.erased).toEqual([STORE]);
+    expect(context.runtime.getState().phase).toBe('signed-out');
+  });
+
+  it('refuses a session whose store nobody claimed', async () => {
+    // Every store written before ownership was recorded, which is everything
+    // already on disk. It is not given to the session sitting next to it: the
+    // two being next to each other is exactly what the old code assumed and
+    // exactly what was not true. One extra sign-in, once.
+    const context = harness({ storage: stored(), unownedStore: true });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.client().restoredWith).toBeUndefined();
+    expect(context.storage.value).toBeUndefined();
+    expect(context.erased).toEqual([STORE]);
+  });
+
+  it('refuses a session whose store belongs to the same person on another device', async () => {
+    // One account, two devices, and the keys are the device's. A store recorded
+    // for DEVICE cannot serve a session for OTHERDEVICE even though the user id
+    // matches, which is why the device id is part of the owner and not just the
+    // user id.
+    const context = harness({
+      storage: stored(),
+      storeOwnedBy: { ...SESSION, deviceId: 'OTHERDEVICE' },
+    });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.client().restoredWith).toBeUndefined();
+    expect(context.erased).toEqual([STORE]);
+  });
+
+  it('makes the store nobody’s before it starts deleting it', async () => {
+    // Order, and it is the part that makes an interrupted erase converge. Killed
+    // between the two, the next launch finds a store recorded as nobody's and
+    // erases it again. Recorded first and erased second, a half-deleted store
+    // would carry a marker saying it was intact.
+    const context = harness({ storage: stored(), storeOwnedBy: OTHER_SESSION });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.events.indexOf('clearOwner')).toBeLessThan(
+      context.events.indexOf('eraseStore'),
+    );
+  });
+
+  it('claims the store for the session a sign-in produced', async () => {
+    const context = harness();
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.owner.value).toEqual(storeOwnerOf(SESSION));
+  });
+
+  it('claims the store before it writes the session down', async () => {
+    // Interrupted between them, the next launch finds a store belonging to a
+    // session nobody wrote down and erases it: no device. The other order leaves
+    // a session whose store the next launch erases underneath it, which is a
+    // device that exists on the homeserver and cannot decrypt anything.
+    const context = harness();
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.events.lastIndexOf('writeOwner')).toBeLessThan(
+      context.events.lastIndexOf('write'),
+    );
+  });
+
+  it('reinstates the session a previous run signed in and claimed', async () => {
+    // The two halves meeting: what a sign-in writes is what the next launch
+    // accepts. A test for each side separately would pass with two different
+    // notions of what an owner is.
+    const first = harness();
+    first.runtime.subscribe(() => {});
+    await settle();
+    await first.runtime.signIn();
+    await settle();
+
+    const second = harness({ storage: first.storage });
+    second.owner.value = first.owner.value;
+    second.runtime.subscribe(() => {});
+    await settle();
+
+    expect(second.opened).toEqual([]);
+    expect(second.client().restoredWith).toEqual(SESSION);
+    expect(second.erased).toEqual([]);
+  });
+
+  it('does not build a client on a store it could not erase', async () => {
+    // The whole reason the erasers were made to throw. Carrying on here is
+    // "I could not delete the last account's keys, so I will open them".
+    const context = harness({
+      storage: stored(),
+      storeOwnedBy: OTHER_SESSION,
+      eraseStoreFails: new Error('the database is still open in another tab'),
+    });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.createClientCalls).toBe(0);
+    expect(context.runtime.getState().phase).toBe('failed');
+  });
+
+  it('does not build a client when it cannot even record that the store is nobody’s', async () => {
+    const context = harness({ storage: stored(), storeOwnedBy: OTHER_SESSION });
+    context.owner.clearFails = new Error('storage is full');
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.createClientCalls).toBe(0);
+    expect(context.erased).toEqual([]);
+    expect(context.runtime.getState().phase).toBe('failed');
+  });
+
+  it('gives the device back rather than keep a session it could not claim a store for', async () => {
+    // A sign-in whose store cannot be claimed is a device that the next launch
+    // will not recognise, and the launch after that would mint another.
+    const context = harness();
+    context.runtime.subscribe(() => {});
+    await settle();
+    context.owner.writeFails = new Error('storage is full');
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.clients[0]?.logouts).toBe(1);
+    expect(context.storage.value).toBeUndefined();
+    expect(context.runtime.getState().phase).toBe('failed');
+  });
+
+  it('lets the run try signing in again after it refuses somebody else’s session', async () => {
+    // The marker says "this run already started a sign-in". The run that started
+    // it was signing a different identity in, and the app has just thrown away
+    // everything of theirs — so leaving it set would show whoever is here now a
+    // button offering to do what the app could have done by itself.
+    const context = harness({ storage: stored(), storeOwnedBy: OTHER_SESSION });
+    context.signInAttempt.record();
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.signInAttempt.forgets).toBe(1);
+    expect(context.signInAttempt.started()).toBe(false);
+  });
+
+  it('leaves the marker alone on an ordinary launch with nothing stored', async () => {
+    // Nothing was refused. Forgetting here is what would send a browser that
+    // came back from the authorization server with no usable code straight back
+    // to it, and again, forever — the loop the marker exists for.
+    const context = harness();
+    context.signInAttempt.record();
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.signInAttempt.forgets).toBe(0);
+    expect(context.signInAttempt.started()).toBe(true);
+  });
+
+  it('does not let a token rotation put the session back after a sign-out cleared it', async () => {
+    // In-flight work crossing the boundary, in the one place Allo actually has
+    // any. The client is not let go of until the end of `signOut`, so between
+    // the session being cleared and that moment the runtime is still subscribed
+    // to the SDK's rotations — `pushRegistration.remove` and `logout` are the two
+    // awaits in the gap, and the first of them is a round trip. A rotation
+    // landing there wrote the session back after it had been cleared, and the
+    // next launch reinstated a session the user had ended.
+    const holder: { context?: Harness } = {};
+    const rotateMidSignOut: MatrixPushRegistration = {
+      apply: async () => {},
+      remove: async () => {
+        holder.context?.clients[0]?.rotateSession(REFRESHED_SESSION);
+      },
+    };
+    const context = harness({ storage: stored(), pushRegistration: rotateMidSignOut });
+    holder.context = context;
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.storage.value).toBeUndefined();
+  });
+
+  it('leaves the marker alone after a deliberate sign-out', async () => {
+    // A sign-out leaves no session and a store still recorded as the old
+    // session's, so the next build erases. That is not a refusal of anybody's
+    // session, and forgetting the marker there would drag somebody who has just
+    // signed out straight back into signing in.
+    const context = harness({ storage: stored() });
+    context.runtime.subscribe(() => {});
+    await settle();
+    context.signInAttempt.record();
+
+    await context.runtime.signOut();
+    await settle();
+
+    expect(context.signInAttempt.forgets).toBe(0);
+    expect(context.erased).toEqual([STORE]);
   });
 });
 

--- a/packages/frontend/__tests__/chat/matrixSignInAttempt.test.ts
+++ b/packages/frontend/__tests__/chat/matrixSignInAttempt.test.ts
@@ -58,6 +58,18 @@ describe('createProcessAttempt', () => {
 
     expect(attempt.started()).toBe(true);
   });
+
+  it('can be forgotten, so the run may try once more', () => {
+    // One caller: `matrixRuntime` refusing a stored session because the chat data
+    // on this device is not that session's. The run that recorded the attempt was
+    // signing somebody else in.
+    const attempt = createProcessAttempt();
+    attempt.record();
+
+    attempt.forget();
+
+    expect(attempt.started()).toBe(false);
+  });
 });
 
 describe('selectSignInAttempt', () => {
@@ -127,6 +139,35 @@ describe('createTabAttempt', () => {
     createTabAttempt().record();
 
     expect(entries.get(SIGN_IN_ATTEMPT_KEY)).toBe('true');
+  });
+
+  it('forgets the attempt across the page as well as within it', () => {
+    // Both halves, or none. Forgetting only the variable would leave the tab's
+    // record intact, and the next page load would still refuse to try — which is
+    // the state this call exists to get out of.
+    const entries = installStorage();
+    const attempt = createTabAttempt();
+    attempt.record();
+
+    attempt.forget();
+
+    expect(attempt.started()).toBe(false);
+    expect(entries.has(SIGN_IN_ATTEMPT_KEY)).toBe(false);
+    installStorage(entries);
+    expect(createTabAttempt().started()).toBe(false);
+  });
+
+  it('forgets in a browser with no sessionStorage without reaching for it', () => {
+    // The mirror is the only half that exists there. Reaching for the other one
+    // anyway is how this would throw in a sandboxed frame.
+    const attempt = createTabAttempt();
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    attempt.record();
+
+    expect(() => {
+      attempt.forget();
+    }).not.toThrow();
+    expect(attempt.started()).toBe(false);
   });
 
   it('still refuses a second attempt in a browser with no sessionStorage', () => {

--- a/packages/frontend/__tests__/chat/matrixStoreOwner.test.ts
+++ b/packages/frontend/__tests__/chat/matrixStoreOwner.test.ts
@@ -1,0 +1,117 @@
+import {
+  decodeStoreOwner,
+  encodeStoreOwner,
+  sameStoreOwner,
+  storeOwnerOf,
+  STORE_OWNER_VERSION,
+  type MatrixStoreOwner,
+} from '@/lib/chat/matrixStoreOwner';
+import type { AlloSession } from '@/lib/matrix/types';
+
+/**
+ * The record that says whose the client's store on disk is.
+ *
+ * Small enough to read in one go and worth testing anyway, because everything
+ * `matrixRuntime` does with the store hangs off the one boolean
+ * {@link sameStoreOwner} answers. Get it wrong in the permissive direction and
+ * the account switching onto this device opens the last account's keys; get it
+ * wrong in the strict direction and every launch erases a store it should have
+ * kept and mints a new Matrix device.
+ */
+
+const OWNER: MatrixStoreOwner = {
+  userId: '@nate:matrix.example',
+  deviceId: 'DEVICE',
+  homeserverUrl: 'https://matrix.example',
+};
+
+const SESSION: AlloSession = {
+  ...OWNER,
+  accessToken: 'secret-access-token',
+  refreshToken: 'secret-refresh-token',
+  authData: 'opaque',
+};
+
+describe('storeOwnerOf', () => {
+  it('takes the identity out of a session and nothing else', () => {
+    // Specifically not the tokens. This record is written to AsyncStorage, which
+    // on web is `localStorage`, and the session's tokens live in the keychain for
+    // a reason.
+    expect(storeOwnerOf(SESSION)).toEqual(OWNER);
+  });
+
+  it('carries no part of the session’s credentials into what is written', () => {
+    expect(encodeStoreOwner(storeOwnerOf(SESSION))).not.toContain('secret-');
+  });
+});
+
+describe('sameStoreOwner', () => {
+  it('matches an identity against itself', () => {
+    expect(sameStoreOwner(OWNER, { ...OWNER })).toBe(true);
+  });
+
+  it.each([
+    ['user', { userId: '@lena:matrix.example' }],
+    ['device', { deviceId: 'OTHERDEVICE' }],
+    ['homeserver', { homeserverUrl: 'https://elsewhere.example' }],
+  ])('refuses a record that differs by %s', (_field, difference) => {
+    // All three, and each on its own. The device id is the one most easily left
+    // out: two sessions for the same person on the same homeserver are still two
+    // devices, and the keys in the store belong to one of them.
+    expect(sameStoreOwner(OWNER, { ...OWNER, ...difference })).toBe(false);
+  });
+
+  it('treats nobody as matching nobody', () => {
+    // An unrecorded store and a launch with no session are both "nobody", and
+    // calling that a match would skip the erase in the one case most likely to
+    // have something left over on disk.
+    expect(sameStoreOwner(undefined, undefined)).toBe(false);
+  });
+
+  it('refuses an identity against nobody, in either direction', () => {
+    expect(sameStoreOwner(OWNER, undefined)).toBe(false);
+    expect(sameStoreOwner(undefined, OWNER)).toBe(false);
+  });
+});
+
+describe('decodeStoreOwner', () => {
+  it('reads back what encode wrote', () => {
+    expect(decodeStoreOwner(encodeStoreOwner(OWNER))).toEqual(OWNER);
+  });
+
+  it.each([
+    ['nothing at all', undefined],
+    ['a key that is not there', null],
+    ['an empty string', ''],
+    ['something that is not JSON', 'not json'],
+    ['something that is not an object', '"a string"'],
+    ['null', 'null'],
+    ['a version this build does not write', `{"version":${STORE_OWNER_VERSION + 1}}`],
+    ['a record naming no user', `{"version":${STORE_OWNER_VERSION},"deviceId":"D","homeserverUrl":"h"}`],
+    ['a record naming no device', `{"version":${STORE_OWNER_VERSION},"userId":"@n:h","homeserverUrl":"h"}`],
+    [
+      'a record naming no homeserver',
+      `{"version":${STORE_OWNER_VERSION},"userId":"@n:h","deviceId":"D"}`,
+    ],
+    [
+      'a record whose fields are not strings',
+      `{"version":${STORE_OWNER_VERSION},"userId":1,"deviceId":2,"homeserverUrl":3}`,
+    ],
+  ])('answers nobody for %s', (_case, raw) => {
+    // Every one of these ends the same way at the caller — the store is erased —
+    // so there is nothing to gain from telling them apart. What matters is that
+    // none of them is ever read as an owner, because being read as an owner is
+    // what would let a store be adopted by the wrong identity.
+    expect(decodeStoreOwner(raw)).toBeUndefined();
+  });
+
+  it('does not adopt a store recorded by a build that wrote a different shape', () => {
+    // The version is the whole guard here. A record this build cannot read tells
+    // it nothing about what is on disk, and "nothing" must not round up to "it is
+    // fine".
+    const older = JSON.stringify({ version: 0, ...OWNER });
+
+    expect(decodeStoreOwner(older)).toBeUndefined();
+    expect(sameStoreOwner(decodeStoreOwner(older), OWNER)).toBe(false);
+  });
+});

--- a/packages/frontend/__tests__/matrix/nativeStore.test.ts
+++ b/packages/frontend/__tests__/matrix/nativeStore.test.ts
@@ -1,0 +1,210 @@
+import { MatrixStoreNotErasedError, MatrixStoreUnavailableError } from '@/lib/matrix/errors';
+import { eraseAlloChatStore, resolveAlloChatStore } from '@/lib/matrix/store.native';
+import type { AlloClientStore } from '@/lib/matrix/types';
+
+/**
+ * Where the native client keeps its data, and what erasing it has to guarantee.
+ *
+ * The interesting half is not the deletion, it is the check afterwards. The
+ * SQLite files may still be open when the erase runs — the client that owns them
+ * is closed first, but the Rust object behind it is released by a garbage
+ * collector nothing can wait for — so `delete()` returning is not the same
+ * statement as "the directory is gone". A quiet non-deletion is exactly the
+ * failure that ends with the next account opening the last account's keys, and
+ * unlike a throw there is nothing in the log to say it happened.
+ */
+
+/** The filesystem, as much of it as `store.native.ts` can observe. */
+interface MockFilesystem {
+  /** Directories that exist. Keyed by normalised URI. */
+  readonly present: Set<string>;
+  /** Directories whose `delete()` does nothing at all, silently. */
+  readonly undeletable: Set<string>;
+  /** Directories whose `delete()` throws. */
+  readonly refusing: Map<string, Error>;
+  /** Every `delete()` attempted, in order. */
+  readonly deletes: string[];
+}
+
+let mockState: MockFilesystem | undefined;
+
+/**
+ * The fake filesystem, built on first use.
+ *
+ * Reached through a hoisted function rather than held in a `const`, because
+ * `jest.mock` is hoisted above every import and the factory below is evaluated
+ * while `store.native.ts` is being imported — before any `const` in this file has
+ * run. A function declaration is hoisted with it; the state it returns is not
+ * touched until a test asks for it.
+ */
+function mockFilesystem(): MockFilesystem {
+  mockState ??= {
+    present: new Set<string>(),
+    undeletable: new Set<string>(),
+    refusing: new Map<string, Error>(),
+    deletes: [],
+  };
+  return mockState;
+}
+
+/**
+ * Joins path segments the way `expo-file-system` does, to one canonical URI.
+ *
+ * The leading segment keeps its own slashes — `file:///app` has three and they
+ * all mean something — while every joint between segments collapses to one. Both
+ * ways the module builds a `Directory` have to land on the same string: once from
+ * `Paths.document` plus a name, and once from the `file://` URI it rebuilds out
+ * of the plain path it handed the SDK.
+ */
+function mockNormalize(segments: readonly string[]): string {
+  const [head = '', ...rest] = segments;
+  return [head.replace(/\/+$/, ''), ...rest.map((segment) => segment.replace(/^\/+|\/+$/g, ''))]
+    .filter((segment) => segment !== '')
+    .join('/');
+}
+
+jest.mock('expo-file-system', () => ({
+  Paths: { document: 'file:///app/documents/', cache: 'file:///app/cache/' },
+  Directory: class {
+    readonly uri: string;
+
+    constructor(...segments: string[]) {
+      this.uri = mockNormalize(segments);
+    }
+
+    get exists(): boolean {
+      return mockFilesystem().present.has(this.uri);
+    }
+
+    delete(): void {
+      const filesystem = mockFilesystem();
+      filesystem.deletes.push(this.uri);
+      const refusal = filesystem.refusing.get(this.uri);
+      if (refusal !== undefined) {
+        throw refusal;
+      }
+      if (filesystem.undeletable.has(this.uri)) {
+        return;
+      }
+      filesystem.present.delete(this.uri);
+    }
+  },
+}));
+
+const DATA = '/app/documents/matrix';
+const CACHE = '/app/cache/matrix';
+const STORE: AlloClientStore = { kind: 'filesystem', dataPath: DATA, cachePath: CACHE };
+
+beforeEach(() => {
+  const filesystem = mockFilesystem();
+  filesystem.present.clear();
+  filesystem.undeletable.clear();
+  filesystem.refusing.clear();
+  filesystem.deletes.length = 0;
+});
+
+describe('resolveAlloChatStore', () => {
+  it('gives the Rust SDK a path and not a URI', () => {
+    // It hands what it is given to SQLite. A `file://` URI opens nothing, and the
+    // percent-encoding a URI carries would name a different directory.
+    expect(resolveAlloChatStore()).toEqual({
+      kind: 'filesystem',
+      dataPath: DATA,
+      cachePath: CACHE,
+    });
+  });
+
+  it('keeps the state store out of the cache directory', () => {
+    // The state store holds the device's encryption keys and belongs where the
+    // system will not reclaim it; the event cache is a cache and a phone running
+    // out of space should be allowed to take it.
+    const store = resolveAlloChatStore();
+    expect(store.kind === 'filesystem' && store.dataPath).not.toBe(
+      store.kind === 'filesystem' && store.cachePath,
+    );
+  });
+});
+
+describe('eraseAlloChatStore', () => {
+  it('deletes both directories', async () => {
+    mockFilesystem().present.add(`file://${DATA}`).add(`file://${CACHE}`);
+
+    await eraseAlloChatStore(STORE);
+
+    expect(mockFilesystem().present.size).toBe(0);
+  });
+
+  it('does not delete the same directory twice when both paths are one', async () => {
+    // A deployment is free to point both at one directory: the SDK allows it, and
+    // the second delete would throw on a directory that is already gone.
+    mockFilesystem().present.add(`file://${DATA}`);
+
+    await eraseAlloChatStore({ kind: 'filesystem', dataPath: DATA, cachePath: DATA });
+
+    expect(mockFilesystem().deletes).toEqual([`file://${DATA}`]);
+  });
+
+  it('does nothing for a store that was never on disk', async () => {
+    await eraseAlloChatStore({ kind: 'in-memory' });
+
+    expect(mockFilesystem().deletes).toEqual([]);
+  });
+
+  it('skips a directory that is not there rather than deleting nothing loudly', async () => {
+    await eraseAlloChatStore(STORE);
+
+    expect(mockFilesystem().deletes).toEqual([]);
+  });
+
+  it('refuses to report success for a directory that is still there', async () => {
+    // The whole point of the file. `delete()` returned, the directory survived,
+    // and the runtime is about to open it as somebody else.
+    mockFilesystem().present.add(`file://${DATA}`);
+    mockFilesystem().undeletable.add(`file://${DATA}`);
+
+    await expect(eraseAlloChatStore(STORE)).rejects.toThrow(MatrixStoreNotErasedError);
+  });
+
+  it('names the directories that survived', async () => {
+    mockFilesystem().present.add(`file://${DATA}`).add(`file://${CACHE}`);
+    mockFilesystem().undeletable.add(`file://${DATA}`).add(`file://${CACHE}`);
+
+    const failure = await eraseAlloChatStore(STORE).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(MatrixStoreNotErasedError);
+    expect((failure as MatrixStoreNotErasedError).names).toEqual([DATA, CACHE]);
+  });
+
+  it('still clears the cache when the state store cannot go', async () => {
+    // Attempting both before raising anything. Stopping at the first survivor
+    // would leave behind a directory that could have been reclaimed.
+    mockFilesystem().present.add(`file://${DATA}`).add(`file://${CACHE}`);
+    mockFilesystem().undeletable.add(`file://${DATA}`);
+
+    await expect(eraseAlloChatStore(STORE)).rejects.toThrow(MatrixStoreNotErasedError);
+
+    expect(mockFilesystem().present.has(`file://${CACHE}`)).toBe(false);
+  });
+
+  it('lets a delete that throws propagate', async () => {
+    // The loud failure, left alone: it already says what went wrong, and wrapping
+    // it would throw away the platform's own reason.
+    mockFilesystem().present.add(`file://${DATA}`);
+    mockFilesystem().refusing.set(`file://${DATA}`, new Error('permission denied'));
+
+    await expect(eraseAlloChatStore(STORE)).rejects.toThrow('permission denied');
+  });
+
+  it('refuses a path a file URI would read as something else', async () => {
+    // `#` starts a fragment and `?` starts a query. Encoding them away would name
+    // a different directory, which is the one mistake this could make that ends
+    // in deleting nothing and reporting success.
+    await expect(
+      eraseAlloChatStore({
+        kind: 'filesystem',
+        dataPath: '/app/documents/matrix#1',
+        cachePath: CACHE,
+      }),
+    ).rejects.toThrow(MatrixStoreUnavailableError);
+  });
+});

--- a/packages/frontend/__tests__/matrix/web/store.test.ts
+++ b/packages/frontend/__tests__/matrix/web/store.test.ts
@@ -1,4 +1,4 @@
-import { MatrixPortError } from '@/lib/matrix/errors';
+import { MatrixPortError, MatrixStoreNotErasedError } from '@/lib/matrix/errors';
 import {
   cryptoDatabasePrefix,
   eraseWebStore,
@@ -148,17 +148,46 @@ describe('eraseWebStore', () => {
     expect(indexedDB.deleted).toEqual(['matrix-js-sdk:allo-matrix']);
   });
 
-  it('carries on past a database it is refused', async () => {
-    // A private window can have an `indexedDB` that refuses every mutation,
-    // including deleting a database that is not there. Stopping would leave the
-    // rest behind.
+  it('carries on past a database it is refused, and then refuses to report success', async () => {
+    // Two halves of one rule, and they only make sense together.
+    //
+    // It carries on, because stopping at the first refusal would leave behind
+    // databases that could have gone.
+    //
+    // And it throws, because this is how one account's synced state and keys are
+    // kept away from the next one. Resolving here — which is what this used to do
+    // — told `matrixRuntime` the store was empty, and the runtime opened it and
+    // put the next identity in it. A private window whose `indexedDB` refuses
+    // every mutation now ends at an explanation instead.
     const indexedDB = new FakeIndexedDB();
     indexedDB.present.push('allo-matrix:DEVICE1::matrix-sdk-crypto');
     indexedDB.refuse.add('matrix-js-sdk:allo-matrix');
 
-    await eraseWebStore(STORE, indexedDB.factory());
+    await expect(eraseWebStore(STORE, indexedDB.factory())).rejects.toThrow(
+      MatrixStoreNotErasedError,
+    );
 
     expect(indexedDB.deleted).toEqual(['allo-matrix:DEVICE1::matrix-sdk-crypto']);
+  });
+
+  it('names what is still there, so the failure says which piece', async () => {
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.present.push(
+      'allo-matrix:DEVICE1::matrix-sdk-crypto',
+      'allo-matrix:DEVICE2::matrix-sdk-crypto',
+    );
+    indexedDB.refuse.add('allo-matrix:DEVICE1::matrix-sdk-crypto');
+    indexedDB.refuse.add('allo-matrix:DEVICE2::matrix-sdk-crypto');
+
+    const failure = await eraseWebStore(STORE, indexedDB.factory()).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(MatrixStoreNotErasedError);
+    expect((failure as MatrixStoreNotErasedError).names).toEqual([
+      'allo-matrix:DEVICE1::matrix-sdk-crypto',
+      'allo-matrix:DEVICE2::matrix-sdk-crypto',
+    ]);
   });
 
   it('does nothing for a store that was never on disk', async () => {

--- a/packages/frontend/lib/chat/matrixRuntime.ts
+++ b/packages/frontend/lib/chat/matrixRuntime.ts
@@ -20,6 +20,13 @@ import type {
 import { readMatrixClientConfig } from './matrixConfig';
 import { decodeStoredSession, encodeStoredSession } from './matrixSession';
 import { matrixSessionStorage, type MatrixSessionStorage } from './matrixSessionStorage';
+import { matrixSignInAttempt, type MatrixSignInAttempt } from './matrixSignInAttempt';
+import {
+  matrixStoreOwnerStorage,
+  sameStoreOwner,
+  storeOwnerOf,
+  type MatrixStoreOwnerStorage,
+} from './matrixStoreOwner';
 import {
   defaultPushRegistrationDependencies,
   MatrixPushRegistrar,
@@ -58,6 +65,36 @@ import {
  *   what was written at login is stale within the hour;
  *   `AlloChatClient.observeSession` is subscribed to for exactly as long as the
  *   client lives, and every version it reports is written down.
+ *
+ * ## One identity per store, proven rather than assumed
+ *
+ * The two facts above were both true and together they were still not enough,
+ * because "a launch that finds no session erases the store" says nothing about
+ * the launch that finds one. A session in storage and a store on disk are two
+ * separate things written at two separate moments, and the app used to open them
+ * together on the strength of their both being there. Switch the account signed
+ * in on the device and that is a client authenticating as one identity while
+ * reading the last identity's synced state and holding its decryption keys.
+ *
+ * So the store now records whose it is, outside itself, in `matrixStoreOwner.ts`,
+ * and this class enforces one rule at the top of every build:
+ *
+ * > **A stored session may only be reinstated when the store on disk is recorded
+ * > as belonging to exactly that session. Otherwise both are erased.**
+ *
+ * One branch, and every case falls into it: a store nobody claimed, which is
+ * every store written before this rule existed; a store claimed by a different
+ * account; a session with no store; a store with no session; a sign-out that was
+ * interrupted halfway. Erasing both rather than keeping the session is
+ * deliberate — a Matrix device whose keys have gone cannot decrypt anything and
+ * cannot be re-verified, so reinstating it would only produce a broken device
+ * instead of a new one.
+ *
+ * **An erase that fails stops the launch.** It is raised by the store modules, it
+ * is not caught here, and {@link MatrixRuntime} ends at {@link
+ * MatrixPhase.failed} with no client. A store that could not be emptied must not
+ * be opened by the identity that comes next; that is the whole point of emptying
+ * it.
  */
 
 /** How far along the runtime is. */
@@ -133,6 +170,22 @@ export interface MatrixRuntimeDependencies {
   /** Where the session is kept between launches. */
   readonly sessionStorage: MatrixSessionStorage;
   /**
+   * Where the answer to "whose is the store on disk" is kept.
+   *
+   * Separate from {@link sessionStorage} because it has to be readable when the
+   * session is not, and writable when there is no session to attach it to. See
+   * `matrixStoreOwner.ts`.
+   */
+  readonly storeOwner: MatrixStoreOwnerStorage;
+  /**
+   * Whether this run has already started an automatic sign-in.
+   *
+   * The runtime does not read it — the gate does — but it is the one place that
+   * knows when the attempt stopped describing the person using the app, which is
+   * the moment a session belonging to somebody else is refused.
+   */
+  readonly signInAttempt: MatrixSignInAttempt;
+  /**
    * Opens the authorization page and reports what the browser did. The middle of
    * OIDC's three steps, which the port deliberately does not own.
    */
@@ -180,6 +233,26 @@ export class MatrixClientNotStartedError extends Error {
   }
 }
 
+/**
+ * Work that started on a session the runtime has since stopped keeping.
+ *
+ * Raised rather than allowed to finish, and the case it is really for is the
+ * quiet one: a token rotation queued for storage while the app was signing out,
+ * landing after the sign-out cleared the session and putting it back. On disk
+ * that is indistinguishable from the defect this class was reworked to remove —
+ * a session belonging to somebody who is no longer using the app, waiting to be
+ * reinstated on the next launch.
+ */
+export class MatrixRuntimeSupersededError extends Error {
+  constructor(operation: string) {
+    super(
+      `${operation} was abandoned: it belongs to a Matrix session this runtime ` +
+        'has already stopped keeping.',
+    );
+    this.name = 'MatrixRuntimeSupersededError';
+  }
+}
+
 /** Nothing has happened yet. Also what a build with the flag off always reports. */
 export const IDLE_RUNTIME_STATE: MatrixRuntimeState = {
   phase: 'idle',
@@ -210,6 +283,29 @@ export class MatrixRuntime implements MatrixRuntimeLike {
    * new login goes through, so a sign-in from here starts over with a fresh one.
    */
   #clientHoldsSession = false;
+  /**
+   * Which session the runtime is currently keeping, or `undefined` for none.
+   *
+   * A number that is never reused, opened when a session is installed in the
+   * client and closed the moment the runtime stops intending to keep it — the
+   * top of a sign-out, the top of a start-over, and every detach. Everything
+   * that awaits and then writes reads it first and checks it again afterwards.
+   *
+   * It is checked rather than assumed because the gap between an await and the
+   * write after it is not short, and the client stays subscribed across it. A
+   * sign-out is two awaits and a round trip to the homeserver, and the SDK is
+   * free to rotate its tokens the whole way through: a rotation landing in that
+   * gap wrote the session back AFTER the sign-out had cleared it, and the next
+   * launch reinstated a session the user had ended. A `#startOver` has the same
+   * shape against the sign-in that asked for it.
+   *
+   * Closing it — rather than counting client rebuilds — is what makes the check
+   * work at all. During a sign-out the client has not been let go of yet, so
+   * anything that asked "is this still the current client" would be told yes.
+   */
+  #sessionEpoch: number | undefined;
+  /** Source of {@link #sessionEpoch}. Only ever moves forward. */
+  #nextSessionEpoch = 0;
   /**
    * The tail of the queue of storage operations.
    *
@@ -376,13 +472,23 @@ export class MatrixRuntime implements MatrixRuntimeLike {
       this.#fail('Allo could not finish the sign-in', error);
       return;
     }
+    // There is a session, and from here the runtime intends to keep it.
+    const epoch = this.#openSessionEpoch();
 
     try {
-      // Written down before sync starts, and before anything is drawn. The
-      // Matrix device exists on the homeserver the moment the line above
-      // returned; from here until the session is stored there is a device this
-      // installation would not recognise on its next launch, and the way to make
-      // that window not matter is to make it as short as the code allows.
+      // The store is claimed first and the session written second, and an
+      // interruption between them is why. Stopping after the claim leaves a store
+      // belonging to a session nobody wrote down, which the next launch erases;
+      // stopping after the reverse would leave a session whose store the next
+      // launch erases underneath it, which is a device with no keys rather than
+      // no device.
+      //
+      // Both happen before sync starts and before anything is drawn. The Matrix
+      // device exists on the homeserver the moment `complete` returned; from here
+      // until these two lines are done there is a device this installation would
+      // not recognise on its next launch, and the way to make that window not
+      // matter is to make it as short as the code allows.
+      await this.#dependencies.storeOwner.write(storeOwnerOf(session));
       await this.#remember(session);
     } catch (error) {
       // A sign-in that cannot be remembered is a device minted for one run of the
@@ -395,12 +501,20 @@ export class MatrixRuntime implements MatrixRuntimeLike {
 
     try {
       await client.startSync();
-      this.#publish({ phase: 'ready', userId: session.userId, error: undefined });
     } catch (error) {
       this.#fail('Allo could not finish the sign-in', error);
       return;
     }
 
+    if (epoch !== this.#sessionEpoch) {
+      // Signed out, or started over, while this login was finishing. The session
+      // it produced is already gone from storage and the client it produced is
+      // not this runtime's any more, so announcing it ready would put a phase on
+      // screen that nothing behind it can serve.
+      return;
+    }
+
+    this.#publish({ phase: 'ready', userId: session.userId, error: undefined });
     this.#registerForNotifications(client);
   }
 
@@ -450,6 +564,16 @@ export class MatrixRuntime implements MatrixRuntimeLike {
     if (client === undefined) {
       return;
     }
+
+    // Before anything else, and this line is a fix rather than bookkeeping. The
+    // client is not let go of until the end of this method, so between clearing
+    // the session below and `#detach` at the bottom the runtime is still
+    // subscribed to the SDK's token rotations and the SDK is still free to
+    // rotate — two awaits' worth of window, one of them a round trip to the
+    // homeserver. A rotation landing in there used to write the session back
+    // AFTER the sign-out had cleared it, leaving the next launch to reinstate a
+    // session the user had ended.
+    this.#sessionEpoch = undefined;
 
     // The stored session goes first, and everything else is allowed to fail
     // afterwards. The worst state this can be interrupted in is a store with no
@@ -549,6 +673,9 @@ export class MatrixRuntime implements MatrixRuntimeLike {
    * client that cannot be reused.
    */
   async #startOver(): Promise<AlloChatClient | undefined> {
+    // Same window as {@link #signOut}: the old client is still subscribed until
+    // `#detach` below, and what is being discarded is a session.
+    this.#sessionEpoch = undefined;
     try {
       await this.#forget();
     } catch (error) {
@@ -581,17 +708,10 @@ export class MatrixRuntime implements MatrixRuntimeLike {
       // authorization code in the address bar is what makes a reload resubmit
       // it. On every platform but web this is always `undefined`.
       const callbackUrl = this.#dependencies.pendingAuthorization.take();
-      const stored = await this.#readStoredSession(config.homeserverUrl);
-
-      if (stored === undefined) {
-        // Nothing is being restored, so nothing on disk belongs to this launch.
-        // What may be there is the store of a session that is gone — a sign-out
-        // the app did not live long enough to finish, a record written by an
-        // Allo that stored them differently — and the SDKs' stores hold one user
-        // each. Erasing here is what makes every one of those endings look the
-        // same to the client that opens next.
-        await this.#dependencies.eraseStore(config.store);
-      }
+      const stored = await this.#reinstatable(
+        await this.#readStoredSession(config.homeserverUrl),
+        config,
+      );
 
       const client = await this.#dependencies.createClient(config);
       this.#config = config;
@@ -626,6 +746,60 @@ export class MatrixRuntime implements MatrixRuntimeLike {
   }
 
   /**
+   * Decides whether the stored session may be reinstated, and makes the answer
+   * true on disk.
+   *
+   * The one place the store is erased, and the one place that decides it. It
+   * answers the session when the store on disk is recorded as that session's, and
+   * `undefined` in every other case — having first emptied the store and thrown
+   * the session away, so that the client built next opens something that is
+   * nobody's rather than somebody else's.
+   *
+   * The order inside is the part worth reading. The marker is cleared BEFORE the
+   * erase, never after: a launch killed midway through deleting a database then
+   * comes back to a store recorded as nobody's, which is a state this method
+   * erases again. Recording first and erasing second would leave a half-deleted
+   * store carrying a marker that says it is intact.
+   *
+   * A failure at any step propagates to {@link #build}, which is what stops the
+   * launch. That is deliberate for all three: a marker that cannot be cleared
+   * cannot be trusted, a store that cannot be emptied must not be reopened, and a
+   * session that cannot be forgotten would be reinstated by the next launch
+   * against the store this one just erased.
+   */
+  async #reinstatable(
+    stored: AlloSession | undefined,
+    config: AlloChatClientConfig,
+  ): Promise<AlloSession | undefined> {
+    const recorded = await this.#dependencies.storeOwner.read();
+    if (sameStoreOwner(recorded, stored === undefined ? undefined : storeOwnerOf(stored))) {
+      return stored;
+    }
+
+    await this.#dependencies.storeOwner.clear();
+    await this.#dependencies.eraseStore(config.store);
+
+    if (stored === undefined) {
+      // The ordinary signed-out launch, and the tail of a sign-out. Nothing was
+      // refused, so the run's sign-in attempt still describes the person here and
+      // is left alone: forgetting it is what would drag somebody who has just
+      // deliberately signed out straight back into a sign-in.
+      return undefined;
+    }
+
+    // A usable session, refused, because the data on this device is not its own.
+    // The log line names no account: a Matrix user id is not a secret, but
+    // nothing is gained by writing one into a log a support ticket may carry.
+    logger.warn(
+      '[chat] the stored Matrix session was not reinstated: the chat data on this ' +
+        'device was not written by it, so both have been erased',
+    );
+    await this.#forget();
+    this.#dependencies.signInAttempt.forget();
+    return undefined;
+  }
+
+  /**
    * Puts a stored session back into a fresh client and starts syncing.
    *
    * A failure here is reported and the stored session is **kept**. The reasons a
@@ -637,11 +811,18 @@ export class MatrixRuntime implements MatrixRuntimeLike {
    */
   async #restore(client: AlloChatClient, session: AlloSession): Promise<void> {
     this.#clientHoldsSession = true;
+    const epoch = this.#openSessionEpoch();
     try {
       await client.restoreSession(session);
       await client.startSync();
     } catch (error) {
       this.#fail('Allo could not reopen your last session', error);
+      return;
+    }
+    if (epoch !== this.#sessionEpoch) {
+      // Let go of while it was coming up. Whatever replaced it publishes its own
+      // phase; this one would only overwrite it with a session that is no longer
+      // the runtime's.
       return;
     }
     this.#publish({ phase: 'ready', userId: session.userId, error: undefined });
@@ -683,10 +864,30 @@ export class MatrixRuntime implements MatrixRuntimeLike {
     });
   };
 
+  /** Starts keeping a session, and says which one this is. */
+  #openSessionEpoch(): number {
+    this.#sessionEpoch = this.#nextSessionEpoch;
+    this.#nextSessionEpoch += 1;
+    return this.#sessionEpoch;
+  }
+
+  /**
+   * Writes a session down, unless the runtime has stopped keeping it.
+   *
+   * The epoch is read here and checked again *inside* the queued operation, not
+   * only before queueing: a write waits behind whatever is already in the queue,
+   * and a sign-out is exactly the kind of thing that can be that "whatever".
+   * Asking the question once, on the way in, would ask it at the one moment the
+   * answer is still the old one.
+   */
   #remember(session: AlloSession): Promise<void> {
-    return this.#sequence(() =>
-      this.#dependencies.sessionStorage.write(encodeStoredSession(session)),
-    );
+    const epoch = this.#sessionEpoch;
+    return this.#sequence(async () => {
+      if (epoch === undefined || epoch !== this.#sessionEpoch) {
+        throw new MatrixRuntimeSupersededError('Storing a Matrix session');
+      }
+      await this.#dependencies.sessionStorage.write(encodeStoredSession(session));
+    });
   }
 
   #forget(): Promise<void> {
@@ -715,6 +916,8 @@ export class MatrixRuntime implements MatrixRuntimeLike {
     this.#sessionSubscription?.();
     this.#sessionSubscription = undefined;
     this.#clientHoldsSession = false;
+    // Everything still in flight for the client being let go is now stale.
+    this.#sessionEpoch = undefined;
 
     const client = this.#client;
     this.#client = undefined;
@@ -800,6 +1003,10 @@ const defaultDependencies: MatrixRuntimeDependencies = {
   // name directories and databases, and neither of them loads a Matrix SDK.
   eraseStore: eraseAlloChatStore,
   sessionStorage: matrixSessionStorage,
+  storeOwner: matrixStoreOwnerStorage,
+  // The same object the sign-in gate reads. It has to be: a marker forgotten in
+  // one copy and read from another is a marker that does nothing.
+  signInAttempt: matrixSignInAttempt,
   pushRegistration: new MatrixPushRegistrar(defaultPushRegistrationDependencies()),
   // Platform-split, because the two platforms do genuinely different things: an
   // in-app browser tab that returns control on iOS and Android, a top-level

--- a/packages/frontend/lib/chat/matrixSignInAttempt.ts
+++ b/packages/frontend/lib/chat/matrixSignInAttempt.ts
@@ -18,11 +18,11 @@ import { logger } from '@/utils/logger';
  * trip to the authorization server, it is scoped to the one tab making the trip,
  * and it dies with that tab. A new tab is a new run and may try again.
  *
- * It is never cleared, and that is deliberate on both platforms. Clearing it
- * after a successful login would let the automatic sign-in fire again the moment
- * somebody deliberately signed out, which is the second thing this decision
- * exists to prevent. The button on the sign-in screen does not consult it: a
- * person asking to sign in is not an automatic retry.
+ * A successful login does not clear it, and neither does a sign-out. That is
+ * deliberate on both platforms: clearing it after a login would let the automatic
+ * sign-in fire again the moment somebody deliberately signed out, which is the
+ * second thing this decision exists to prevent. The button on the sign-in screen
+ * does not consult it: a person asking to sign in is not an automatic retry.
  */
 
 export interface MatrixSignInAttempt {
@@ -30,6 +30,22 @@ export interface MatrixSignInAttempt {
   started(): boolean;
   /** Records that one has been. Called before the sign-in, never after. */
   record(): void;
+  /**
+   * Forgets the attempt, so the next render may start a fresh one.
+   *
+   * There is exactly one caller and it is not "the login finished": it is
+   * `matrixRuntime.ts` refusing a stored session because the store on disk is
+   * not that session's, which is what an account switch looks like from
+   * underneath. The attempt being forgotten there is not the retry the paragraph
+   * above refuses — the run that recorded it was signing somebody else in, and
+   * the app has just thrown away everything of theirs. Leaving the marker set
+   * would show whoever is here now a button offering to do the thing the app
+   * could have done by itself.
+   *
+   * It is NOT called for an ordinary sign-out, where there is a session to
+   * discard but no foreign store: that case is the one the marker is for.
+   */
+  forget(): void;
 }
 
 /** The one key. Namespaced so it cannot collide with anything else on the origin. */
@@ -48,6 +64,9 @@ export function createProcessAttempt(): MatrixSignInAttempt {
     started: () => attempted,
     record: () => {
       attempted = true;
+    },
+    forget: () => {
+      attempted = false;
     },
   };
 }
@@ -86,6 +105,14 @@ export function createTabAttempt(): MatrixSignInAttempt {
         return;
       }
       storage.setItem(SIGN_IN_ATTEMPT_KEY, 'true');
+    },
+    forget: () => {
+      process.forget();
+      // Both halves, and the in-memory one first: a browser with no
+      // `sessionStorage` still has the mirror set, and forgetting only the half
+      // that can be written would leave the tab refusing to try again for a
+      // reason nothing on screen could explain.
+      globalThis.sessionStorage?.removeItem(SIGN_IN_ATTEMPT_KEY);
     },
   };
 }

--- a/packages/frontend/lib/chat/matrixStoreOwner.ts
+++ b/packages/frontend/lib/chat/matrixStoreOwner.ts
@@ -1,0 +1,193 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { AlloSession } from '@/lib/matrix/types';
+
+/**
+ * Who the client's store on disk belongs to.
+ *
+ * The store holds one identity's synced state and, on native, that identity's
+ * encryption keys. Nothing inside it says whose it is in a form the app can read
+ * without opening it, and opening it is the thing that has to be decided first —
+ * so the answer is kept outside it, here, and written the moment a session takes
+ * the store over.
+ *
+ * ## Why this exists
+ *
+ * The store's name is fixed. `matrix-js-sdk:allo-matrix` on web and one directory
+ * on native, the same strings whichever session is running, because the SDKs need
+ * a path before there is a session to name one after: a login has to have
+ * somewhere to write the device it is about to mint. A fixed name is safe only if
+ * a store never outlives the session it was made for, and *"the launch found no
+ * session, so it erased the store"* — which is what `matrixRuntime.ts` used to
+ * decide on — is not the same statement. It misses the case that matters:
+ *
+ * > there IS a session in storage, and the store on disk is not its store.
+ *
+ * That is what an account switch looks like from here, and it is what let one
+ * account's client come up holding the previous account's synced state and its
+ * crypto store. Recording the owner turns the question into one the app can
+ * actually answer before it opens anything.
+ *
+ * ## Why AsyncStorage and not the keychain
+ *
+ * Nothing here is a credential. A Matrix user id and a device id are published
+ * by the homeserver to everyone in a room; the session's tokens stay in
+ * `matrixSessionStorage.ts` and never come near this. Keeping the marker out of
+ * the keychain also fixes something on iOS that the keychain causes: keychain
+ * items can survive the app being deleted and reinstalled, while the app's
+ * documents directory cannot. A reinstalled Allo would find a valid session for a
+ * device whose keys no longer exist anywhere. It now finds a session whose store
+ * is not recorded as anyone's, which is a state {@link matrixRuntime} knows what
+ * to do with.
+ *
+ * ## An unrecorded store is nobody's, and is never adopted
+ *
+ * Every store written before this module existed has no owner. It is not given to
+ * whichever identity signs in next — that is precisely the defect — and it is not
+ * guessed at from the session that happens to be in storage beside it, because
+ * the two being beside each other is exactly what the old code assumed and what
+ * was not true. An unowned store is erased, and the session that was sitting next
+ * to it goes with it. The cost is one sign-in, once, for anyone already using the
+ * Matrix backend.
+ */
+
+/**
+ * The identity a store belongs to.
+ *
+ * Three fields and not one: the device id alone repeats across accounts on a
+ * homeserver that recycles them, the user id alone does not distinguish this
+ * installation's device from the same person's other device, and the homeserver
+ * is what makes both of the others mean anything. Comparing all three is the
+ * cheapest way to be exactly right.
+ */
+export interface MatrixStoreOwner {
+  /** The Matrix user id the store's session belongs to. */
+  readonly userId: string;
+  /** The Matrix device the store's keys belong to. */
+  readonly deviceId: string;
+  /** The homeserver both of the above are names on. */
+  readonly homeserverUrl: string;
+}
+
+/**
+ * Bumped when {@link MatrixStoreOwner} changes shape.
+ *
+ * A record this build cannot read is treated as no record at all, which erases
+ * the store. That is the safe direction and the only one available: a marker
+ * that cannot be read cannot prove anything about what is on disk.
+ */
+export const STORE_OWNER_VERSION = 1;
+
+/** The one key. Namespaced so it cannot collide with anything else on the origin. */
+export const STORE_OWNER_KEY = 'allo.matrix.store.owner';
+
+/** The owner a session would be, if it took the store over. */
+export function storeOwnerOf(session: AlloSession): MatrixStoreOwner {
+  return {
+    userId: session.userId,
+    deviceId: session.deviceId,
+    homeserverUrl: session.homeserverUrl,
+  };
+}
+
+/**
+ * Whether two owners are the same identity.
+ *
+ * `undefined` is not equal to anything, including itself. An unrecorded store and
+ * a launch with no session are both "nobody", and treating those as a match would
+ * mean skipping the erase in the one case where there is most likely to be
+ * something left over.
+ */
+export function sameStoreOwner(
+  left: MatrixStoreOwner | undefined,
+  right: MatrixStoreOwner | undefined,
+): boolean {
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  return (
+    left.userId === right.userId &&
+    left.deviceId === right.deviceId &&
+    left.homeserverUrl === right.homeserverUrl
+  );
+}
+
+export function encodeStoreOwner(owner: MatrixStoreOwner): string {
+  return JSON.stringify({ version: STORE_OWNER_VERSION, ...owner });
+}
+
+/**
+ * Reads back what {@link encodeStoreOwner} wrote.
+ *
+ * Every failure answers `undefined` rather than throwing, and they all mean the
+ * same thing to the caller: this store cannot be proven to belong to anybody, so
+ * it belongs to nobody. There is nothing to repair and nothing worth
+ * distinguishing — a damaged marker and a missing one lead to the same erase.
+ */
+export function decodeStoreOwner(raw: string | undefined | null): MatrixStoreOwner | undefined {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return undefined;
+  }
+
+  const fields: Record<string, unknown> = { ...parsed };
+  if (fields.version !== STORE_OWNER_VERSION) {
+    return undefined;
+  }
+
+  const userId = readRequired(fields.userId);
+  const deviceId = readRequired(fields.deviceId);
+  const homeserverUrl = readRequired(fields.homeserverUrl);
+  if (userId === undefined || deviceId === undefined || homeserverUrl === undefined) {
+    return undefined;
+  }
+
+  return { userId, deviceId, homeserverUrl };
+}
+
+/** A non-empty string, or `undefined` if it is anything else. */
+function readRequired(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
+ * Where the marker is kept between launches.
+ *
+ * The same three-method shape as {@link
+ * import('./matrixSessionStorage').MatrixSessionStorage}, and an interface for
+ * the same reason: the runtime takes it as a dependency, so the whole decision
+ * about whose store is on disk can be exercised without a device.
+ */
+export interface MatrixStoreOwnerStorage {
+  /** The recorded owner, or `undefined` if the store is nobody's. */
+  read(): Promise<MatrixStoreOwner | undefined>;
+  /** Records a new owner. Throws if it could not be written. */
+  write(owner: MatrixStoreOwner): Promise<void>;
+  /** Makes the store nobody's. Removing what is not there is not an error. */
+  clear(): Promise<void>;
+}
+
+/**
+ * AsyncStorage, on every platform.
+ *
+ * A write that fails is raised rather than swallowed, and the runtime treats it
+ * as fatal. The alternative reads worse than it sounds: an unrecorded store is
+ * erased on the next launch, so a marker that quietly failed to be written means
+ * a device that mints itself again on every launch — the exact failure the
+ * session storage exists to prevent, arriving by a different door.
+ */
+export const matrixStoreOwnerStorage: MatrixStoreOwnerStorage = {
+  read: async () => decodeStoreOwner(await AsyncStorage.getItem(STORE_OWNER_KEY)),
+  write: (owner) => AsyncStorage.setItem(STORE_OWNER_KEY, encodeStoreOwner(owner)),
+  clear: () => AsyncStorage.removeItem(STORE_OWNER_KEY),
+};

--- a/packages/frontend/lib/matrix/errors.ts
+++ b/packages/frontend/lib/matrix/errors.ts
@@ -161,6 +161,34 @@ export class MatrixStoreUnavailableError extends MatrixPortError {
 }
 
 /**
+ * The client's data was still on disk after it was asked to go.
+ *
+ * The one failure in this file that is a privacy control rather than a guard
+ * against a bug, and the reason it is an error at all rather than a warning: the
+ * store is erased so that the identity signing in next cannot open the identity
+ * before it, and a store that could not be erased must therefore stop the launch
+ * rather than be opened by somebody it does not belong to. Resolving instead —
+ * which is what this used to do on web — turns "I could not delete a database"
+ * into "the next account reads the last account's synced state and holds its
+ * decryption keys".
+ *
+ * {@link names} is what is still there, so the failure says which piece rather
+ * than only that there was one. They are database names and directory paths, not
+ * anything in them.
+ */
+export class MatrixStoreNotErasedError extends MatrixPortError {
+  readonly names: readonly string[];
+
+  constructor(names: readonly string[]) {
+    super(
+      'The Matrix client\'s data could not be erased, so it must not be ' +
+        `reopened by a different account: ${names.join(', ')}`,
+    );
+    this.names = names;
+  }
+}
+
+/**
  * A recovery phrase that is not a BIP-39 mnemonic.
  *
  * The message names no words and quotes nothing back: the phrase is the whole

--- a/packages/frontend/lib/matrix/store.native.ts
+++ b/packages/frontend/lib/matrix/store.native.ts
@@ -1,6 +1,6 @@
 import { Directory, Paths } from 'expo-file-system';
 
-import { MatrixStoreUnavailableError } from '@/lib/matrix/errors';
+import { MatrixStoreNotErasedError, MatrixStoreUnavailableError } from '@/lib/matrix/errors';
 import type { AlloChatStoreEraser, AlloClientStore } from '@/lib/matrix/types';
 
 /**
@@ -49,11 +49,20 @@ export function resolveAlloChatStore(): AlloClientStore {
  * filesystem immediately, and whatever still holds it writes to something no path
  * leads to. What must not happen is the directory surviving, because a client
  * built afterwards would open it.
+ *
+ * So the directory is checked again afterwards rather than assumed gone, and a
+ * survivor is raised as {@link MatrixStoreNotErasedError}. `delete()` throwing is
+ * the loud failure and is left to propagate; this is the quiet one — a delete
+ * that reports nothing and removes nothing — and it is the one that ends with the
+ * next account opening the last account's keys. Both directories are attempted
+ * before anything is raised, so a state store that cannot go does not also leave
+ * the event cache behind.
  */
 export const eraseAlloChatStore: AlloChatStoreEraser = async (store) => {
   if (store.kind === 'in-memory') {
     return;
   }
+  const remaining: string[] = [];
   // A set, because a deployment is free to point both at one directory: the SDK
   // allows it, and deleting the same directory twice would throw on the second.
   for (const path of new Set([store.dataPath, store.cachePath])) {
@@ -61,6 +70,12 @@ export const eraseAlloChatStore: AlloChatStoreEraser = async (store) => {
     if (directory.exists) {
       directory.delete();
     }
+    if (directory.exists) {
+      remaining.push(path);
+    }
+  }
+  if (remaining.length > 0) {
+    throw new MatrixStoreNotErasedError(remaining);
   }
 };
 

--- a/packages/frontend/lib/matrix/store.web.ts
+++ b/packages/frontend/lib/matrix/store.web.ts
@@ -1,4 +1,4 @@
-import { MatrixStoreUnavailableError } from '@/lib/matrix/errors';
+import { MatrixStoreNotErasedError, MatrixStoreUnavailableError } from '@/lib/matrix/errors';
 import type { AlloChatStoreEraser, AlloClientStore } from '@/lib/matrix/types';
 import { logger } from '@/utils/logger';
 
@@ -23,6 +23,14 @@ import { logger } from '@/utils/logger';
  * Both are deleted here, and neither is deleted while a client is using it. Allo
  * on web is safe in one tab and untested in two (`client.web.ts`), and a second
  * tab holding a live session is one of the things that is untested.
+ *
+ * **A deletion that is refused is a failure, and it is raised.** Erasing is how
+ * `matrixRuntime.ts` keeps one identity's synced state and keys away from the
+ * next one, so reporting success for a database that is still there would hand
+ * the next account exactly what this exists to take away. Every candidate is
+ * still attempted before the failure is raised — stopping at the first refusal
+ * would leave behind databases that could have gone — and what is raised names
+ * the ones that did not.
  */
 
 const LOG_TAG = '[matrix]';
@@ -94,8 +102,14 @@ export async function eraseWebStore(
     names.add(name);
   }
 
+  const remaining: string[] = [];
   for (const name of names) {
-    await deleteDatabase(name, indexedDB);
+    if (!(await deleteDatabase(name, indexedDB))) {
+      remaining.push(name);
+    }
+  }
+  if (remaining.length > 0) {
+    throw new MatrixStoreNotErasedError(remaining);
   }
 }
 
@@ -133,25 +147,31 @@ async function cryptoDatabaseNames(
 }
 
 /**
- * Deletes one database, and does not let a refusal stop the others.
+ * Deletes one database, and says whether it went.
+ *
+ * `false` rather than a throw, so that a refusal does not stop the databases
+ * after it from being attempted. The caller collects the refusals and raises one
+ * failure naming all of them.
  *
  * A deletion can be *blocked* rather than refused, which is a connection
  * somewhere else still holding the database open — another tab. It is reported
  * and waited out rather than treated as an error, because the request stays
- * pending and completes when the other connection closes.
+ * pending and completes when the other connection closes. Waiting is the right
+ * answer and it is also the safe one: the caller is holding off a client that
+ * would otherwise open this database, and a launch that hangs with a line in the
+ * log beats one that proceeds into somebody else's keys.
  */
-function deleteDatabase(name: string, indexedDB: IDBFactory): Promise<void> {
+function deleteDatabase(name: string, indexedDB: IDBFactory): Promise<boolean> {
   return new Promise((resolve) => {
     const request = indexedDB.deleteDatabase(name);
     request.onsuccess = () => {
-      resolve();
+      resolve(true);
     };
     request.onerror = () => {
-      // Firefox in a private window has an `indexedDB` that refuses every
-      // mutation, including deleting a database that does not exist. There is
-      // nothing to do about it and nothing the user can do about it.
+      // A browser whose `indexedDB` refuses mutations — some private windows do
+      // — cannot have its store erased, and cannot be allowed to reopen one.
       logger.warn(`${LOG_TAG} the database ${name} could not be deleted`, request.error);
-      resolve();
+      resolve(false);
     };
     request.onblocked = () => {
       logger.warn(


### PR DESCRIPTION
## Summary

Switching the account signed in on a device left Allo authenticated as one identity while reading the last identity's synced state and holding its **decryption keys**. On a shared device account B could read account A's messages. This is a privacy defect, not a refresh bug.

The runtime kept two rules: the stored session is the authority, and a launch that finds no session erases the store before opening it. Neither covers the launch that *does* find one — the session and the store are written at two separate moments and were opened together on the strength of their both being there.

`lib/chat/matrixStoreOwner.ts` now records whose the store is (MXID, device id, homeserver) **outside** it, since whether to open it is the thing that has to be decided first. One rule replaces the old branch in `matrixRuntime.ts`:

> A stored session may only be reinstated when the store on disk is recorded as belonging to exactly that session. Otherwise both are erased.

Every case falls into it: an unclaimed store, another account's store, the same person's other device, a session with no store, a store with no session, an interrupted sign-out. Both are erased rather than just the store — a Matrix device without its keys decrypts nothing and cannot be re-verified.

The identity is taken from the **Matrix session itself**, not from `useOxy()`, so it survives the move to a single MAS session.

**Data already on disk has no owner and is never adopted.** It is not handed to whichever identity signs in next, and not guessed at from the session beside it — that assumption is exactly what was untrue. It is erased, and that session with it: one extra sign-in, once, for anyone on the Matrix backend (`EXPO_PUBLIC_CHAT_BACKEND` defaults to `allo-api`, so approximately nobody). This also fixes an iOS case: the keychain can survive an app being deleted while the documents directory cannot, so a reinstall used to restore a session for a device whose keys were gone.

Two supporting fixes, without which the rule means nothing:

- **A failed erase blocks.** `store.web.ts` resolved on a refused IndexedDB deletion — telling the runtime the store was empty and letting it open the last account's keys. Both erasers now attempt everything, then raise `MatrixStoreNotErasedError` naming what survived; native rechecks that the directory is actually gone rather than trusting `delete()`. The build ends at `failed` with **no client**.
- **In-flight work does not cross the boundary.** The client is not released until the end of `signOut`, so across two awaits and a homeserver round trip the runtime stayed subscribed to token rotations — one landing there rewrote the session *after* the sign-out cleared it. A session epoch closes the moment the runtime stops intending to keep a session, and is rechecked *inside* the queued write, not only before queueing.

## Test plan

Baseline on `main`: 87 suites / 1224 tests, tsc 0 errors.

- `bunx tsc --noEmit -p tsconfig.json` — **0 errors**
- `bunx jest --watchAll=false` — **89 suites / 1275 tests, all passing** (+2 suites, +51 tests)
- `bun run --cwd packages/frontend build` — production web export succeeds
- `bunx eslint` on every changed file — 0 errors, 0 warnings

New coverage: `__tests__/chat/matrixStoreOwner.test.ts`, `__tests__/matrix/nativeStore.test.ts` (the native eraser had none), a `MatrixRuntime store ownership` block, and cases for `forget()` and the web eraser's new contract.

One existing test changed contract deliberately: *"carries on past a database it is refused"* now also asserts it refuses to report success.

### Mutation testing

13 mutations, each applied to the source, **asserted changed on disk before the run** and asserted restored after. All 13 killed.

| Mutation | Result |
|---|---|
| M1 a store owned by another identity is accepted | KILLED (7 failed) |
| M2 owner comparison ignores the device id | KILLED (2 failed) |
| M3 an unrecorded store counts as a match | KILLED (2 failed) |
| M4 the marker is cleared after the erase instead of before | KILLED (2 failed) |
| M5 a failed erase is swallowed and the launch continues | KILLED (1 failed) |
| M6 the web eraser reports success for a database it could not delete | KILLED (2 failed) |
| M7 the native eraser never rechecks the directory is gone | KILLED (3 failed) |
| M8 the session is written down before the store is claimed | KILLED (1 failed) |
| M9 a sign-out no longer closes the session epoch on the way in | KILLED (1 failed) |
| M10 a late write is accepted because the epoch is never rechecked | KILLED (1 failed) |
| M11 the sign-in marker survives a refused session | KILLED (1 failed) |
| M12 the marker is forgotten on every erase, sign-outs included | KILLED (3 failed) |
| M13 `forget()` leaves the tab's record of the attempt in place | KILLED (1 failed) |

## Not in this change

The React `AccountSwitchReset`-style boundary, Oxy-viewer-keyed cache leases and the wipe of the legacy `allo-api` AsyncStorage caches (`conversations_list`, `messages_*`, `@allo/drafts`, the offline queue, the `signal_*` keys) were dropped when the architecture moved to one MAS session: all of them key on an Oxy viewer id that is being removed, and those caches are written under the Oxy identity on a path where no Matrix identity exists. **They remain unscoped on disk** and want a separate change once the single-session work lands.

Also unchanged: refusing a session does not tell the homeserver, so the abandoned Matrix device stays listed on the account until its token expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)