### PR TITLE
fix(chat): show the person, not their Matrix id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,23 @@ Two spikes back the decisions. Both live outside the workspaces, so a root
   profile here is who somebody is plus a button to talk to them, not a feed:
   `components/profile/ProfileIdentity.tsx` draws the person and is shared with
   the conversation-details pane.
+- **Who somebody in a conversation is:** `lib/chat/people.ts`, and nothing else
+  in chat asks Oxy about a person. It exists because **the homeserver knows
+  nobody's name**: MAS knows the Oxy subject only as a localpart and Allo never
+  sets a Matrix `displayname`, so every title a client computes from a room's
+  members is an MXID and every `displayName` the port reports is `undefined`.
+  `matrixIdentity.ts` goes both ways now — `oxyUserIdFrom` is the exact inverse
+  of `matrixUserIdFor` and **as strict**, because a coerced lookup succeeds
+  against a stranger; a bridge puppet, a foreign user and a malformed localpart
+  are all refused, and `roomOrigin.ts` is asked about the first before the
+  localpart is examined at all. `hooks/useChatPeople.ts` binds it to React
+  Query: one cache entry per person, and `ChatPeopleDirectory` coalesces a tick's
+  worth of ids into one `getUsersByIds`, so a group of thirty is one request. A
+  person still being looked up draws NOTHING and one that could not be resolved
+  draws `chat.person.unknown` — never the id.
+  `__tests__/chat/noMatrixIdsOnScreen.test.ts` is a source scan that fails if an
+  identifier can reach a screen again; there is no render test in this repo, and
+  the regression is the shape of the expression rather than one screen.
 - **Privacy settings:** five rows, and the shapes differ on purpose — one switch
   in the list (online status), one chooser screen (visibility), three list
   screens (blocked, restricted, hidden words, the first two sharing

--- a/docs/matrix/ui-wiring.md
+++ b/docs/matrix/ui-wiring.md
@@ -827,13 +827,17 @@ no cumple. Tampoco borra nada — la sala sigue ahí para quien se queda — y v
 sólo es posible si alguien invita otra vez, porque una sala de Allo es sólo por
 invitación.
 
-### 10.5 Los miembros no tienen cara
+### 10.5 Los miembros no tienen cara *en Matrix*
 
 `AlloRoomMember` no lleva avatar, y es una decisión. Lo que los dos SDK tienen de
 un miembro es un `mxc://`, que no es algo que una vista pueda pedir — el mismo
 problema por el que existe `AlloMediaRef` (§7.1) — así que un campo ahí sería una
 URL que dibuja una imagen rota en todas las filas. Hasta que los avatares de
-miembro pasen por `downloadMedia`, la lista honesta son los nombres.
+miembro pasen por `downloadMedia`, el puerto no da cara.
+
+La cara que sí se dibuja no es la de Matrix: es la de la cuenta Oxy, resuelta por
+`lib/chat/people.ts` (§12). Son dos cosas distintas y la de Matrix sigue sin
+existir.
 
 ---
 
@@ -905,3 +909,64 @@ en cuanto el runtime deja de querer conservarla. Todo lo que espera y luego
 escribe lo lee antes y lo vuelve a comprobar después —dentro de la operación
 encolada, no sólo al encolarla, porque una escritura espera detrás de lo que ya
 hubiera en la cola.
+
+---
+
+## 12. Quién es cada persona
+
+### 12.1 El problema: el homeserver no sabe el nombre de nadie
+
+MAS conoce el sujeto de Oxy solo como *localpart*, y nada en Allo escribe nunca
+un `displayname` ni un `avatar_url` de Matrix. **Así que en `allo.you` nadie
+tiene nombre**, y todo lo que Matrix calcula a partir de un nombre de miembro
+sale como un identificador:
+
+- el título de una sala sin `m.room.name` — que es toda conversación de dos, y
+  todo grupo creado sin nombre — se calcula a partir de los miembros, y sale
+  `@<hex>:allo.you`, o varios unidos por lo que una y otra SDK usen para unirlos;
+- `AlloRoomMember.displayName` sale `undefined`;
+- `AlloTimelineItem.senderDisplayName` sale `undefined`.
+
+El dueño abrió una conversación y leyó `@<hex>:allo.you` donde va un nombre.
+
+### 12.2 La costura
+
+`lib/chat/matrixIdentity.ts` va ahora en las dos direcciones. `oxyUserIdFrom` es
+el inverso exacto de `matrixUserIdFor` y **es igual de estricto**: un localpart
+que no sea un id de Oxy bien formado se rechaza en vez de repararse, porque una
+búsqueda forzada acierta — con otra persona, cuyo nombre y cuya cara acabarían
+sobre los mensajes de un desconocido. Rechaza tres casos, y los tres son
+corrientes: el fantasma de un puente, alguien de otro homeserver, y un localpart
+que no es un id.
+
+`lib/chat/people.ts` es **la única puerta** por la que el chat pregunta a Oxy
+quién es alguien. Está así porque las cinco llamadas `oxyServices.*` del frontend
+se van detrás de `api.allo.you`: un módulo que las hace es una mudanza, veinte
+sitios son veinte. Clasifica primero (`bridged` → `oxy` → `foreign`, y el orden
+importa: la regla del puente se pregunta antes de mirar el localpart), y solo
+para `oxy` busca en Oxy.
+
+`hooks/useChatPeople.ts` lo ata a React con React Query, **una entrada de caché
+por persona y una petición por lote**: `ChatPeopleDirectory` junta todo lo que se
+pide en un mismo tick en un solo `getUsersByIds`, así que un grupo de treinta es
+una petición, y la segunda vez ninguna.
+
+### 12.3 Qué se dibuja cuando no se sabe
+
+Tres estados, y son distintos a propósito:
+
+| estado | qué se dibuja |
+|---|---|
+| `resolved` | su nombre, su handle y su cara |
+| `pending` | **nada**. Un nombre que aparece y cambia dice algo falso mientras tanto |
+| `unresolved` | `chat.person.unknown` — "Persona desconocida" |
+
+Un contacto de un puente se dibuja con lo que diga Matrix y **nunca** se busca en
+Oxy: mautrix pone nombre a sus fantasmas, y ese es el único que hay. Si el puente
+no puso ninguno, lee como cualquier otra persona sin resolver.
+
+**En ningún estado sale un identificador.**
+`__tests__/chat/noMatrixIdsOnScreen.test.ts` lo vigila leyendo el código fuente,
+porque no hay ningún test de render en el repositorio y porque la regresión es la
+*forma* de la expresión — `displayName ?? userId` — idéntica en los cinco sitios
+donde estaba.

--- a/packages/frontend/__tests__/chat/ephemeralRefusalCopy.test.ts
+++ b/packages/frontend/__tests__/chat/ephemeralRefusalCopy.test.ts
@@ -1,0 +1,128 @@
+import {
+  ephemeralRefusalMessage,
+  REFUSAL_NAMING_NOBODY_KEY,
+  REFUSAL_NAMING_PEOPLE_KEY,
+  REFUSAL_OWN_DEVICE_KEY,
+  UNKNOWN_PERSON_KEY,
+  type Translate,
+} from '@/components/matrix/ephemeralRefusal';
+import { NO_CHAT_PEOPLE, type ChatPeopleLookup, type ChatPerson } from '@/lib/chat/people';
+import { MatrixEphemeralUntrustedError } from '@/lib/matrix/errors';
+
+/**
+ * WHAT THE COMPOSER SAYS WHEN AN EPHEMERAL CONVERSATION REFUSES TO SEND.
+ *
+ * The refusal names people, and the port hands it Matrix user ids. Joined
+ * straight into the sentence, the toast read "it does not recognise the identity
+ * of @507f1f77bcf86cd799439011:allo.you" — which the reader cannot act on,
+ * because they have no idea who that is. `EphemeralSection` has taken a name
+ * mapper for exactly this reason since it was written; the composer had none.
+ */
+
+const ALBA = '@507f1f77bcf86cd799439011:allo.you';
+const BRUNO = '@507f1f77bcf86cd799439012:allo.you';
+const ROOM = '!room:allo.you';
+
+/** Interpolates rather than translating, so the assertion is about the sentence. */
+const t: Translate = (key, options) =>
+  key.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => String(options?.[name] ?? ''));
+
+function person(userId: string, displayName: string): ChatPerson {
+  return {
+    userId,
+    origin: { kind: 'oxy', oxyUserId: userId.slice(1).split(':')[0] },
+    state: displayName === '' ? 'pending' : 'resolved',
+    displayName,
+    handle: undefined,
+    avatarUrl: undefined,
+    verified: false,
+  };
+}
+
+function lookup(...people: readonly ChatPerson[]): ChatPeopleLookup {
+  const byUserId = new Map(people.map((entry) => [entry.userId, entry]));
+  return (userId) => byUserId.get(userId);
+}
+
+function untrusted(...userIds: readonly string[]): MatrixEphemeralUntrustedError {
+  return new MatrixEphemeralUntrustedError(ROOM, {
+    kind: 'members-untrusted',
+    userIds: [...userIds],
+  });
+}
+
+describe('ephemeralRefusalMessage', () => {
+  it('names the people it does not recognise', () => {
+    const message = ephemeralRefusalMessage(
+      untrusted(ALBA, BRUNO),
+      lookup(person(ALBA, 'Alba Ruiz'), person(BRUNO, 'Bruno Vidal')),
+      t,
+    );
+
+    expect(message).toContain('Alba Ruiz, Bruno Vidal');
+  });
+
+  it('never puts a Matrix user id in the sentence', () => {
+    // The regression, stated as the property rather than as one wording. Every
+    // combination of resolved, pending and never-asked-about, and none of them
+    // may produce an id.
+    const cases: readonly ChatPeopleLookup[] = [
+      NO_CHAT_PEOPLE,
+      lookup(person(ALBA, 'Alba Ruiz')),
+      lookup(person(ALBA, ''), person(BRUNO, 'Bruno Vidal')),
+      lookup(person(ALBA, 'Alba Ruiz'), person(BRUNO, 'Bruno Vidal')),
+    ];
+
+    for (const people of cases) {
+      const message = ephemeralRefusalMessage(untrusted(ALBA, BRUNO), people, t) ?? '';
+      expect(message).not.toContain(ALBA);
+      expect(message).not.toContain(BRUNO);
+      expect(message).not.toContain('allo.you');
+    }
+  });
+
+  it('drops the list whole when one of the people cannot be named', () => {
+    // Rather than padding it: "the identity of Bruno, Unknown person" reads as a
+    // bug, and the sentence below says the same thing without pretending to
+    // enumerate.
+    const message = ephemeralRefusalMessage(
+      untrusted(ALBA, BRUNO),
+      lookup(person(BRUNO, 'Bruno Vidal')),
+      t,
+    );
+
+    expect(message).toBe(REFUSAL_NAMING_NOBODY_KEY);
+    expect(message).not.toContain('Bruno');
+  });
+
+  it('does not use the unknown-person label as one of the names', () => {
+    const message = ephemeralRefusalMessage(untrusted(ALBA), NO_CHAT_PEOPLE, t) ?? '';
+    expect(message).not.toContain(UNKNOWN_PERSON_KEY);
+  });
+
+  it('says the other refusal without naming anybody', () => {
+    const message = ephemeralRefusalMessage(
+      new MatrixEphemeralUntrustedError(ROOM, { kind: 'own-device-unverified' }),
+      NO_CHAT_PEOPLE,
+      t,
+    );
+
+    expect(message).toBe(REFUSAL_OWN_DEVICE_KEY);
+  });
+
+  it('leaves every other failure to the caller', () => {
+    // Anything that is really an error keeps its own handling, which is what the
+    // `?? errorMessage` at the call site is for.
+    expect(ephemeralRefusalMessage(new Error('offline'), NO_CHAT_PEOPLE, t)).toBeUndefined();
+    expect(ephemeralRefusalMessage(undefined, NO_CHAT_PEOPLE, t)).toBeUndefined();
+  });
+
+  it('uses the two keys the bundles carry', () => {
+    // The English sentence is the i18next key here, as everywhere else in the
+    // app, so a reworded sentence that is not also reworded in `locales/` shows
+    // up as the sentence in English for everybody. `personTranslations.test.ts`
+    // is what checks the bundles have them.
+    expect(REFUSAL_NAMING_PEOPLE_KEY).toContain('{{people}}');
+    expect(REFUSAL_NAMING_NOBODY_KEY).not.toContain('{{');
+  });
+});

--- a/packages/frontend/__tests__/chat/matrixIdentity.test.ts
+++ b/packages/frontend/__tests__/chat/matrixIdentity.test.ts
@@ -2,6 +2,9 @@ import {
   MatrixIdentityError,
   matrixServerNameOf,
   matrixUserIdFor,
+  matrixUserIdsIn,
+  oxyUserIdFrom,
+  parseMatrixUserId,
 } from '@/lib/chat/matrixIdentity';
 
 /**
@@ -73,5 +76,134 @@ describe('matrixUserIdFor', () => {
     // is ASCII — the localpart by its grammar, the server name by Matrix's —
     // so the character count is the byte count.
     expect(() => matrixUserIdFor('a'.repeat(256), 'allo.you')).toThrow(MatrixIdentityError);
+  });
+});
+
+describe('parseMatrixUserId', () => {
+  it('splits on the first colon, so a port stays with the server', () => {
+    // An IPv6 literal holds several colons and a localpart holds none, so the
+    // first one is the only split that is right in both cases.
+    expect(parseMatrixUserId('@alba:localhost:8448')).toEqual({
+      localpart: 'alba',
+      serverName: 'localhost:8448',
+    });
+    expect(parseMatrixUserId('@alba:[::1]:8448')).toEqual({
+      localpart: 'alba',
+      serverName: '[::1]:8448',
+    });
+  });
+
+  it('reads a localpart the modern grammar would reject', () => {
+    // Wider on the way in than on the way out. A bridge's puppet and any
+    // account from before the modern rules have to be RECOGNISED as user ids,
+    // because a string that is not recognised as one is left on screen verbatim.
+    expect(parseMatrixUserId('@whatsapp_34600111222:allo.you')?.localpart).toBe(
+      'whatsapp_34600111222',
+    );
+    expect(parseMatrixUserId('@Alice:matrix.org')?.localpart).toBe('Alice');
+  });
+
+  it.each([
+    ['no sigil', 'alba:allo.you'],
+    ['no colon', '@alba'],
+    ['an empty localpart', '@:allo.you'],
+    ['an empty server name', '@alba:'],
+    ['a space in the localpart', '@al ba:allo.you'],
+    ['nothing at all', ''],
+  ])('refuses a string with %s', (_what, value) => {
+    expect(parseMatrixUserId(value)).toBeUndefined();
+  });
+
+  it('refuses a user id past the 255-byte cap', () => {
+    const tooLong = `@${'a'.repeat(250)}:allo.you`;
+    expect(tooLong.length).toBeGreaterThan(255);
+    expect(parseMatrixUserId(tooLong)).toBeUndefined();
+  });
+});
+
+describe('oxyUserIdFrom', () => {
+  it('is the exact inverse of matrixUserIdFor', () => {
+    // The round trip is the whole claim `data-model.md` §6.2 makes: the mapping
+    // is arithmetic in both directions, so neither side needs a table.
+    expect(oxyUserIdFrom(matrixUserIdFor(OXY_ID, 'allo.you'), 'allo.you')).toBe(OXY_ID);
+  });
+
+  it('refuses a localpart that is not an Oxy id, rather than coercing one', () => {
+    // The mirror of `matrixUserIdFor`'s refusal, and the same hazard read
+    // backwards: pad, trim or lowercase a localpart into an Oxy id and the
+    // lookup succeeds — against somebody else, whose name and face are then
+    // drawn over a stranger's messages.
+    expect(oxyUserIdFrom('@alba:allo.you', 'allo.you')).toBeUndefined();
+    expect(oxyUserIdFrom(`@${OXY_ID}x:allo.you`, 'allo.you')).toBeUndefined();
+    expect(oxyUserIdFrom(`@${OXY_ID.slice(0, 23)}:allo.you`, 'allo.you')).toBeUndefined();
+    expect(oxyUserIdFrom('@507F1F77BCF86CD799439011:allo.you', 'allo.you')).toBeUndefined();
+    expect(oxyUserIdFrom('@507f1f77bcf86cd79943901z:allo.you', 'allo.you')).toBeUndefined();
+  });
+
+  it("refuses a bridge's puppet, which is not an Oxy account at all", () => {
+    expect(oxyUserIdFrom('@whatsapp_34600111222:allo.you', 'allo.you')).toBeUndefined();
+    // Even one whose remote id happens to be shaped like an Oxy ObjectId: the
+    // namespace prefix is part of the localpart, so it is not one.
+    expect(oxyUserIdFrom(`@telegram_${OXY_ID}:allo.you`, 'allo.you')).toBeUndefined();
+  });
+
+  it('refuses a user on another homeserver, whose localpart means nothing here', () => {
+    expect(oxyUserIdFrom(`@${OXY_ID}:matrix.org`, 'allo.you')).toBeUndefined();
+  });
+
+  it('refuses a user id past the 255-byte cap', () => {
+    expect(oxyUserIdFrom(`@${'a'.repeat(250)}:allo.you`, 'allo.you')).toBeUndefined();
+  });
+
+  it('refuses something that is not a user id', () => {
+    // `undefined` and not a throw, unlike the forward direction: this is asked
+    // about every member of every room, and "not an Oxy account" is a routine,
+    // correct answer with a rendering of its own.
+    expect(oxyUserIdFrom('Familia', 'allo.you')).toBeUndefined();
+    expect(oxyUserIdFrom('', 'allo.you')).toBeUndefined();
+  });
+});
+
+describe('matrixUserIdsIn', () => {
+  it('finds the one id a direct conversation is titled with', () => {
+    expect(matrixUserIdsIn(`@${OXY_ID}:allo.you`)).toEqual([`@${OXY_ID}:allo.you`]);
+  });
+
+  it('finds every id in a title an SDK composed from the members', () => {
+    // What both SDKs produce for a group with no `m.room.name` when nobody in it
+    // has a Matrix display name, which on Allo's homeserver is everybody.
+    expect(matrixUserIdsIn('@aaa:allo.you, @bbb:allo.you and 2 others')).toEqual([
+      '@aaa:allo.you',
+      '@bbb:allo.you',
+    ]);
+  });
+
+  it('does not eat the punctuation after an id', () => {
+    // The server half is matched as dot-separated labels, so a full stop at the
+    // end of a sentence is not read as another one.
+    expect(matrixUserIdsIn('ask @aaa:allo.you.')).toEqual(['@aaa:allo.you']);
+    expect(matrixUserIdsIn('@aaa:allo.you, then')).toEqual(['@aaa:allo.you']);
+  });
+
+  it('reports each id once, however often it appears', () => {
+    expect(matrixUserIdsIn('@aaa:allo.you and @aaa:allo.you')).toEqual(['@aaa:allo.you']);
+  });
+
+  it('re-checks what the scan found instead of trusting it', () => {
+    // The scan is deliberately wider than the grammar, so its candidates go back
+    // through `parseMatrixUserId`. Without that, a string past the 255-byte cap
+    // comes out as an id — and a caller would then substitute a name for
+    // something no homeserver could ever have issued.
+    const tooLong = `@${'a'.repeat(250)}:allo.you`;
+    expect(tooLong.length).toBeGreaterThan(255);
+    expect(matrixUserIdsIn(`talking to ${tooLong}`)).toEqual([]);
+  });
+
+  it('finds nothing in a name somebody typed', () => {
+    // A title with no user id in it must come back byte for byte, which is what
+    // an empty list gives the caller.
+    expect(matrixUserIdsIn('Familia')).toEqual([]);
+    expect(matrixUserIdsIn('budget@work: 2026')).toEqual([]);
+    expect(matrixUserIdsIn('')).toEqual([]);
   });
 });

--- a/packages/frontend/__tests__/chat/matrixViewModel.test.ts
+++ b/packages/frontend/__tests__/chat/matrixViewModel.test.ts
@@ -71,18 +71,28 @@ describe('toConversation', () => {
       type: 'direct',
       name: 'Alice',
       unreadCount: 3,
-      avatar: 'mxc://a',
     });
+  });
+
+  it("drops the room's own avatar, which is an mxc URI nothing here can fetch", () => {
+    // It used to be passed straight through, and `getConversationAvatar` hands
+    // anything that is not an http(s)/file URL to `oxyServices.getFileDownloadUrl`
+    // — so every Matrix room with an avatar drew a broken image pointing at Oxy's
+    // CDN for a file id that is not one.
+    expect(toConversation(room({ avatarUrl: 'mxc://a' }), LABELS, false).avatar).toBeUndefined();
   });
 
   it('calls a room that is not a direct message a group', () => {
     expect(toConversation(room({ isDirect: false }), LABELS, false).type).toBe('group');
   });
 
-  it('falls back to the room id while the name has not synced', () => {
-    // A blank row is worse than an ugly one: the user can still tell two
-    // unnamed conversations apart by their ids, and cannot tell two blanks apart.
-    expect(toConversation(room({ displayName: undefined }), LABELS, false).name).toBe('!room:allo.you');
+  it('has no name at all while the room has not synced, rather than a room id', () => {
+    // It used to fall back to `summary.roomId`, on the reasoning that two unnamed
+    // conversations can at least be told apart by their ids. They cannot: nobody
+    // knows which of their conversations is `!AbCdEf:allo.you`, and the row
+    // already carries a message and a time to tell them apart by. A row with no
+    // title is a row missing one; a row titled with an identifier looks broken.
+    expect(toConversation(room({ displayName: undefined }), LABELS, false).name).toBe('');
   });
 
   it('shows the last message and the time it was sent', () => {

--- a/packages/frontend/__tests__/chat/noMatrixIdsOnScreen.test.ts
+++ b/packages/frontend/__tests__/chat/noMatrixIdsOnScreen.test.ts
@@ -52,6 +52,57 @@ const NAME_FALLS_BACK_TO_ID = new RegExp(
     String.raw`(?:\?\?|\|\|)\s*[A-Za-z0-9_.?[\]'"]*\b(?:${IDENTIFIER_FIELDS})\b`,
 );
 
+/** The bindings this app draws as a person's name. */
+const NAME_BINDINGS = String.raw`name|displayName|title|label|senderName|contactName|roomName`;
+
+/**
+ * An identifier assigned INTO a name, which is the same bug wearing a variable.
+ *
+ * {@link NAME_FALLS_BACK_TO_ID} reads one direction — `displayName ?? userId`.
+ * Reverse the operands and it matches nothing, yet
+ * `const name = member.userId ?? person?.displayName` draws exactly the
+ * `@<hex>:allo.you` this whole change removed. The identifier never appears next
+ * to a `<Text>`; it appears next to an `=`, and two lines later `name` is drawn
+ * by a rule that has no reason to suspect it.
+ *
+ * Found by mutation: that one line was applied to `app/(chat)/room/[id].tsx` and
+ * all 1355 tests stayed green. A regression test that cannot fail on a
+ * one-line reintroduction of the bug it is named after is decoration.
+ */
+const NAME_BINDING = new RegExp(
+  String.raw`\b(?:const|let)\s+(?:${NAME_BINDINGS})\s*(?::[^=]+)?=\s*([^;\n]*)`,
+  'g',
+);
+
+const IDENTIFIER_FIELD = new RegExp(String.raw`\b(?:${IDENTIFIER_FIELDS})\b`);
+
+/**
+ * What a name-shaped binding is actually assigned, with the two places an
+ * identifier legitimately appears taken out first.
+ *
+ * `people(senderId)?.displayName` passes an id to a resolver and keeps the name
+ * it answers with; `isIncoming && senderId ? getSenderName(senderId) : undefined`
+ * tests one. Both are correct, and a rule that could not tell them from
+ * `member.userId ?? person?.displayName` would be switched off within a week —
+ * all three of Allo's current name bindings are of the first two kinds.
+ *
+ * So: call arguments go (innermost first, until none are left), then a ternary's
+ * condition. `??` and `?.` are not ternaries and survive, which is the point —
+ * the identifier in the reversed fallback is on neither side of a `?`.
+ */
+function assignedNames(source: string): string[] {
+  const values: string[] = [];
+  for (const [, initializer] of source.matchAll(NAME_BINDING)) {
+    let value = initializer;
+    for (let previous = ''; value !== previous; ) {
+      previous = value;
+      value = value.replace(/\([^()]*\)/g, '()');
+    }
+    values.push(value.replace(/^[^?]*?\?(?![.?])/, ''));
+  }
+  return values;
+}
+
 /**
  * The two components that put a string on screen in this app.
  *
@@ -204,6 +255,18 @@ describe('no Matrix user id can reach the screen', () => {
     // homeserver. It is the only path, because nobody there has a Matrix display
     // name. What to draw for somebody who cannot be named is
     // `chat.person.unknown`, and `lib/chat/people.ts` is what decides it.
+    expect(offenders).toEqual([]);
+  });
+
+  it('never assigns an identifier into something called a name', () => {
+    const offenders = sourceFiles()
+      .filter(({ path }) => NOT_DRAWN[path.split(sep).join('/')] === undefined)
+      .filter(({ source }) => assignedNames(source).some((value) => IDENTIFIER_FIELD.test(value)))
+      .map(({ path }) => path);
+
+    // The rule above only reads `name ?? id`. Written the other way round the
+    // identifier lands in a variable the drawing rules trust by its name, and
+    // the bug is back with nothing to catch it.
     expect(offenders).toEqual([]);
   });
 

--- a/packages/frontend/__tests__/chat/noMatrixIdsOnScreen.test.ts
+++ b/packages/frontend/__tests__/chat/noMatrixIdsOnScreen.test.ts
@@ -1,0 +1,269 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+/**
+ * NOBODY IS SHOWN AS AN IDENTIFIER.
+ *
+ * The owner opened a conversation and read `@<hex>:allo.you` where a person's
+ * name belongs. It was not one mistake: the conversation header, the room list,
+ * the member list, the message-info sheet and the ephemeral refusal each reached
+ * for an id independently, because each one had a name that might be absent and
+ * an id that never is. On Allo's homeserver the name is ALWAYS absent — Matrix
+ * Authentication Service publishes no `displayname` — so every one of those
+ * fallbacks was not a fallback but the normal path.
+ *
+ * **This is the test that stops it coming back**, and it is a source scan rather
+ * than a render test on purpose. There is no render test in this repo — there is
+ * no `@testing-library/react-native` and no `react-test-renderer` — so a test
+ * that covered these surfaces by drawing them would have to bring in a rendering
+ * stack, mock the Oxy provider, the Matrix runtime, React Query, i18n and the
+ * theme for each one, and would still only cover the surfaces somebody
+ * remembered to write a case for. The regression is the *shape* of the
+ * expression, it is identical in all five places, and a scan sees every file
+ * whether or not anybody thought about it. Same shape and same reasoning as
+ * `__tests__/routes/navigationTargets.test.ts` and
+ * `__tests__/appearanceEndpoint.test.ts`.
+ *
+ * What it cannot see: an id that reaches the screen through a variable named
+ * something else, or through a helper. Those are covered where they are built
+ * instead — `lib/chat/people.ts` is the only place that builds a name for
+ * somebody in a conversation, and `__tests__/chat/people.test.ts` asserts that
+ * what comes out of it is never an id, in every one of its states.
+ */
+
+const FRONTEND = join(__dirname, '..', '..');
+
+/** Where a person can be drawn. */
+const SOURCE_DIRS = ['app', 'components', 'hooks', 'lib', 'stores', 'utils'];
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx'];
+
+/** The fields of the port's view models that hold an identifier and not a name. */
+const IDENTIFIER_FIELDS = String.raw`userId|senderId|roomId`;
+
+/**
+ * A name falling back to an identifier: `member.displayName ?? member.userId`.
+ *
+ * Both spellings of the fallback, because `??` and `||` differ in exactly one
+ * way that does not matter here — an empty display name is not a name either.
+ */
+const NAME_FALLS_BACK_TO_ID = new RegExp(
+  String.raw`\b(?:displayName|name|title|label|senderName|contactName|roomName)\s*` +
+    String.raw`(?:\?\?|\|\|)\s*[A-Za-z0-9_.?[\]'"]*\b(?:${IDENTIFIER_FIELDS})\b`,
+);
+
+/**
+ * The two components that put a string on screen in this app.
+ *
+ * Everything a user reads is inside one of them or is handed to something else
+ * as a prop, which is the other rule below. Naming them rather than scanning
+ * every element is what keeps this precise: `key={item.userId}` is correct and
+ * necessary, and a rule that could not tell it from `{item.userId}` would be
+ * turned off within a month.
+ */
+const TEXT_ELEMENT_BODY = /<(Text|ThemedText)\b[^>]*>([\s\S]*?)<\/\1>/g;
+
+/**
+ * The props that are read out loud, whatever draws them.
+ *
+ * `title` is a screen header, `label` is an avatar's initial or a field's
+ * caption, `placeholder` is what a user reads in an empty box, and
+ * `accessibilityLabel` is the one a screen reader speaks — an identifier there
+ * is worse than on screen, not better.
+ */
+const READ_ALOUD_PROP = new RegExp(
+  String.raw`\b(?:title|label|placeholder|accessibilityLabel|children)=\{[^}]*\b(?:${IDENTIFIER_FIELDS})\b`,
+  'g',
+);
+
+const ID_IN_INTERPOLATION = new RegExp(
+  String.raw`\{[^}]*\b(?:${IDENTIFIER_FIELDS})\b[^}]*\}`,
+);
+
+/**
+ * The port's room-title fields, which are an identifier as often as not.
+ *
+ * `AlloRoomSummary.displayName` and `AlloRoomDetails.name` are documented as
+ * "the name from room state, **or one computed from the members**", and both
+ * SDKs compute that one by naming a member with no `displayname` after their
+ * user id. On Allo's homeserver that is everybody, so the second case is the
+ * ordinary one: a one-to-one conversation is titled with an MXID and an unnamed
+ * group with several.
+ *
+ * They are therefore not strings a screen may draw. `conversationTitleFrom` is
+ * what turns one into a title, and `isOwnRoomName` is what decides whether it is
+ * a name the user typed — anything else is the bug, wearing a field name a scan
+ * for `userId` would never notice.
+ */
+const COMPUTED_ROOM_TITLE = /\b(?:details|summary|room)\.(?:displayName|name)\b/;
+
+/** The two functions allowed to read one. */
+const TITLE_RESOLVERS = /\b(?:conversationTitleFrom|isOwnRoomName)\s*\(/;
+
+/**
+ * Any prop whose value is an expression, so its contents can be examined.
+ *
+ * `key` is excluded and is the only exclusion. React never draws a key: it is
+ * the identity of a list row, and for a room-title field it is precisely how a
+ * component is reset when the homeserver's name for the room changes — which is
+ * what `RoomNameSection` uses it for, instead of an Effect watching a prop.
+ */
+const JSX_EXPRESSION_PROP = /\b(?!key=)[A-Za-z][A-Za-z0-9]*=\{[^}]*\}/g;
+
+/**
+ * Files allowed to put a name beside an identifier, each for a reason that is
+ * not about drawing.
+ *
+ * Kept as a list rather than as an inline comment so that adding to it is a
+ * visible change to this test, which is where the argument for the exception
+ * belongs.
+ */
+const NOT_DRAWN: Readonly<Record<string, string>> = {
+  // A sort key. The member list is ordered by the name a row is drawn with, and
+  // a member with no name has to sort somewhere stable; nothing here reaches a
+  // view. Documented at the function itself.
+  'lib/matrix/roomMembers.ts': 'orders members; the value is a sort key, never drawn',
+};
+
+/**
+ * Everything on the Matrix path resolves a person through `lib/chat/people.ts`
+ * and through nothing else.
+ *
+ * The five Oxy calls the frontend makes about people are moving behind
+ * `api.allo.you`. One module reaching for them is a move; a call site per screen
+ * is twenty. This is the half of that rule a scan can hold: the Matrix path is
+ * new code and has exactly one, so there is a line to defend. The Express path
+ * has fifteen and predates the seam — migrating it is its own change.
+ */
+const OXY_PERSON_CALLS =
+  /\b(?:getUsersByIds|getUserById|getProfileByUsername|searchProfiles|getFileDownloadUrl)\s*\(/;
+
+/** The files that are the Matrix chat path. */
+const MATRIX_PATH = [
+  `lib${sep}matrix${sep}`,
+  `lib${sep}chat${sep}matrix`,
+  `lib${sep}chat${sep}room`,
+  `lib${sep}chat${sep}timeline`,
+  `lib${sep}chat${sep}invitations`,
+  `lib${sep}chat${sep}ephemeral`,
+  `hooks${sep}useMatrix`,
+  `hooks${sep}useChatPeople`,
+  `components${sep}matrix${sep}`,
+  `app${sep}(chat)${sep}room${sep}`,
+];
+
+/** The one module allowed to ask Oxy who somebody in a conversation is. */
+const THE_SEAM = `lib${sep}chat${sep}people.ts`;
+
+function walk(directory: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(directory)) {
+    const full = join(directory, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      found.push(...walk(full));
+      continue;
+    }
+    if (SOURCE_EXTENSIONS.some((extension) => entry.endsWith(extension))) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * The source with its comments removed.
+ *
+ * Every one of these rules is stated in prose somewhere near the code that used
+ * to break it — "it used to be `member.displayName ?? member.userId`" — and a
+ * scan that read comments would fail on its own explanation.
+ */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+function sourceFiles(): { readonly path: string; readonly source: string }[] {
+  return SOURCE_DIRS.flatMap((directory) => walk(join(FRONTEND, directory))).map((path) => ({
+    path: relative(FRONTEND, path),
+    source: withoutComments(readFileSync(path, 'utf8')),
+  }));
+}
+
+describe('no Matrix user id can reach the screen', () => {
+  it('has source to scan', () => {
+    // A scan that walked nothing would pass every rule below in silence, which
+    // is the way this kind of test dies.
+    expect(sourceFiles().length).toBeGreaterThan(200);
+  });
+
+  it('never falls back from a name to an identifier', () => {
+    const offenders = sourceFiles()
+      .filter(({ path }) => NOT_DRAWN[path.split(sep).join('/')] === undefined)
+      .filter(({ source }) => NAME_FALLS_BACK_TO_ID.test(source))
+      .map(({ path }) => path);
+
+    // `member.displayName ?? member.userId` is not a fallback on Allo's
+    // homeserver. It is the only path, because nobody there has a Matrix display
+    // name. What to draw for somebody who cannot be named is
+    // `chat.person.unknown`, and `lib/chat/people.ts` is what decides it.
+    expect(offenders).toEqual([]);
+  });
+
+  it('never draws an identifier as the contents of a text element', () => {
+    const offenders: string[] = [];
+    for (const { path, source } of sourceFiles()) {
+      if (!path.endsWith('.tsx')) continue;
+      for (const match of source.matchAll(TEXT_ELEMENT_BODY)) {
+        if (ID_IN_INTERPOLATION.test(match[2])) {
+          offenders.push(`${path}: ${match[2].trim().slice(0, 120)}`);
+        }
+      }
+    }
+
+    // `<Text>ID: {message.senderId}</Text>` and
+    // `<ThemedText>{member.userId}</ThemedText>` were both on screen. An
+    // identifier is not something a reader can do anything with; a handle is,
+    // and a name is what they came for.
+    expect(offenders).toEqual([]);
+  });
+
+  it('never hands an identifier to a prop that is read out loud', () => {
+    const offenders: string[] = [];
+    for (const { path, source } of sourceFiles()) {
+      if (!path.endsWith('.tsx')) continue;
+      for (const match of source.matchAll(READ_ALOUD_PROP)) {
+        offenders.push(`${path}: ${match[0]}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("never draws a room's computed title without resolving the people in it", () => {
+    const offenders: string[] = [];
+    for (const { path, source } of sourceFiles()) {
+      if (!path.endsWith('.tsx')) continue;
+      for (const [region] of [
+        ...[...source.matchAll(TEXT_ELEMENT_BODY)].map((match) => [match[2]]),
+        ...[...source.matchAll(JSX_EXPRESSION_PROP)].map((match) => [match[0]]),
+      ]) {
+        if (COMPUTED_ROOM_TITLE.test(region) && !TITLE_RESOLVERS.test(region)) {
+          offenders.push(`${path}: ${region.trim().slice(0, 120)}`);
+        }
+      }
+    }
+
+    // `title={details.name}` is `@<hex>:allo.you` for every one-to-one
+    // conversation on Allo's homeserver, and no scan for a field called
+    // `userId` would ever see it. This is the rule that does.
+    expect(offenders).toEqual([]);
+  });
+
+  it('resolves a person through one module on the Matrix path', () => {
+    const offenders = sourceFiles()
+      .filter(({ path }) => path !== THE_SEAM)
+      .filter(({ path }) => MATRIX_PATH.some((prefix) => path.startsWith(prefix)))
+      .filter(({ source }) => OXY_PERSON_CALLS.test(source))
+      .map(({ path }) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/frontend/__tests__/chat/people.test.ts
+++ b/packages/frontend/__tests__/chat/people.test.ts
@@ -1,0 +1,437 @@
+import type { User } from '@oxyhq/core';
+
+import {
+  ChatPeopleDirectory,
+  chatPersonFrom,
+  chatPersonOriginOf,
+  conversationTitleFrom,
+  isOwnRoomName,
+  oxyPersonProfileOf,
+  peopleInConversationTitles,
+  viewerServerNameOf,
+  type ChatPeopleGateway,
+  type ChatPeopleLookup,
+  type ChatPerson,
+  type ChatPersonRequest,
+} from '@/lib/chat/people';
+import { ghostNamespacesFor } from '@/lib/chat/roomOrigin';
+
+/**
+ * WHO SOMEBODY IN A CONVERSATION IS.
+ *
+ * Two properties are load-bearing and everything below is one of them:
+ *
+ *  1. **Nobody who is not an Oxy account is ever looked up as one.** A bridge's
+ *     puppet and a user on another homeserver are refused, because a coerced
+ *     lookup succeeds against a stranger.
+ *  2. **A Matrix user id never comes out as a name.** Not while a lookup is in
+ *     flight, not when it fails, and not for somebody Oxy has never heard of.
+ */
+
+const ALBA = '507f1f77bcf86cd799439011';
+const BRUNO = '507f1f77bcf86cd799439012';
+const ALBA_MXID = `@${ALBA}:allo.you`;
+const BRUNO_MXID = `@${BRUNO}:allo.you`;
+const UNKNOWN = 'Unknown person';
+
+function user(overrides: Partial<User> = {}): User {
+  return {
+    id: ALBA,
+    publicKey: 'key',
+    username: 'alba',
+    name: { displayName: 'Alba Ruiz' },
+    ...overrides,
+  } as User;
+}
+
+function gateway(users: readonly User[] = [], calls: string[][] = []): ChatPeopleGateway {
+  return {
+    getUsersByIds: async (ids) => {
+      calls.push(ids);
+      return users.filter((entry) => ids.includes(entry.id));
+    },
+    getFileDownloadUrl: (fileId, variant) => `https://cloud.oxy.so/${fileId}?variant=${variant}`,
+  };
+}
+
+/** A lookup over a fixed set, in the shape `useChatPeople` answers. */
+function lookup(people: readonly ChatPerson[]): ChatPeopleLookup {
+  const byUserId = new Map(people.map((person) => [person.userId, person]));
+  return (userId) => byUserId.get(userId);
+}
+
+function person(overrides: Partial<ChatPerson> = {}): ChatPerson {
+  return {
+    userId: ALBA_MXID,
+    origin: { kind: 'oxy', oxyUserId: ALBA },
+    state: 'resolved',
+    displayName: 'Alba Ruiz',
+    handle: 'alba',
+    avatarUrl: undefined,
+    verified: false,
+    ...overrides,
+  };
+}
+
+describe('chatPersonOriginOf', () => {
+  it('recognises an Oxy account on the viewer’s own homeserver', () => {
+    expect(chatPersonOriginOf(ALBA_MXID, 'allo.you', [])).toEqual({
+      kind: 'oxy',
+      oxyUserId: ALBA,
+    });
+  });
+
+  it("recognises a bridge's puppet from the namespaces the server published", () => {
+    const namespaces = ghostNamespacesFor(['whatsapp']);
+    expect(chatPersonOriginOf(`@whatsapp_${ALBA}:allo.you`, 'allo.you', namespaces)).toEqual({
+      kind: 'bridged',
+      networkId: 'whatsapp',
+    });
+  });
+
+  it('asks the bridge rule first, before the localpart is examined at all', () => {
+    // The ordering is the safeguard and not an optimisation, and this is the case
+    // it exists for: a namespace whose prefix a valid Oxy id happens to start
+    // with. `<id>_` is mautrix's DEFAULT `username_template` and `roomOrigin.ts`
+    // says so explicitly — the day a deployment publishes its real namespaces,
+    // the prefix is whatever the operator configured. Looking at the localpart
+    // first would then answer with somebody's Oxy account for a WhatsApp contact:
+    // their name, their face, over a stranger's messages.
+    const namespaces = [{ networkId: 'legacy', localpartPrefix: ALBA.slice(0, 4) }];
+    expect(chatPersonOriginOf(ALBA_MXID, 'allo.you', namespaces)).toEqual({
+      kind: 'bridged',
+      networkId: 'legacy',
+    });
+  });
+
+  it('calls somebody on another homeserver foreign', () => {
+    expect(chatPersonOriginOf(`@${ALBA}:matrix.org`, 'allo.you', [])).toEqual({
+      kind: 'foreign',
+    });
+  });
+
+  it('calls a localpart that is not an Oxy id foreign rather than guessing', () => {
+    expect(chatPersonOriginOf('@alba:allo.you', 'allo.you', [])).toEqual({ kind: 'foreign' });
+  });
+
+  it('claims nothing about anybody when nobody is signed in', () => {
+    expect(chatPersonOriginOf(ALBA_MXID, undefined, [])).toEqual({ kind: 'foreign' });
+  });
+});
+
+describe('viewerServerNameOf', () => {
+  it('reads the homeserver out of the viewer’s own id', () => {
+    expect(viewerServerNameOf(ALBA_MXID)).toBe('allo.you');
+  });
+
+  it('answers undefined rather than throwing, so a screen still renders', () => {
+    expect(viewerServerNameOf(undefined)).toBeUndefined();
+    expect(viewerServerNameOf('not-a-user-id')).toBeUndefined();
+  });
+});
+
+describe('oxyPersonProfileOf', () => {
+  it('prefers the display name the API resolved', () => {
+    expect(oxyPersonProfileOf(user(), gateway())).toMatchObject({
+      displayName: 'Alba Ruiz',
+      handle: 'alba',
+      verified: false,
+    });
+  });
+
+  it('falls back to the handle when there is no display name', () => {
+    const profile = oxyPersonProfileOf(user({ name: undefined }), gateway());
+    expect(profile.displayName).toBe('alba');
+  });
+
+  it('turns an avatar file id into a URL', () => {
+    const profile = oxyPersonProfileOf(user({ avatar: 'file-1' }), gateway());
+    expect(profile.avatarUrl).toBe('https://cloud.oxy.so/file-1?variant=thumb');
+  });
+
+  it('passes an absolute avatar URL through', () => {
+    const profile = oxyPersonProfileOf(user({ avatar: 'https://cdn/a.png' }), gateway());
+    expect(profile.avatarUrl).toBe('https://cdn/a.png');
+  });
+
+  it('drops an avatar with a scheme Oxy Cloud does not serve', () => {
+    // `mxc://` is the one that turns up. Handed to the file endpoint it is a 404
+    // the view draws as a broken image.
+    expect(oxyPersonProfileOf(user({ avatar: 'mxc://allo.you/abc' }), gateway()).avatarUrl)
+      .toBeUndefined();
+  });
+});
+
+describe('chatPersonFrom', () => {
+  const oxy = { kind: 'oxy', oxyUserId: ALBA } as const;
+
+  it('draws an Oxy account as their name, handle and face', () => {
+    const resolved = chatPersonFrom(
+      { userId: ALBA_MXID },
+      oxy,
+      { displayName: 'Alba Ruiz', handle: 'alba', avatarUrl: 'https://cdn/a', verified: true },
+      UNKNOWN,
+    );
+    expect(resolved).toMatchObject({
+      state: 'resolved',
+      displayName: 'Alba Ruiz',
+      handle: 'alba',
+      avatarUrl: 'https://cdn/a',
+      verified: true,
+    });
+  });
+
+  it('has no name at all while the lookup is in flight', () => {
+    // Not the honest word either: drawing "Unknown person" and replacing it with
+    // a name a moment later says something false in between.
+    const pending = chatPersonFrom({ userId: ALBA_MXID }, oxy, undefined, UNKNOWN);
+    expect(pending).toMatchObject({ state: 'pending', displayName: '' });
+  });
+
+  it('says something human when the lookup finished and found nobody', () => {
+    const missing = chatPersonFrom({ userId: ALBA_MXID }, oxy, null, UNKNOWN);
+    expect(missing).toMatchObject({ state: 'unresolved', displayName: UNKNOWN });
+  });
+
+  it('never draws the Matrix user id, whatever happened', () => {
+    for (const profile of [undefined, null] as const) {
+      const drawn = chatPersonFrom({ userId: ALBA_MXID }, oxy, profile, UNKNOWN);
+      expect(drawn.displayName).not.toContain('@');
+      expect(drawn.displayName).not.toContain('allo.you');
+    }
+  });
+
+  it("draws a bridged contact from what Matrix says, and never looks them up", () => {
+    const bridged = chatPersonFrom(
+      { userId: '@whatsapp_34600111222:allo.you', matrixDisplayName: 'Alba (WhatsApp)' },
+      { kind: 'bridged', networkId: 'whatsapp' },
+      // A profile is passed in to prove it is ignored: a WhatsApp contact is not
+      // an Oxy account, so even an answer about one must not be drawn as them.
+      { displayName: 'Somebody Else', handle: 'else', avatarUrl: undefined, verified: true },
+      UNKNOWN,
+    );
+    expect(bridged).toMatchObject({
+      state: 'resolved',
+      displayName: 'Alba (WhatsApp)',
+      handle: undefined,
+      verified: false,
+    });
+  });
+
+  it('falls back to the honest word for a bridged contact the bridge did not name', () => {
+    const bridged = chatPersonFrom(
+      { userId: '@whatsapp_34600111222:allo.you' },
+      { kind: 'bridged', networkId: 'whatsapp' },
+      null,
+      UNKNOWN,
+    );
+    expect(bridged).toMatchObject({ state: 'unresolved', displayName: UNKNOWN });
+  });
+
+  it('refuses a Matrix display name that is itself a user id', () => {
+    // `matrix-js-sdk` answers `RoomMember.name` with the MXID when somebody has
+    // no display name, and appends it to disambiguate a duplicate. A name
+    // arriving from Matrix is therefore not automatically a name.
+    const foreign = chatPersonFrom(
+      { userId: '@alba:matrix.org', matrixDisplayName: '@alba:matrix.org' },
+      { kind: 'foreign' },
+      null,
+      UNKNOWN,
+    );
+    expect(foreign.displayName).toBe(UNKNOWN);
+  });
+
+  it('treats a blank Matrix display name as no name', () => {
+    const foreign = chatPersonFrom(
+      { userId: '@alba:matrix.org', matrixDisplayName: '   ' },
+      { kind: 'foreign' },
+      null,
+      UNKNOWN,
+    );
+    expect(foreign.displayName).toBe(UNKNOWN);
+  });
+});
+
+describe('conversationTitleFrom', () => {
+  it('names a direct conversation after the person it is with', () => {
+    expect(conversationTitleFrom(ALBA_MXID, 'allo.you', lookup([person()]))).toBe('Alba Ruiz');
+  });
+
+  it('names every person in a title an SDK composed from the members', () => {
+    const people = lookup([
+      person(),
+      person({ userId: BRUNO_MXID, displayName: 'Bruno Vidal', handle: 'bruno' }),
+    ]);
+    expect(
+      conversationTitleFrom(`${ALBA_MXID} and ${BRUNO_MXID}`, 'allo.you', people),
+    ).toBe('Alba Ruiz and Bruno Vidal');
+  });
+
+  it("leaves a name somebody typed exactly as they typed it", () => {
+    const people = lookup([person()]);
+    expect(conversationTitleFrom('Familia', 'allo.you', people)).toBe('Familia');
+    expect(conversationTitleFrom('budget@work: 2026', 'allo.you', people)).toBe(
+      'budget@work: 2026',
+    );
+  });
+
+  it('leaves an id from another homeserver alone', () => {
+    // At that point the string is far likelier to be something a person typed
+    // into a group's name than a member of it, and a title the user chose has to
+    // survive this function byte for byte.
+    expect(conversationTitleFrom('@a:matrix.org', 'allo.you', lookup([]))).toBe('@a:matrix.org');
+  });
+
+  it('has no title while somebody in it is still being looked up', () => {
+    // Half a title is not a title, and the alternative is the id.
+    const people = lookup([person({ state: 'pending', displayName: '' })]);
+    expect(conversationTitleFrom(ALBA_MXID, 'allo.you', people)).toBe('');
+  });
+
+  it('has no title for a room whose name has not arrived', () => {
+    expect(conversationTitleFrom(undefined, 'allo.you', lookup([]))).toBe('');
+  });
+
+  it('never leaves one of this homeserver’s ids on screen', () => {
+    // Nobody resolved at all: the title comes back empty rather than as the id
+    // that could not be named.
+    expect(conversationTitleFrom(ALBA_MXID, 'allo.you', lookup([]))).toBe('');
+  });
+});
+
+describe('isOwnRoomName', () => {
+  it('recognises a name the room was given', () => {
+    expect(isOwnRoomName('Familia', 'allo.you')).toBe(true);
+  });
+
+  it('refuses a title computed from the people in the room', () => {
+    // Written into `m.room.name` it would be a list of Matrix ids, saved in the
+    // clear for everybody in the conversation.
+    expect(isOwnRoomName(ALBA_MXID, 'allo.you')).toBe(false);
+    expect(isOwnRoomName(`${ALBA_MXID} and ${BRUNO_MXID}`, 'allo.you')).toBe(false);
+  });
+
+  it('has no name to offer for a room that has none', () => {
+    expect(isOwnRoomName(undefined, 'allo.you')).toBe(false);
+    expect(isOwnRoomName('', 'allo.you')).toBe(false);
+  });
+});
+
+describe('peopleInConversationTitles', () => {
+  it('asks about each person once across the whole list', () => {
+    const requests = peopleInConversationTitles([
+      ALBA_MXID,
+      `${ALBA_MXID} and ${BRUNO_MXID}`,
+      'Familia',
+      undefined,
+    ]);
+    expect(requests.map((request: ChatPersonRequest) => request.userId)).toEqual([
+      ALBA_MXID,
+      BRUNO_MXID,
+    ]);
+  });
+});
+
+describe('ChatPeopleDirectory', () => {
+  /** Flushes on demand, so the batching is asserted rather than slept through. */
+  function manual() {
+    const pending: (() => void)[] = [];
+    return {
+      schedule: (flush: () => void) => pending.push(flush),
+      run: () => {
+        const scheduled = [...pending];
+        pending.length = 0;
+        for (const flush of scheduled) flush();
+      },
+    };
+  }
+
+  it('turns thirty people into one request', () => {
+    // The whole reason this class exists. React Query caches per person, which
+    // means a fetch per person, and thirty of those is the M+1 `getUsersByIds`
+    // is there to prevent.
+    const calls: string[][] = [];
+    const ids = Array.from({ length: 30 }, (_unused, index) =>
+      `507f1f77bcf86cd7994390${String(index).padStart(2, '0')}`,
+    );
+    const clock = manual();
+    const directory = new ChatPeopleDirectory(gateway([], calls), clock.schedule);
+
+    const loading = Promise.all(ids.map((id) => directory.load(id)));
+    clock.run();
+
+    return loading.then(() => {
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toHaveLength(30);
+    });
+  });
+
+  it('answers each waiter with their own person', async () => {
+    const clock = manual();
+    const directory = new ChatPeopleDirectory(
+      gateway([user(), user({ id: BRUNO, username: 'bruno', name: { displayName: 'Bruno' } })]),
+      clock.schedule,
+    );
+
+    const both = Promise.all([directory.load(ALBA), directory.load(BRUNO)]);
+    clock.run();
+
+    expect((await both).map((profile) => profile?.displayName)).toEqual(['Alba Ruiz', 'Bruno']);
+  });
+
+  it('answers null for an id that names nobody', async () => {
+    // The server returns only what it matched, so an absent id is an answer and
+    // not a failure — and `null` is what makes it `unresolved` rather than
+    // `pending` for ever.
+    const clock = manual();
+    const directory = new ChatPeopleDirectory(gateway([]), clock.schedule);
+    const loading = directory.load(ALBA);
+    clock.run();
+    expect(await loading).toBeNull();
+  });
+
+  it('asks once for a person asked about twice in the same tick', () => {
+    const calls: string[][] = [];
+    const clock = manual();
+    const directory = new ChatPeopleDirectory(gateway([user()], calls), clock.schedule);
+
+    const both = Promise.all([directory.load(ALBA), directory.load(ALBA)]);
+    clock.run();
+
+    return both.then((profiles) => {
+      expect(calls).toEqual([[ALBA]]);
+      expect(profiles[0]).toEqual(profiles[1]);
+    });
+  });
+
+  it('rejects the batch rather than caching a blip as thirty missing people', async () => {
+    const clock = manual();
+    const directory = new ChatPeopleDirectory(
+      {
+        getUsersByIds: async () => {
+          throw new Error('offline');
+        },
+        getFileDownloadUrl: (fileId) => fileId,
+      },
+      clock.schedule,
+    );
+
+    const loading = directory.load(ALBA);
+    clock.run();
+    await expect(loading).rejects.toThrow('offline');
+  });
+
+  it('does not drop somebody asked about while a request is in flight', async () => {
+    const calls: string[][] = [];
+    const clock = manual();
+    const directory = new ChatPeopleDirectory(gateway([user()], calls), clock.schedule);
+
+    const first = directory.load(ALBA);
+    clock.run();
+    const second = directory.load(BRUNO);
+    clock.run();
+
+    await Promise.all([first, second]);
+    expect(calls).toEqual([[ALBA], [BRUNO]]);
+  });
+});

--- a/packages/frontend/__tests__/chat/personTranslations.test.ts
+++ b/packages/frontend/__tests__/chat/personTranslations.test.ts
@@ -1,0 +1,74 @@
+import { createInstance } from 'i18next';
+
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+import itIT from '@/locales/it.json';
+
+/**
+ * That the words for somebody who cannot be named exist in all three languages.
+ *
+ * The whole point of the change these belong to is that a person is never drawn
+ * as an identifier. A missing key renders as its own dotted name, so
+ * `chat.person.unknown` going untranslated would put `chat.person.unknown` in a
+ * member row — which is the same failure in a different alphabet, and invisible
+ * to whoever ships it because English is the language that has the key.
+ */
+
+const LOCALES: readonly (readonly [string, Record<string, unknown>])[] = [
+  ['en', en as Record<string, unknown>],
+  ['es', es as Record<string, unknown>],
+  ['it', itIT as Record<string, unknown>],
+];
+
+/** What a person who could not be resolved reads as. */
+const UNKNOWN_PERSON_KEY = 'chat.person.unknown';
+
+/**
+ * The refusal, in both of its forms.
+ *
+ * The second one exists because the first cannot be written honestly when one of
+ * the people in it has no name: "the identity of Bruno, Unknown person" reads as
+ * a bug. See `components/matrix/ephemeralRefusal.ts`.
+ */
+const REFUSAL_NAMING_PEOPLE =
+  'Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.';
+const REFUSAL_NAMING_NOBODY =
+  'Allo will not send here: it does not recognise the identity of everybody in this conversation. Ask them to open Allo and finish setting up their account.';
+
+const REQUIRED_KEYS: readonly string[] = [
+  UNKNOWN_PERSON_KEY,
+  REFUSAL_NAMING_PEOPLE,
+  REFUSAL_NAMING_NOBODY,
+];
+
+for (const [name, bundle] of LOCALES) {
+  describe(`the ${name} translations`, () => {
+    it('names somebody who could not be looked up', () => {
+      const missing = REQUIRED_KEYS.filter(
+        (key) => typeof bundle[key] !== 'string' || (bundle[key] as string).length === 0,
+      );
+
+      expect(missing).toEqual([]);
+    });
+
+    it('resolves the flat dotted key rather than reading it as a path', () => {
+      // The bundles are flat: `chat.person.unknown` is one entry at the top
+      // level and not a `chat` object. i18next finds a flat key before it splits
+      // on the separator, and this is what says so out loud.
+      const i18n = createInstance();
+      void i18n.init({
+        lng: name,
+        resources: { [name]: { translation: bundle } },
+        interpolation: { escapeValue: false },
+      });
+
+      const unknown = i18n.t(UNKNOWN_PERSON_KEY);
+      expect(unknown).not.toBe(UNKNOWN_PERSON_KEY);
+      expect(unknown).not.toContain('.');
+
+      const refusal = i18n.t(REFUSAL_NAMING_PEOPLE, { people: 'Alba' });
+      expect(refusal).not.toContain('{{');
+      expect(refusal).toContain('Alba');
+    });
+  });
+}

--- a/packages/frontend/__tests__/matrix/web/roomList.test.ts
+++ b/packages/frontend/__tests__/matrix/web/roomList.test.ts
@@ -55,7 +55,7 @@ function event(
     getRelation: () => relation,
     replacingEvent: () => null,
     status: null,
-    sender: { name: 'Alice' },
+    sender: { rawDisplayName: 'Alice' },
   };
 }
 

--- a/packages/frontend/__tests__/matrix/web/translate.test.ts
+++ b/packages/frontend/__tests__/matrix/web/translate.test.ts
@@ -58,7 +58,7 @@ function event(overrides: Partial<TimelineEventFields> = {}): TimelineEventField
     getRelation: () => null,
     replacingEvent: () => null,
     status: null,
-    sender: { name: 'Alice' },
+    sender: { rawDisplayName: 'Alice' },
     ...overrides,
   };
 }
@@ -288,6 +288,24 @@ describe('toTimelineItem', () => {
 
   it('leaves the sender nameless until the SDK has resolved one', () => {
     expect(toTimelineItem(event({ sender: null }), VIEWER, [])?.senderDisplayName).toBe(undefined);
+  });
+
+  it('leaves the sender nameless when they have set no display name', () => {
+    // `rawDisplayName` and not the SDK's `name`, which answers with the user id
+    // for a member who has set none and appends it to disambiguate a duplicate —
+    // so the port would report `@alice:allo.you`, or `Alice (@alice:allo.you)`,
+    // in a field whose whole contract is that it holds a name or nothing. On
+    // Allo's homeserver nobody has one, so that was every sender.
+    expect(
+      toTimelineItem(event({ sender: { rawDisplayName: undefined } }), VIEWER, [])
+        ?.senderDisplayName,
+    ).toBe(undefined);
+    // An empty string is not a name either: a member whose `m.room.member` event
+    // carries `displayname: ""` would otherwise be drawn as nobody rather than
+    // resolved through `lib/chat/people.ts`.
+    expect(
+      toTimelineItem(event({ sender: { rawDisplayName: '' } }), VIEWER, [])?.senderDisplayName,
+    ).toBe(undefined);
   });
 
   it('reports an edited message with the content that replaced it', () => {

--- a/packages/frontend/app/(chat)/room/[id].tsx
+++ b/packages/frontend/app/(chat)/room/[id].tsx
@@ -12,11 +12,19 @@ import { EphemeralSection } from '@/components/matrix/EphemeralSection';
 import { MatrixSignInGate } from '@/components/matrix/MatrixSignInGate';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { useChatPeople } from '@/hooks/useChatPeople';
 import { useEphemeralPolicy } from '@/hooks/useEphemeralPolicy';
 import { useMatrixRuntime } from '@/hooks/useMatrixRuntime';
 import { useTheme } from '@/hooks/useTheme';
 import { CHAT_BACKEND } from '@/lib/chat/backend';
 import { ephemeralPolicies } from '@/lib/chat/ephemeralPolicies';
+import {
+  conversationTitleFrom,
+  isOwnRoomName,
+  NO_CHAT_PERSON_REQUESTS,
+  viewerServerNameOf,
+  type ChatPerson,
+} from '@/lib/chat/people';
 import { roomAdminSource, type RoomAdminSnapshot } from '@/lib/chat/roomAdmin';
 import type {
   AlloEphemeralPolicy,
@@ -102,10 +110,45 @@ function RoomAdminScreen({ roomId }: { readonly roomId: string }) {
     return byUserId;
   }, [snapshot.trust]);
 
-  const nameOf = useCallback(
-    (userId: string) =>
-      details?.members.find((member) => member.userId === userId)?.displayName ?? userId,
+  /**
+   * Who everybody in this room is.
+   *
+   * One request for the whole room rather than one per row: a family group of
+   * thirty must not be thirty requests, and `useChatPeople` collects every id
+   * asked for in a tick into a single lookup. Matrix's own name for a member
+   * travels with the id because for a bridged contact it is the only name there
+   * will ever be.
+   */
+  const requests = useMemo(
+    () =>
+      details === undefined
+        ? NO_CHAT_PERSON_REQUESTS
+        : details.members.map((member) => ({
+            userId: member.userId,
+            matrixDisplayName: member.displayName,
+          })),
     [details],
+  );
+  const people = useChatPeople(requests);
+  const serverName = useMemo(() => viewerServerNameOf(runtime.userId), [runtime.userId]);
+
+  /**
+   * The name to put in a sentence about somebody.
+   *
+   * It used to be `member.displayName ?? userId`, so the warning that names the
+   * people an ephemeral conversation will not send to was a list of MXIDs — the
+   * exact thing `EphemeralSection` takes this mapper in order to avoid. Somebody
+   * still being looked up has no name yet, and the honest word for them is the
+   * one `chat.person.unknown` carries rather than their identifier.
+   */
+  const nameOf = useCallback(
+    (userId: string) => {
+      const person = people(userId);
+      return person === undefined || person.displayName === ''
+        ? t('chat.person.unknown')
+        : person.displayName;
+    },
+    [people, t],
   );
 
   const setPolicy = useCallback(
@@ -177,6 +220,7 @@ function RoomAdminScreen({ roomId }: { readonly roomId: string }) {
       renderItem={({ item }) => (
         <MemberRow
           member={item}
+          person={people(item.userId)}
           isViewer={item.userId === runtime.userId}
           trust={trustByUserId.get(item.userId)}
           // The identity of the people in a conversation only decides anything
@@ -192,7 +236,12 @@ function RoomAdminScreen({ roomId }: { readonly roomId: string }) {
               over by a `useState` that was initialised once. */}
           <RoomNameSection
             key={details.name ?? ''}
-            name={details.name}
+            title={conversationTitleFrom(details.name, serverName, people)}
+            // The room's own name and nothing else goes in the field: a title
+            // computed from the people in the room is not something the user
+            // typed, and offering it back would let one tap write a list of
+            // Matrix ids into `m.room.name` for everybody, in the clear.
+            name={isOwnRoomName(details.name, serverName) ? details.name : undefined}
             isDirect={details.isDirect}
             canRename={rights?.canRename === true}
             onRename={source.rename}
@@ -249,11 +298,15 @@ function RoomAdminScreen({ roomId }: { readonly roomId: string }) {
  * homeserver's name changes, rather than by an Effect watching a prop.
  */
 function RoomNameSection({
+  title,
   name,
   isDirect,
   canRename,
   onRename,
 }: {
+  /** What this conversation is called on screen, people already resolved. */
+  readonly title: string;
+  /** The room's own `m.room.name`, and only that. See the call site. */
   readonly name: string | undefined;
   readonly isDirect: boolean;
   readonly canRename: boolean;
@@ -289,7 +342,7 @@ function RoomNameSection({
     // would ever see the point of.
     return (
       <View style={styles.section}>
-        <ThemedText style={styles.roomName}>{name ?? ''}</ThemedText>
+        <ThemedText style={styles.roomName}>{title}</ThemedText>
       </View>
     );
   }
@@ -367,35 +420,83 @@ function AddPeopleRow({
   );
 }
 
+/**
+ * One person in the conversation.
+ *
+ * It used to draw `member.displayName ?? member.userId` as the name and
+ * `member.userId` underneath it, so a room on Allo's homeserver — where nobody
+ * has a Matrix display name — was a column of `@<hex>:allo.you` with `@` for an
+ * avatar. Both lines come from {@link ChatPerson} now, which is never an
+ * identifier: their name, their handle, their face.
+ *
+ * A bridged contact is drawn from what Matrix says about them and from nothing
+ * else — a mautrix bridge names its puppets, and that name is the only one that
+ * exists — so they get no handle line. Which network carries the conversation is
+ * a fact about the room, not about the row, and `roomOrigin.ts` already puts it
+ * where it belongs.
+ */
 function MemberRow({
   member,
+  person,
   isViewer,
   trust,
   showTrust,
 }: {
   readonly member: AlloRoomMember;
+  /** `undefined` for the moment before the lookup has been set up. */
+  readonly person: ChatPerson | undefined;
   readonly isViewer: boolean;
   readonly trust: AlloIdentityTrust | undefined;
   readonly showTrust: boolean;
 }) {
   const { t } = useTranslation();
   const styles = useStyles();
-  const name = member.displayName ?? member.userId;
+
+  // Empty while the lookup is in flight, and the row draws a nameless avatar for
+  // that moment rather than an id it would have to take back.
+  const name = person?.displayName ?? '';
+  const detail = memberDetail(person, member.membership === 'invited', t);
 
   return (
     <View style={styles.row}>
-      <Avatar size={40} label={name.charAt(0).toUpperCase()} />
+      <Avatar
+        size={40}
+        source={person?.avatarUrl === undefined ? undefined : { uri: person.avatarUrl }}
+        label={name === '' ? undefined : name.charAt(0).toUpperCase()}
+      />
       <View style={styles.rowText}>
         <ThemedText style={styles.rowLabel} numberOfLines={1}>
-          {isViewer ? t('{{name}} (you)', { name }) : name}
+          {isViewer && name !== '' ? t('{{name}} (you)', { name }) : name}
         </ThemedText>
-        <ThemedText style={styles.rowDetail} numberOfLines={1}>
-          {member.membership === 'invited' ? t('Invited') : member.userId}
-        </ThemedText>
+        {detail !== undefined && (
+          <ThemedText style={styles.rowDetail} numberOfLines={1}>
+            {detail}
+          </ThemedText>
+        )}
         {showTrust && <TrustLine trust={trust} />}
       </View>
     </View>
   );
+}
+
+/**
+ * The second line of a member row, or nothing.
+ *
+ * "Invited" first, because whether somebody has actually joined is what the
+ * reader is looking for; then their handle, which is how they would find that
+ * person anywhere else in Oxy. Nothing at all otherwise — this line used to be
+ * `member.userId`, and a row with no second line says strictly more than a row
+ * with an identifier on it.
+ */
+function memberDetail(
+  person: ChatPerson | undefined,
+  isInvited: boolean,
+  t: (key: string) => string,
+): string | undefined {
+  if (isInvited) {
+    return t('Invited');
+  }
+  return person?.handle === undefined ? undefined : `@${person.handle}`;
 }
 
 /**

--- a/packages/frontend/components/conversation/ConversationView.tsx
+++ b/packages/frontend/components/conversation/ConversationView.tsx
@@ -78,6 +78,8 @@ import { useUsersStore } from '@/stores/usersStore';
 import { useRealtimeMessaging } from '@/hooks/useRealtimeMessaging';
 import { useTypingIndicator } from '@/hooks/useTypingIndicator';
 import { useSenderInfo } from '@/hooks/useSenderInfo';
+import { useMatrixSenderInfo, useMessageSenderRequests } from '@/hooks/useMatrixSenderInfo';
+import { useChatPeople } from '@/hooks/useChatPeople';
 // Matrix chat backend (behind EXPO_PUBLIC_CHAT_BACKEND)
 import { CHAT_BACKEND } from '@/lib/chat/backend';
 import { useMatrixTimeline } from '@/hooks/useMatrixTimeline';
@@ -194,10 +196,6 @@ export default function ConversationView({ conversationId: propConversationId }:
   // Whether this conversation's messages disappear, and after how long. Answers
   // `undefined` on the Express backend, which has no such thing.
   const ephemeralPolicy = useEphemeralPolicy(conversationId);
-  // An ephemeral conversation refuses to send when it cannot account for who is
-  // in it. That is a rule and not a fault, so it is said in the reader's own
-  // language rather than passed through as the port's English.
-  const ephemeralRefusalMessage = useEphemeralRefusalMessage();
 
   // Use conversation-specific theme (falls back to global theme if no conversation theme set)
   const theme = useConversationTheme(conversation?.theme);
@@ -364,6 +362,31 @@ export default function ConversationView({ conversationId: propConversationId }:
   // Use custom hook for conversation metadata
   const conversationMetadata = useConversationMetadata(conversation, currentUserId);
   const { isGroup } = conversationMetadata;
+
+  /**
+   * Who sent each incoming message, from whichever backend this build talks to.
+   *
+   * Both hooks are called because hooks must be; only one of them answers.
+   * `useMatrixSenderInfo` is `undefined` on the Express path, and on the Matrix
+   * path `useSenderInfo` has nothing to do — a Matrix `Conversation` carries no
+   * participants, so its Effect iterates nothing and it fetches nobody.
+   *
+   * The lookup is built here rather than inside `useMatrixSenderInfo` because
+   * the refusal below needs the same people, and asking twice would be two sets
+   * of queries for one answer.
+   */
+  const senderRequests = useMessageSenderRequests(messages);
+  const chatPeople = useChatPeople(senderRequests);
+  const alloApiSenderInfo = useSenderInfo(conversation, isGroup, conversationMetadata);
+  const matrixSenderInfo = useMatrixSenderInfo(chatPeople);
+  const { getSenderName, getSenderHandle, getSenderAvatar } =
+    matrixSenderInfo ?? alloApiSenderInfo;
+
+  // An ephemeral conversation refuses to send when it cannot account for who is
+  // in it. That is a rule and not a fault, so it is said in the reader's own
+  // language rather than passed through as the port's English — and it names the
+  // people rather than their Matrix ids, which is what the lookup above is for.
+  const ephemeralRefusalMessage = useEphemeralRefusalMessage(chatPeople);
 
   /**
    * Handle header press to show contact/group details
@@ -861,9 +884,6 @@ export default function ConversationView({ conversationId: propConversationId }:
   const handleEmoji = useCallback(() => {
     // Placeholder for emoji picker functionality
   }, []);
-
-  // Use the new hook for sender info
-  const { getSenderName, getSenderAvatar } = useSenderInfo(conversation, isGroup, conversationMetadata);
 
   /**
    * Toggle timestamp visibility for a message
@@ -1446,6 +1466,7 @@ export default function ConversationView({ conversationId: propConversationId }:
             visible={infoScreenVisible}
             message={selectedMessage}
             senderName={selectedMessage ? getSenderName(selectedMessage.senderId) : undefined}
+            senderHandle={selectedMessage ? getSenderHandle(selectedMessage.senderId) : undefined}
             senderAvatar={selectedMessage ? getSenderAvatar(selectedMessage.senderId) : undefined}
             onClose={() => {
               setInfoScreenVisible(false);

--- a/packages/frontend/components/matrix/ephemeralRefusal.ts
+++ b/packages/frontend/components/matrix/ephemeralRefusal.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { ChatPeopleLookup } from '@/lib/chat/people';
 import { MatrixEphemeralUntrustedError } from '@/lib/matrix/errors';
 
 /**
@@ -13,27 +14,87 @@ import { MatrixEphemeralUntrustedError } from '@/lib/matrix/errors';
  * cross-signing identities would be the app refusing to explain itself at the
  * one moment it has to.
  *
- * Answers `undefined` for anything else, so the caller keeps its existing
- * handling for everything that really is an error.
+ * **It names people and not identifiers.** `AlloEphemeralRefusal.userIds` holds
+ * Matrix user ids, and joining them into the sentence made the toast read "it
+ * does not recognise the identity of @<hex>:allo.you" — a refusal the reader
+ * cannot act on, because they have no idea who that is. `EphemeralSection` has
+ * taken a `nameOf` mapper for exactly this reason since it was written; this
+ * does the same with `lib/chat/people.ts`.
+ *
+ * The wording lives in {@link ephemeralRefusalMessage}, which is a plain
+ * function, so that what it says can be checked without a renderer — the same
+ * reason `recoveryDisclosureCopy.ts` is a `.ts` module beside its component.
  */
-export function useEphemeralRefusalMessage(): (error: unknown) => string | undefined {
+
+/** Just enough of i18next's `t` to write a sentence, so a test can supply one. */
+export type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+/** The key for somebody `lib/chat/people.ts` could not name. */
+export const UNKNOWN_PERSON_KEY = 'chat.person.unknown';
+
+export const REFUSAL_OWN_DEVICE_KEY =
+  'Allo will not send here until this device is verified with your Oxy recovery phrase, in Settings.';
+
+export const REFUSAL_NAMING_PEOPLE_KEY =
+  'Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.';
+
+/**
+ * The same refusal for a conversation where at least one of the people cannot
+ * be named.
+ *
+ * It exists because the sentence above cannot be written honestly then: "the
+ * identity of Bruno, Unknown person" reads as a bug, and padding the list with
+ * the honest word for one of its entries is worse than not listing it. So the
+ * list is dropped whole and the sentence says the same thing without pretending
+ * to enumerate.
+ */
+export const REFUSAL_NAMING_NOBODY_KEY =
+  'Allo will not send here: it does not recognise the identity of everybody in this conversation. Ask them to open Allo and finish setting up their account.';
+
+/**
+ * What to say about a failed send, or `undefined` for anything that is not this
+ * refusal — so the caller keeps its existing handling for everything that
+ * really is an error.
+ */
+export function ephemeralRefusalMessage(
+  error: unknown,
+  people: ChatPeopleLookup,
+  t: Translate,
+): string | undefined {
+  if (!(error instanceof MatrixEphemeralUntrustedError)) {
+    return undefined;
+  }
+  if (error.refusal.kind === 'own-device-unverified') {
+    return t(REFUSAL_OWN_DEVICE_KEY);
+  }
+
+  const named: string[] = [];
+  for (const userId of error.refusal.userIds) {
+    const name = people(userId)?.displayName;
+    if (name === undefined || name === '') {
+      named.length = 0;
+      break;
+    }
+    named.push(name);
+  }
+  if (named.length === 0) {
+    return t(REFUSAL_NAMING_NOBODY_KEY);
+  }
+  return t(REFUSAL_NAMING_PEOPLE_KEY, { people: named.join(', ') });
+}
+
+/**
+ * @param people who the participants are. A lookup that knows nobody is allowed
+ * and is what the Express backend passes: the refusal cannot be raised there,
+ * and every name falls back to the honest sentence rather than to an id.
+ */
+export function useEphemeralRefusalMessage(
+  people: ChatPeopleLookup,
+): (error: unknown) => string | undefined {
   const { t } = useTranslation();
 
   return useCallback(
-    (error: unknown): string | undefined => {
-      if (!(error instanceof MatrixEphemeralUntrustedError)) {
-        return undefined;
-      }
-      if (error.refusal.kind === 'own-device-unverified') {
-        return t(
-          'Allo will not send here until this device is verified with your Oxy recovery phrase, in Settings.',
-        );
-      }
-      return t(
-        'Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.',
-        { people: error.refusal.userIds.join(', ') },
-      );
-    },
-    [t],
+    (error: unknown): string | undefined => ephemeralRefusalMessage(error, people, t),
+    [people, t],
   );
 }

--- a/packages/frontend/components/messages/MessageInfoScreen.tsx
+++ b/packages/frontend/components/messages/MessageInfoScreen.tsx
@@ -26,6 +26,16 @@ export interface MessageInfoScreenProps {
   visible: boolean;
   message: Message | null;
   senderName?: string;
+  /**
+   * The sender's handle, without its `@`.
+   *
+   * What this line used to hold was `message.senderId`, printed as `ID: …` — an
+   * Oxy account id on the Express backend and a Matrix user id on the other. A
+   * handle is the identifier a reader can actually use: it is how they would
+   * find the same person anywhere else in Oxy. When there is none, the line is
+   * absent rather than filled with the id it replaced.
+   */
+  senderHandle?: string;
   senderAvatar?: string;
   onClose: () => void;
 }
@@ -51,6 +61,7 @@ export const MessageInfoScreen = memo<MessageInfoScreenProps>(({
   visible,
   message,
   senderName,
+  senderHandle,
   senderAvatar,
   onClose,
 }) => {
@@ -206,7 +217,9 @@ export const MessageInfoScreen = memo<MessageInfoScreenProps>(({
                   />
                   <View style={styles.senderInfo}>
                     <Text style={styles.senderName}>{senderName || 'Unknown'}</Text>
-                    <Text style={styles.senderId}>ID: {message.senderId}</Text>
+                    {senderHandle ? (
+                      <Text style={styles.senderId}>@{senderHandle}</Text>
+                    ) : null}
                   </View>
                 </View>
               </View>

--- a/packages/frontend/hooks/useChatPeople.ts
+++ b/packages/frontend/hooks/useChatPeople.ts
@@ -1,0 +1,200 @@
+import { useCallback, useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { useOxy } from '@oxyhq/services';
+
+import { useBridgeGhostNamespaces } from '@/hooks/useBridges';
+import { useMatrixRuntime } from '@/hooks/useMatrixRuntime';
+import {
+  ChatPeopleDirectory,
+  chatPersonFrom,
+  chatPersonOriginOf,
+  NO_CHAT_PERSON_REQUESTS,
+  viewerServerNameOf,
+  type ChatPeopleLookup,
+  type ChatPerson,
+  type ChatPersonOrigin,
+  type ChatPersonRequest,
+  type OxyPersonProfile,
+} from '@/lib/chat/people';
+
+/**
+ * WHO THE PEOPLE ON THIS SCREEN ARE.
+ *
+ * The React half of `lib/chat/people.ts`: it takes the Matrix user ids a screen
+ * is about to draw and answers with people. Every surface in chat that shows
+ * somebody goes through this, and nothing else in chat asks Oxy about a person.
+ *
+ * **No Effect, and no fetch written by hand.** React Query, per the house rule
+ * and for the same reason `useProfileData` uses it: a lookup has three outcomes
+ * and a hook that derived "loading" from "no answer yet" cannot tell the third
+ * one — an account that does not exist — from the first, so it spins forever
+ * over somebody who will never arrive. Here the difference decides what is drawn:
+ * see `ChatPersonState`.
+ *
+ * **One entry in the cache per person, one request per batch.** The two are not
+ * in tension: the query key is the person, so a member list whose faces were
+ * already in the conversation list costs nothing, while `ChatPeopleDirectory`
+ * collects every id asked for in the same tick into a single `getUsersByIds`.
+ * Thirty people in a group is one request, and the second time it is none.
+ */
+
+/**
+ * How long somebody stays fresh.
+ *
+ * Five minutes, the same as `useProfileData` and the same as the Oxy client's
+ * own cache, so moving between the conversation list and a conversation does not
+ * re-ask for the people in both.
+ */
+const PERSON_STALE_TIME_MS = 5 * 60 * 1000;
+
+/** Exported because invalidating a person is otherwise a key typed twice. */
+export const chatPeopleQueryKeys = {
+  byOxyId: (oxyUserId: string) => ['chatPerson', oxyUserId] as const,
+};
+
+/** One entry, so a screen with nobody to draw does not allocate a lookup. */
+const NO_ENTRIES: readonly ChatPersonEntry[] = [];
+
+interface ChatPersonEntry {
+  readonly request: ChatPersonRequest;
+  readonly origin: ChatPersonOrigin;
+}
+
+/**
+ * The people behind a list of Matrix user ids.
+ *
+ * `requests` must be a stable reference — wrap it in `useMemo` — because it is
+ * what decides the set of queries. A new array every render would be a new set
+ * of queries every render.
+ */
+export function useChatPeople(requests: readonly ChatPersonRequest[]): ChatPeopleLookup {
+  const { t } = useTranslation();
+  const { oxyServices } = useOxy();
+  const runtime = useMatrixRuntime();
+  const namespaces = useBridgeGhostNamespaces();
+
+  /**
+   * The homeserver everybody in this account lives on, read from the viewer's
+   * own session — see `matrixServerNameOf` for why it is not configuration.
+   *
+   * `undefined` before anybody is signed in, which is a state every surface
+   * reaches on a cold start, and one where nothing can be claimed about anybody:
+   * `chatPersonOriginOf` treats every id as foreign until it is known.
+   */
+  const serverName = useMemo(() => viewerServerNameOf(runtime.userId), [runtime.userId]);
+
+  const directory = useMemo(() => new ChatPeopleDirectory(oxyServices), [oxyServices]);
+
+  const entries = useMemo<readonly ChatPersonEntry[]>(() => {
+    if (requests.length === 0) {
+      return NO_ENTRIES;
+    }
+    return dedupeRequests(requests).map((request) => ({
+      request,
+      origin: chatPersonOriginOf(request.userId, serverName, namespaces),
+    }));
+  }, [requests, serverName, namespaces]);
+
+  /**
+   * The Oxy accounts to ask about, and nobody else.
+   *
+   * A bridge's puppet and a foreign user are absent by construction rather than
+   * by a disabled query, because "do not ask Oxy about this person" is a rule
+   * about correctness and not about saving a request.
+   */
+  const oxyUserIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const entry of entries) {
+      if (entry.origin.kind === 'oxy') {
+        ids.add(entry.origin.oxyUserId);
+      }
+    }
+    return [...ids];
+  }, [entries]);
+
+  const profiles = useQueries({
+    queries: oxyUserIds.map((oxyUserId) => ({
+      queryKey: chatPeopleQueryKeys.byOxyId(oxyUserId),
+      queryFn: () => directory.load(oxyUserId),
+      staleTime: PERSON_STALE_TIME_MS,
+      // Two attempts and then the honest sentence. A member list that retried
+      // for half a minute would be a list of blank rows for half a minute.
+      retry: 1,
+    })),
+    combine: (results) => results.map((result) => result.data),
+  });
+
+  const profileByOxyId = useMemo(() => {
+    const byId = new Map<string, OxyPersonProfile | null | undefined>();
+    oxyUserIds.forEach((oxyUserId, index) => {
+      byId.set(oxyUserId, profiles[index]);
+    });
+    return byId;
+  }, [oxyUserIds, profiles]);
+
+  const unknownPersonLabel = t('chat.person.unknown');
+
+  const people = useMemo(() => {
+    const byUserId = new Map<string, ChatPerson>();
+    for (const entry of entries) {
+      // `null` — not `undefined` — for anybody who is never looked up: there is
+      // nothing pending for them, and `undefined` means "the answer has not
+      // arrived".
+      const profile =
+        entry.origin.kind === 'oxy' ? profileByOxyId.get(entry.origin.oxyUserId) : null;
+      byUserId.set(
+        entry.request.userId,
+        chatPersonFrom(entry.request, entry.origin, profile, unknownPersonLabel),
+      );
+    }
+    return byUserId;
+  }, [entries, profileByOxyId, unknownPersonLabel]);
+
+  return useCallback(
+    (matrixUserId: string) => people.get(matrixUserId),
+    [people],
+  );
+}
+
+/**
+ * One person, for a surface that draws exactly one.
+ *
+ * The same cache and the same batch as {@link useChatPeople}; this is only the
+ * shape a caller with a single id would otherwise have to build by hand.
+ */
+export function useChatPerson(
+  request: ChatPersonRequest | undefined,
+): ChatPerson | undefined {
+  const requests = useMemo(
+    () => (request === undefined ? NO_CHAT_PERSON_REQUESTS : [request]),
+    [request],
+  );
+  const people = useChatPeople(requests);
+  return request === undefined ? undefined : people(request.userId);
+}
+
+/**
+ * One request per person, keeping whichever of the duplicates carries a name.
+ *
+ * The same person turns up twice all the time — several messages in a row from
+ * one sender, somebody who is in the room and also sent its latest message — and
+ * only some of those places have Matrix's own display name to offer.
+ */
+function dedupeRequests(
+  requests: readonly ChatPersonRequest[],
+): readonly ChatPersonRequest[] {
+  const byUserId = new Map<string, ChatPersonRequest>();
+  for (const request of requests) {
+    const existing = byUserId.get(request.userId);
+    if (existing === undefined) {
+      byUserId.set(request.userId, request);
+      continue;
+    }
+    if (existing.matrixDisplayName === undefined && request.matrixDisplayName !== undefined) {
+      byUserId.set(request.userId, request);
+    }
+  }
+  return [...byUserId.values()];
+}

--- a/packages/frontend/hooks/useMatrixConversations.ts
+++ b/packages/frontend/hooks/useMatrixConversations.ts
@@ -2,10 +2,17 @@ import { useMemo, useSyncExternalStore } from 'react';
 
 import type { Conversation } from '@/app/(chat)/index';
 import { useBridgeGhostNamespaces } from '@/hooks/useBridges';
+import { useChatPeople } from '@/hooks/useChatPeople';
 import { useEphemeralPolicies } from '@/hooks/useEphemeralPolicy';
 import { useMatrixEventLabels } from '@/hooks/useMatrixEventLabels';
+import { useMatrixRuntime } from '@/hooks/useMatrixRuntime';
 import { CHAT_BACKEND } from '@/lib/chat/backend';
 import { toConversation } from '@/lib/chat/matrixViewModel';
+import {
+  NO_CHAT_PERSON_REQUESTS,
+  peopleInConversationTitles,
+  viewerServerNameOf,
+} from '@/lib/chat/people';
 import { roomListSource } from '@/lib/chat/roomListSource';
 import type { AlloRoomSummary, AlloUnsubscribe } from '@/lib/matrix/types';
 
@@ -50,6 +57,31 @@ export function useMatrixConversations(): readonly Conversation[] | undefined {
   // loaded, which `roomOrigin.ts` treats as "nothing is known to be bridged".
   const namespaces = useBridgeGhostNamespaces();
 
+  /**
+   * The people the rows have to be named after.
+   *
+   * A room with no `m.room.name` is titled after its members by both SDKs, and
+   * on Allo's homeserver a member has no Matrix display name — so the title of a
+   * one-to-one conversation is an MXID and the title of an unnamed group is
+   * several. Collected across the whole list and deduplicated before anything is
+   * asked, so a person in four conversations is one lookup and the list as a
+   * whole is one request. See `lib/chat/people.ts`.
+   */
+  const requests = useMemo(
+    () =>
+      enabled
+        ? peopleInConversationTitles(rooms.map((room) => room.displayName))
+        : NO_CHAT_PERSON_REQUESTS,
+    [rooms],
+  );
+  const people = useChatPeople(requests);
+
+  const runtime = useMatrixRuntime();
+  const naming = useMemo(
+    () => ({ serverName: viewerServerNameOf(runtime.userId), people }),
+    [runtime.userId, people],
+  );
+
   // Derived during render, as a mapping of the snapshot should be. An Effect that
   // mirrored this into state would render one frame of the previous list every
   // time a message arrived.
@@ -57,9 +89,9 @@ export function useMatrixConversations(): readonly Conversation[] | undefined {
     () =>
       enabled
         ? rooms.map((room) =>
-            toConversation(room, labels, policies.has(room.roomId), namespaces),
+            toConversation(room, labels, policies.has(room.roomId), namespaces, naming),
           )
         : undefined,
-    [rooms, labels, policies, namespaces],
+    [rooms, labels, policies, namespaces, naming],
   );
 }

--- a/packages/frontend/hooks/useMatrixSenderInfo.ts
+++ b/packages/frontend/hooks/useMatrixSenderInfo.ts
@@ -1,0 +1,111 @@
+import { useCallback, useMemo } from 'react';
+
+import { CHAT_BACKEND } from '@/lib/chat/backend';
+import {
+  NO_CHAT_PERSON_REQUESTS,
+  type ChatPeopleLookup,
+  type ChatPersonRequest,
+} from '@/lib/chat/people';
+import type { Message } from '@/stores/messagesStore';
+
+/**
+ * WHO SENT EACH MESSAGE, on the Matrix backend.
+ *
+ * The counterpart of `useSenderInfo`, which is the Express one and cannot serve
+ * both: it looks a sender up in the Oxy users store by the id it was handed, and
+ * on Matrix that id is an MXID. The store has no entry under one, the
+ * `senderId === user.id` comparison is an MXID against an Oxy id and is always
+ * false, and a Matrix `Conversation` carries no `participants` to fall back to —
+ * so it returned the empty string for every sender in every group. The names
+ * over incoming bubbles were not wrong; there were none.
+ *
+ * Split in two — the ids to look up, then the drawing — because the conversation
+ * needs the same people for a second thing: the ephemeral refusal names them,
+ * and one lookup has to serve both. See `ConversationView`.
+ */
+
+/**
+ * What a conversation needs to draw the people who spoke in it.
+ *
+ * Both backends answer this shape — see `useSenderInfo` for the other — so the
+ * screen picks one and nothing downstream branches. Every one of them may answer
+ * `undefined`, which means "draw nothing here": an identifier is never a fallback.
+ */
+export interface SenderInfo {
+  readonly getSenderName: (senderId: string) => string | undefined;
+  /** Without its `@`. */
+  readonly getSenderHandle: (senderId: string) => string | undefined;
+  readonly getSenderAvatar: (senderId: string) => string | undefined;
+}
+
+const enabled = CHAT_BACKEND === 'matrix';
+
+/**
+ * Everybody who spoke in what is on screen, once each.
+ *
+ * From the messages rather than from the room's member list, because that is who
+ * has to be named: somebody who left is still the sender of what they said, and
+ * a member who has never spoken needs no name here. `senderName` travels with
+ * the id because for a bridged contact it is the only name there will ever be —
+ * a mautrix bridge names its puppets — and for anybody on Allo's own homeserver
+ * there is none at all.
+ *
+ * Empty on the Express backend, where senders are Oxy ids and `useSenderInfo`
+ * already resolves them.
+ */
+export function useMessageSenderRequests(
+  messages: readonly Message[],
+): readonly ChatPersonRequest[] {
+  return useMemo(() => {
+    if (!enabled) {
+      return NO_CHAT_PERSON_REQUESTS;
+    }
+    const seen = new Set<string>();
+    const collected: ChatPersonRequest[] = [];
+    for (const message of messages) {
+      if (message.isSent || message.senderId === '' || seen.has(message.senderId)) {
+        continue;
+      }
+      seen.add(message.senderId);
+      collected.push({
+        userId: message.senderId,
+        matrixDisplayName: message.senderName,
+      });
+    }
+    return collected;
+  }, [messages]);
+}
+
+/**
+ * Answers `undefined` when this build talks to the Express API, so
+ * `ConversationView` can pick between the two providers with `??` and neither
+ * hook needs to know about the other.
+ */
+export function useMatrixSenderInfo(people: ChatPeopleLookup): SenderInfo | undefined {
+  const getSenderName = useCallback(
+    (senderId: string): string | undefined => {
+      // Empty while the lookup is in flight, and `undefined` is what the bubble
+      // wants for "draw no name": an id has never been an acceptable answer, and
+      // a name that appears and then changes is worse than one that appears a
+      // moment late.
+      const name = people(senderId)?.displayName;
+      return name === undefined || name === '' ? undefined : name;
+    },
+    [people],
+  );
+
+  const getSenderHandle = useCallback(
+    (senderId: string): string | undefined => people(senderId)?.handle,
+    [people],
+  );
+
+  const getSenderAvatar = useCallback(
+    (senderId: string): string | undefined => people(senderId)?.avatarUrl,
+    [people],
+  );
+
+  return useMemo(
+    () => (enabled ? { getSenderName, getSenderHandle, getSenderAvatar } : undefined),
+    [getSenderName, getSenderHandle, getSenderAvatar],
+  );
+}

--- a/packages/frontend/hooks/useSenderInfo.ts
+++ b/packages/frontend/hooks/useSenderInfo.ts
@@ -2,12 +2,22 @@ import { useCallback, useEffect } from 'react';
 import { useUsersStore } from '@/stores/usersStore';
 import { useOxy } from '@oxyhq/services';
 import { Conversation } from '@/app/(chat)/index';
+import type { SenderInfo } from '@/hooks/useMatrixSenderInfo';
+import { logger } from '@/utils/logger';
 
+/**
+ * Who sent each message, on the Express backend.
+ *
+ * Every id here is an **Oxy account id**. `useMatrixSenderInfo` is the other
+ * half, for the backend where they are Matrix user ids, and the two answer the
+ * same {@link SenderInfo} shape so that `ConversationView` picks between them
+ * with a `??` and nothing else changes.
+ */
 export function useSenderInfo(
   conversation: Conversation | null | undefined,
   isGroup: boolean,
   conversationMetadata: { contactAvatar?: string }
-) {
+): SenderInfo {
   const usersStore = useUsersStore();
   const { user, oxyServices } = useOxy();
 
@@ -59,6 +69,22 @@ export function useSenderInfo(
   }, [conversation, user, usersStore]);
 
   /**
+   * The sender's handle, without its `@`.
+   *
+   * Drawn by `MessageInfoScreen`, where the line used to be the raw account id.
+   */
+  const getSenderHandle = useCallback((senderId: string): string | undefined => {
+    const senderUser = usersStore.getCachedById(senderId);
+    if (senderUser?.username || senderUser?.handle) {
+      return senderUser.username || senderUser.handle;
+    }
+    if (senderId === user?.id) {
+      return user.username;
+    }
+    return conversation?.participants?.find((p) => p.id === senderId)?.username;
+  }, [conversation, user, usersStore]);
+
+  /**
    * Get sender avatar for incoming messages using Oxy user data
    */
   const getSenderAvatar = useCallback((senderId: string): string | undefined => {
@@ -90,13 +116,15 @@ export function useSenderInfo(
     if (avatar && oxyServices && !avatar.startsWith('http') && !avatar.startsWith('file://')) {
       try {
         return oxyServices.getFileDownloadUrl(avatar, 'thumb');
-      } catch (e) {
-        // Ignore error
+      } catch (error: unknown) {
+        // The id is kept and handed on: an image that fails to load is a missing
+        // face, and swallowing the reason leaves nothing to explain it by.
+        logger.error(`[chat] no avatar URL could be built for ${senderId}`, error);
       }
     }
 
     return avatar;
   }, [conversation, conversationMetadata.contactAvatar, isGroup, usersStore, oxyServices]);
 
-  return { getSenderName, getSenderAvatar };
+  return { getSenderName, getSenderHandle, getSenderAvatar };
 }

--- a/packages/frontend/lib/chat/matrixIdentity.ts
+++ b/packages/frontend/lib/chat/matrixIdentity.ts
@@ -1,5 +1,6 @@
 /**
- * Turning an Oxy user id into the Matrix user id that names the same person.
+ * Turning an Oxy user id into the Matrix user id that names the same person,
+ * and back again.
  *
  * Allo's screens know people by their Oxy id: that is what the profile search
  * answers with, what an avatar is looked up by, and what a report is filed
@@ -15,6 +16,13 @@
  * directions. The alternative is a table mapping the two, and a table brings
  * every failure a table has: rows that go missing, two ids that map to one, and
  * a user nobody can invite because the row that named them was lost.
+ *
+ * "In both directions" is the operative half, and for a long time only one of
+ * them was here. The consequence was visible: every room on Allo's homeserver
+ * has to be named after its members, Matrix Authentication Service publishes no
+ * `displayname` for anybody, and so a conversation was titled `@<hex>:allo.you`
+ * and a member list was a column of them. {@link oxyUserIdFrom} is the missing
+ * half of the argument above.
  *
  * The backend does the same arithmetic in
  * `packages/backend/src/services/bridges/matrixIdentity.ts`, for the opposite
@@ -34,10 +42,55 @@
  * quietly.
  *
  * Allo's Oxy ids are 24-character hexadecimal ObjectIds, which fit unchanged.
+ *
+ * **The reverse direction refuses for the mirror reason.** A localpart that is
+ * not a well-formed Oxy id must not be trimmed, lowercased or padded into one
+ * and then looked up: the lookup would succeed against somebody else, and their
+ * name and their face would be drawn over a stranger's messages. A bridge's
+ * puppet and a user on another homeserver are exactly that case, and they are
+ * routine rather than exceptional — which is why {@link oxyUserIdFrom} answers
+ * `undefined` where {@link matrixUserIdFor} throws. See its own note.
  */
 
 /** The grammar of a Matrix localpart Allo is willing to build. */
 const LOCALPART_PATTERN = /^[a-z0-9._=/+-]+$/;
+
+/**
+ * The grammar of a Matrix localpart Allo is willing to *read*.
+ *
+ * Wider than {@link LOCALPART_PATTERN}, and deliberately so: that one says what
+ * Allo may mint, this one says what a homeserver may hand back. The spec's
+ * "historical user ID" grammar is any printable ASCII except `:`, and Allo meets
+ * plenty of it — a bridge's `@whatsapp_34600…`, and any account on a homeserver
+ * that predates the modern rules. Reading those with the narrow grammar would
+ * classify them as "not a Matrix user id at all", and something that is not an
+ * id is left on screen verbatim, which is the failure this module is here to
+ * stop.
+ *
+ * `\x21` to `\x7E` is printable ASCII with the space excluded; `\x3A` is the
+ * colon, which separates the two halves and so cannot be in either.
+ */
+const READABLE_LOCALPART_PATTERN = /^[\x21-\x39\x3B-\x7E]+$/;
+
+/**
+ * The grammar of the server half: a DNS name, an IPv4 or bracketed IPv6
+ * literal, and an optional port.
+ *
+ * Kept loose on purpose. Nothing here has to *validate* a homeserver — that is
+ * the homeserver's own business — it only has to know where a user id stops, so
+ * that {@link matrixUserIdsIn} does not swallow the rest of a sentence into one.
+ */
+const SERVER_NAME_PATTERN = /^[A-Za-z0-9\-.[\]:]+$/;
+
+/**
+ * The shape of an Oxy user id: a 24-character hexadecimal MongoDB ObjectId.
+ *
+ * Lowercase only, because that is what the forward direction produces and what
+ * MAS therefore puts in a localpart. Accepting uppercase here would accept an
+ * id this app could never have minted, which is the loosening that turns a
+ * refusal into a wrong lookup.
+ */
+const OXY_USER_ID_PATTERN = /^[0-9a-f]{24}$/;
 
 /**
  * A Matrix user id is capped at 255 bytes, sigil and server name included.
@@ -116,3 +169,114 @@ export function matrixUserIdFor(oxyUserId: string, serverName: string): string {
   }
   return userId;
 }
+
+/** The two halves of a Matrix user id, once it is known to be one. */
+export interface MatrixUserIdParts {
+  /** What is between the `@` and the first colon. */
+  readonly localpart: string;
+  /** Everything after that colon, port included. */
+  readonly serverName: string;
+}
+
+/**
+ * The two halves of a Matrix user id, or `undefined` if it is not one.
+ *
+ * Split on the FIRST colon and not the last, because the server half may hold a
+ * port and an IPv6 literal holds several — `@alba:[::1]:8448` is one user on one
+ * server — while the localpart may hold none at all.
+ *
+ * `undefined` rather than a throw: this is asked about strings that have every
+ * right not to be user ids, starting with the title of a room somebody named
+ * themselves.
+ */
+export function parseMatrixUserId(value: string): MatrixUserIdParts | undefined {
+  if (!value.startsWith('@') || value.length > MAX_MATRIX_USER_ID_LENGTH) {
+    return undefined;
+  }
+  const separator = value.indexOf(':');
+  if (separator < 0) {
+    return undefined;
+  }
+  const localpart = value.slice(1, separator);
+  const serverName = value.slice(separator + 1);
+  if (!READABLE_LOCALPART_PATTERN.test(localpart)) {
+    return undefined;
+  }
+  if (!SERVER_NAME_PATTERN.test(serverName)) {
+    return undefined;
+  }
+  return { localpart, serverName };
+}
+
+/**
+ * The Oxy account a Matrix user id names, or `undefined` when it names none.
+ *
+ * The exact inverse of {@link matrixUserIdFor}, and as strict: it answers only
+ * for an id on `serverName` whose localpart is a well-formed Oxy user id, and
+ * nothing else is coerced into being one. Three kinds of MXID are therefore
+ * refused, and all three are ordinary rather than exceptional:
+ *
+ * - **a bridge's puppet** — `@whatsapp_34600111222:allo.you` is a WhatsApp
+ *   contact, not an Oxy account, and asking Oxy who it is is wrong at every
+ *   level. `lib/chat/roomOrigin.ts` is what recognises those, and
+ *   `lib/chat/people.ts` asks it first.
+ * - **somebody on another homeserver** — their localpart means whatever their
+ *   server decided it means, and it is not an Oxy id even when it looks like
+ *   one, which is why the server name is checked before the localpart is.
+ * - **a localpart that is not an Oxy id at all.**
+ *
+ * `undefined` and not a throw, unlike the forward direction: there the caller
+ * has asked to name one specific person and must not be handed the wrong one,
+ * whereas here the question is asked about every member of every room and "not
+ * an Oxy account" is a correct answer with a rendering of its own.
+ */
+export function oxyUserIdFrom(
+  matrixUserId: string,
+  serverName: string,
+): string | undefined {
+  const parts = parseMatrixUserId(matrixUserId);
+  if (parts === undefined || parts.serverName !== serverName) {
+    return undefined;
+  }
+  return OXY_USER_ID_PATTERN.test(parts.localpart) ? parts.localpart : undefined;
+}
+
+/**
+ * Every Matrix user id inside a longer string, in the order they appear and
+ * without duplicates.
+ *
+ * This exists for one thing: **the title both SDKs compute for a room that has
+ * no `m.room.name`.** Matrix names such a room after its members, a member with
+ * no `displayname` is named after their user id, and nobody on Allo's homeserver
+ * has a `displayname` — so the title of a one-to-one conversation is a bare
+ * MXID, and the title of an unnamed group is two or three of them joined by
+ * whatever the SDK joins them with. Neither is a string this app may draw, and
+ * neither can be recovered from anything else the room summary carries.
+ *
+ * The candidates a scan finds are put through {@link parseMatrixUserId} rather
+ * than trusted, so what comes back is a list of complete, well-formed ids and
+ * never a fragment of one. Everything else in the string is left alone: a room
+ * somebody named "budget@work: 2026" contains no user id and comes back empty.
+ */
+export function matrixUserIdsIn(text: string): readonly string[] {
+  const found: string[] = [];
+  for (const match of text.matchAll(MATRIX_USER_ID_IN_TEXT)) {
+    const candidate = match[0];
+    if (parseMatrixUserId(candidate) !== undefined && !found.includes(candidate)) {
+      found.push(candidate);
+    }
+  }
+  return found;
+}
+
+/**
+ * Where a user id might start and stop inside prose.
+ *
+ * Wider than the grammar on purpose — every candidate is re-checked by
+ * {@link parseMatrixUserId} — but not so wide that it runs past the end of one.
+ * The server half is matched as dot-separated labels rather than as "dots and
+ * letters", so the full stop at the end of a sentence is not eaten; and the
+ * localpart excludes the space, so the next word is not either.
+ */
+const MATRIX_USER_ID_IN_TEXT =
+  /@[\x21-\x39\x3B-\x7E]+:(?:\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*)(?::\d{1,5})?/g;

--- a/packages/frontend/lib/chat/matrixViewModel.ts
+++ b/packages/frontend/lib/chat/matrixViewModel.ts
@@ -11,10 +11,33 @@ import type {
   MessageAttachment,
   MessageAttachmentKind,
 } from '@/stores/messagesStore';
+import { matrixUserIdsIn } from './matrixIdentity';
+import {
+  conversationTitleFrom,
+  NO_CHAT_PEOPLE,
+  type ChatPeopleLookup,
+} from './people';
 import { roomSummarySecurity, type GhostNamespace } from './roomOrigin';
 
 /** Shared so that the default argument is one identity and not a new array per row. */
 const NO_NAMESPACES: readonly GhostNamespace[] = [];
+
+/**
+ * What is needed to draw a room's title as people rather than as identifiers.
+ *
+ * One argument and not two, because the pair is meaningless apart: a lookup
+ * without the viewer's server name cannot tell one of this account's people from
+ * a string somebody typed into a group's name, and a server name without a
+ * lookup has nobody to name. See {@link conversationTitleFrom}.
+ */
+export interface ConversationNaming {
+  /** The viewer's own homeserver, from their session. */
+  readonly serverName: string | undefined;
+  readonly people: ChatPeopleLookup;
+}
+
+/** Nobody, as one identity, for a caller that has no people yet. */
+const NO_NAMING: ConversationNaming = { serverName: undefined, people: NO_CHAT_PEOPLE };
 
 /**
  * The port's view model, translated into the one Allo's chat components draw.
@@ -104,19 +127,37 @@ export function toConversation(
    * "not bridged", which is both correct there and the answer that says less.
    */
   namespaces: readonly GhostNamespace[] = NO_NAMESPACES,
+  /**
+   * Who the people named in the room's title are.
+   *
+   * Defaulted to nobody, which yields a room with no title rather than a wrong
+   * one. See {@link ConversationNaming}.
+   */
+  naming: ConversationNaming = NO_NAMING,
 ): Conversation {
   const latest = summary.latestMessage;
   return {
     id: summary.roomId,
     type: summary.isDirect ? 'direct' : 'group',
-    // The room id is a poor name and a better one than nothing: it is what the
-    // user sees while sync has not yet delivered the room's name or enough
-    // members to compute one.
-    name: summary.displayName ?? summary.roomId,
+    /**
+     * The people in it, when the room has no name of its own.
+     *
+     * It used to be `summary.displayName ?? summary.roomId`, and both halves of
+     * that were an identifier on screen. A room with no `m.room.name` is named
+     * by both SDKs after its members, and nobody on Allo's homeserver has a
+     * Matrix display name — Matrix Authentication Service knows the Oxy subject
+     * only as a localpart — so what the title bar said was `@<hex>:allo.you`,
+     * and a room whose name had not arrived said `!room:allo.you`.
+     *
+     * An empty string while the people in it are still being looked up. A row
+     * with no title still has its message and its time; a row with somebody
+     * else's name on it has nothing to recover from.
+     */
+    name: conversationTitleFrom(summary.displayName, naming.serverName, naming.people),
     lastMessage: latest === undefined ? '' : previewOf(latest.content, labels),
     timestamp: latest === undefined ? '' : new Date(latest.sentAt).toISOString(),
     unreadCount: summary.unreadCount,
-    avatar: summary.avatarUrl,
+    avatar: conversationAvatarFrom(summary, naming),
     // An invitation is in the list because the port's definition of a
     // conversation is everything the viewer has not left, and it is not a
     // conversation yet: there is nothing to read in it and accepting comes first.
@@ -134,6 +175,35 @@ export function toConversation(
      */
     security: roomSummarySecurity(summary, namespaces),
   };
+}
+
+/**
+ * The picture beside a conversation, or nothing.
+ *
+ * **A room's own avatar is not usable here and never was.** Both halves of the
+ * port report it as the `mxc://` URI Matrix stores, and `getConversationAvatar`
+ * hands anything that is not an `http(s)`/`file` URL to
+ * `oxyServices.getFileDownloadUrl` — so every Matrix room with an avatar drew a
+ * broken image pointing at Oxy's CDN for a file id that is not one. Fetching the
+ * real bytes needs `AlloChatClient.downloadMedia`, which a pure mapping cannot
+ * call, so this reports nothing rather than something wrong.
+ *
+ * What it does have is the other person. A one-to-one conversation named after
+ * exactly one member is that member, and their Oxy avatar is a URL a view can
+ * fetch today.
+ */
+function conversationAvatarFrom(
+  summary: AlloRoomSummary,
+  naming: ConversationNaming,
+): string | undefined {
+  if (!summary.isDirect || summary.displayName === undefined) {
+    return undefined;
+  }
+  const userIds = matrixUserIdsIn(summary.displayName);
+  if (userIds.length !== 1) {
+    return undefined;
+  }
+  return naming.people(userIds[0])?.avatarUrl;
 }
 
 /**

--- a/packages/frontend/lib/chat/people.ts
+++ b/packages/frontend/lib/chat/people.ts
@@ -1,0 +1,523 @@
+import type { User } from '@oxyhq/core';
+
+import { logger } from '@/utils/logger';
+
+import {
+  matrixServerNameOf,
+  matrixUserIdsIn,
+  oxyUserIdFrom,
+  parseMatrixUserId,
+} from './matrixIdentity';
+import { ghostNetworkFor, type GhostNamespace } from './roomOrigin';
+
+/**
+ * WHO SOMEBODY IN A CONVERSATION IS.
+ *
+ * The one place that turns a Matrix user id into a person, and the only place in
+ * chat that asks Oxy anything about one.
+ *
+ * ## Why it is one module
+ *
+ * Five `oxyServices.*` calls are all the frontend makes about people, and they
+ * are moving behind `api.allo.you`. Every surface that draws somebody in a
+ * conversation — the room list's titles, the conversation header, the member
+ * list, the sender of a message in a group, an invitation, the ephemeral send
+ * warning — goes through {@link ChatPeopleGateway} and nothing else, so that
+ * move is a change to one implementation of one interface and not to twenty call
+ * sites. The gateway is deliberately the narrowest thing that works: two methods,
+ * both of which the replacement will have to provide anyway.
+ *
+ * ## Why the classification comes before the lookup
+ *
+ * Not every member of a room is an Oxy account, and the ones that are not must
+ * never reach an Oxy lookup:
+ *
+ * - **A bridge's puppet** is a WhatsApp or Telegram contact wearing an MXID.
+ *   `roomOrigin.ts` already owns the rule for recognising one and is asked
+ *   FIRST — before the localpart is examined at all — because that ordering is
+ *   what stops a namespace ever being mistaken for an account.
+ * - **Somebody on another homeserver** has a localpart that means whatever their
+ *   server decided, and it is not an Oxy id even when it is shaped like one.
+ * - **A localpart that is not a well-formed Oxy id** is refused rather than
+ *   repaired, which is the mirror of the rule in `matrixIdentity.ts`: coercing
+ *   one and looking it up puts a stranger's name and face on somebody's
+ *   messages.
+ *
+ * All three are drawn from what Matrix itself says about them, and Matrix
+ * usually says nothing, so all three can end up as {@link ChatPersonState
+ * `unresolved`}. That is a state with words of its own — see
+ * {@link chatPersonFrom} — and never the id.
+ *
+ * ## Why "not yet" and "not ever" are different states
+ *
+ * A lookup takes a round trip. Drawing "Unknown person" for that moment and then
+ * replacing it with a name is a flicker that says something false in between, so
+ * a person still being looked up is `pending` and every surface draws nothing for
+ * them. A person the lookup finished and failed on is `unresolved`, and *that* is
+ * where the honest sentence goes.
+ */
+
+/** Where somebody in a conversation comes from. */
+export type ChatPersonOrigin =
+  /** An Oxy account on the viewer's own homeserver. The only kind Oxy is asked about. */
+  | { readonly kind: 'oxy'; readonly oxyUserId: string }
+  /** A remote network's contact, carried by a bridge. Never an Oxy lookup. */
+  | { readonly kind: 'bridged'; readonly networkId: string }
+  /**
+   * Nobody Allo can name from an id: another homeserver's user, or a localpart
+   * on ours that is not an Oxy id. Whatever Matrix says about them is all there
+   * is.
+   */
+  | { readonly kind: 'foreign' };
+
+/** How far Allo has got with finding out who somebody is. */
+export type ChatPersonState =
+  /** Their name is known, from Oxy or from Matrix. */
+  | 'resolved'
+  /** The lookup has not answered yet. Surfaces draw nothing rather than a guess. */
+  | 'pending'
+  /** The lookup finished and nobody could be named. */
+  | 'unresolved';
+
+/**
+ * Somebody, ready to be drawn.
+ *
+ * {@link displayName} is **never a Matrix user id**. That is the invariant this
+ * whole module exists to hold, and `__tests__/chat/noMatrixIdsOnScreen.test.ts`
+ * is what keeps it holding.
+ */
+export interface ChatPerson {
+  /** The Matrix user id this is about. For keys and lookups, never for drawing. */
+  readonly userId: string;
+  readonly origin: ChatPersonOrigin;
+  readonly state: ChatPersonState;
+  /** Never an MXID. Empty only while {@link state} is `pending`. */
+  readonly displayName: string;
+  /** The Oxy handle, without its `@`. Absent for anybody who is not an Oxy account. */
+  readonly handle: string | undefined;
+  /** An image URL a view can fetch. Never an id and never an `mxc://` URI. */
+  readonly avatarUrl: string | undefined;
+  readonly verified: boolean;
+}
+
+/**
+ * What a surface knows about somebody before anything is looked up.
+ *
+ * `matrixDisplayName` travels with the id because for a bridged or foreign
+ * person it is the *only* name there will ever be, and the surface asking has it
+ * already — `AlloRoomMember.displayName`, `AlloTimelineItem.senderDisplayName`.
+ * Fetching it separately would be a second round trip for something already in
+ * hand.
+ */
+export interface ChatPersonRequest {
+  readonly userId: string;
+  /** The name Matrix itself has for them, if any. */
+  readonly matrixDisplayName?: string | undefined;
+}
+
+/** Somebody by their Matrix user id, or `undefined` if nobody asked about them. */
+export type ChatPeopleLookup = (matrixUserId: string) => ChatPerson | undefined;
+
+/** A lookup that knows nobody, so a caller with no people to draw needs no branch. */
+export const NO_CHAT_PEOPLE: ChatPeopleLookup = () => undefined;
+
+/**
+ * Everything chat asks about a person, and the whole of what moves to
+ * `api.allo.you`.
+ *
+ * Structurally typed against `OxyServices` rather than importing it, for the
+ * same reason `lib/matrix/web/` types the Matrix SDK structurally: it keeps this
+ * module — and its tests — free of a client that needs a session to exist.
+ */
+export interface ChatPeopleGateway {
+  /**
+   * Several accounts in one round trip.
+   *
+   * Plural, and there is no singular version on purpose: a group of thirty must
+   * not be thirty requests, and an interface that offered one at a time would be
+   * the thing that made it so. The SDK deduplicates, chunks and drops ids it
+   * cannot use, and answers only with the accounts it found — an id that names
+   * nobody is simply absent, which is what {@link ChatPersonState `unresolved`}
+   * is for.
+   */
+  getUsersByIds(ids: string[]): Promise<readonly User[]>;
+  /** Turns an Oxy Cloud file id into a URL a view can fetch. */
+  getFileDownloadUrl(fileId: string, variant?: string): string;
+}
+
+/** What one Oxy account contributes to a {@link ChatPerson}. */
+export interface OxyPersonProfile {
+  readonly displayName: string;
+  readonly handle: string | undefined;
+  readonly avatarUrl: string | undefined;
+  readonly verified: boolean;
+}
+
+/**
+ * The homeserver the viewer's own account is on, or `undefined`.
+ *
+ * `matrixServerNameOf` throws, and here it must not. Every caller is a screen
+ * drawing people: with no server name nothing is claimed to be an Oxy account,
+ * every id stays foreign, and the screen still renders — whereas a throw takes
+ * the conversation list away over a session that cannot exist unless an SDK
+ * produced a malformed one. Worth a log line, not a crash.
+ */
+export function viewerServerNameOf(viewerUserId: string | undefined): string | undefined {
+  if (viewerUserId === undefined) {
+    return undefined;
+  }
+  try {
+    return matrixServerNameOf(viewerUserId);
+  } catch (error: unknown) {
+    logger.error('[chat] the signed-in session does not name a homeserver', error);
+    return undefined;
+  }
+}
+
+/**
+ * Which of the three kinds of person an MXID names.
+ *
+ * `serverName` is the viewer's own homeserver, read from their session — see
+ * `matrixServerNameOf`. `undefined` means nobody is signed in, in which case
+ * nothing can be claimed about anybody and every id is `foreign`.
+ */
+export function chatPersonOriginOf(
+  matrixUserId: string,
+  serverName: string | undefined,
+  namespaces: readonly GhostNamespace[],
+): ChatPersonOrigin {
+  // First, and not as an optimisation. A bridge's namespace is a prefix on the
+  // localpart, so asking Oxy before asking `roomOrigin.ts` would be asking about
+  // a WhatsApp contact — and the day a namespace produces something that parses
+  // as an Oxy id, it would be answered.
+  const networkId = ghostNetworkFor(matrixUserId, namespaces);
+  if (networkId !== undefined) {
+    return { kind: 'bridged', networkId };
+  }
+  if (serverName === undefined) {
+    return { kind: 'foreign' };
+  }
+  const oxyUserId = oxyUserIdFrom(matrixUserId, serverName);
+  return oxyUserId === undefined ? { kind: 'foreign' } : { kind: 'oxy', oxyUserId };
+}
+
+/**
+ * An Oxy account, reduced to what a conversation draws of somebody.
+ *
+ * `name.displayName` before `username`, matching `useProfileData`: the API
+ * resolves the first one and consumers render it rather than recomposing a name
+ * from its parts. A handle is a last resort for the *name* and always the
+ * `handle`, which is why the two fields can hold the same string.
+ */
+export function oxyPersonProfileOf(
+  user: User,
+  gateway: ChatPeopleGateway,
+): OxyPersonProfile {
+  const handle = user.username === '' ? undefined : user.username;
+  return {
+    displayName: user.name?.displayName || handle || '',
+    handle,
+    avatarUrl: avatarUrlOf(user.avatar, gateway),
+    verified: user.verified === true,
+  };
+}
+
+/**
+ * A URL for an avatar, from whatever the account happens to carry.
+ *
+ * An Oxy avatar is normally a Cloud file id and occasionally an absolute URL
+ * already. Anything that is neither — an `mxc://` URI most of all — is dropped
+ * rather than handed to the file endpoint, which would answer with a 404 that
+ * the view draws as a broken image.
+ */
+function avatarUrlOf(
+  avatar: string | null | undefined,
+  gateway: ChatPeopleGateway,
+): string | undefined {
+  if (avatar === null || avatar === undefined || avatar === '') {
+    return undefined;
+  }
+  if (avatar.startsWith('http://') || avatar.startsWith('https://')) {
+    return avatar;
+  }
+  if (avatar.includes('://')) {
+    // A scheme Oxy Cloud does not serve. `mxc://` is the one that turns up, and
+    // there is no id in it that the file endpoint could resolve.
+    return undefined;
+  }
+  return gateway.getFileDownloadUrl(avatar, 'thumb');
+}
+
+/**
+ * Somebody, from everything now known about them.
+ *
+ * @param profile the Oxy account, `null` when the lookup finished and found
+ * nobody, and `undefined` while it has not finished. The three are different
+ * answers and the distinction is the whole reason this takes three arguments
+ * instead of one optional profile.
+ * @param unknownPersonLabel what to call somebody nobody could name. Passed in
+ * rather than looked up here so this stays a pure function of its arguments and
+ * the sentence stays in the user's own language.
+ */
+export function chatPersonFrom(
+  request: ChatPersonRequest,
+  origin: ChatPersonOrigin,
+  profile: OxyPersonProfile | null | undefined,
+  unknownPersonLabel: string,
+): ChatPerson {
+  const matrixName = nonEmpty(request.matrixDisplayName);
+
+  if (origin.kind === 'oxy') {
+    if (profile === undefined) {
+      // Still being looked up. Nothing is drawn: a name that appears and then
+      // changes is worse than one that appears a moment late.
+      return placeholder(request.userId, origin, 'pending', '', matrixName);
+    }
+    if (profile !== null && profile.displayName !== '') {
+      return {
+        userId: request.userId,
+        origin,
+        state: 'resolved',
+        displayName: profile.displayName,
+        handle: profile.handle,
+        avatarUrl: profile.avatarUrl,
+        verified: profile.verified,
+      };
+    }
+    // The account exists on the homeserver and Oxy could not describe it. What
+    // Matrix says is worth more than nothing, and the honest sentence is the
+    // last resort.
+    return placeholder(request.userId, origin, 'unresolved', unknownPersonLabel, matrixName);
+  }
+
+  // Bridged and foreign people are never looked up, so there is nothing to wait
+  // for: whatever Matrix said is the answer, and it is final either way.
+  return placeholder(request.userId, origin, 'unresolved', unknownPersonLabel, matrixName);
+}
+
+function placeholder(
+  userId: string,
+  origin: ChatPersonOrigin,
+  state: ChatPersonState,
+  label: string,
+  matrixDisplayName: string | undefined,
+): ChatPerson {
+  // Matrix's own name is preferred over the label, and refused when it is itself
+  // a user id: `matrix-js-sdk` answers `RoomMember.name` with the MXID when
+  // somebody has set no display name, and disambiguates a duplicate by appending
+  // it, so a name arriving from there is not automatically a name.
+  const fromMatrix =
+    matrixDisplayName !== undefined && parseMatrixUserId(matrixDisplayName) === undefined
+      ? matrixDisplayName
+      : undefined;
+  return {
+    userId,
+    origin,
+    state: fromMatrix === undefined ? state : 'resolved',
+    displayName: fromMatrix ?? label,
+    handle: undefined,
+    avatarUrl: undefined,
+    verified: false,
+  };
+}
+
+/**
+ * The title of a conversation, with the people in it named instead of numbered.
+ *
+ * A room with an `m.room.name` comes back unchanged; there is nothing here for
+ * one. What this is for is the other kind, whose title both SDKs compute from its
+ * members — see {@link matrixUserIdsIn} for why that title is made of MXIDs on
+ * Allo's homeserver, and why it cannot be reconstructed from anything else the
+ * summary carries.
+ *
+ * **Only ids on the viewer's own homeserver are rewritten.** An id belonging to
+ * somebody else's server is left exactly as it was found, because at that point
+ * the string is far more likely to be something a person typed into a group's
+ * name than a member of it — and a title the user chose must survive this
+ * function byte for byte.
+ *
+ * An empty string when a person in the title is still being looked up: half a
+ * title is not a title, and the alternative is the id.
+ */
+export function conversationTitleFrom(
+  roomTitle: string | undefined,
+  serverName: string | undefined,
+  people: ChatPeopleLookup,
+): string {
+  if (roomTitle === undefined || roomTitle === '') {
+    return '';
+  }
+  let title = roomTitle;
+  for (const userId of matrixUserIdsIn(roomTitle)) {
+    if (parseMatrixUserId(userId)?.serverName !== serverName) {
+      continue;
+    }
+    const person = people(userId);
+    if (person === undefined || person.displayName === '') {
+      return '';
+    }
+    title = title.split(userId).join(person.displayName);
+  }
+  return title;
+}
+
+/**
+ * Whether a room title is the name the room was GIVEN, rather than one computed
+ * from the people in it.
+ *
+ * The two are the same field everywhere the port reports a title, and only one
+ * of them may be offered back to the user in the box that renames the room:
+ * writing a computed title into `m.room.name` turns "the people in this
+ * conversation" into a permanent, server-readable string — which for an unnamed
+ * group on Allo's homeserver would be a list of MXIDs, saved for everyone.
+ *
+ * Decided by whether the title contains an id from the viewer's own homeserver,
+ * which is what a computed one is made of here and what a name somebody typed
+ * has no reason to contain.
+ */
+export function isOwnRoomName(
+  roomTitle: string | undefined,
+  serverName: string | undefined,
+): boolean {
+  if (roomTitle === undefined || roomTitle === '') {
+    return false;
+  }
+  return !matrixUserIdsIn(roomTitle).some(
+    (userId) => parseMatrixUserId(userId)?.serverName === serverName,
+  );
+}
+
+/**
+ * Everybody a list of conversation titles needs resolved.
+ *
+ * Deduplicated across the whole list, because one person is in several
+ * conversations and the point of asking here — rather than inside each row — is
+ * that the list makes one request and not one per row.
+ */
+export function peopleInConversationTitles(
+  titles: readonly (string | undefined)[],
+): readonly ChatPersonRequest[] {
+  const seen = new Set<string>();
+  const requests: ChatPersonRequest[] = [];
+  for (const title of titles) {
+    if (title === undefined || title === '') {
+      continue;
+    }
+    for (const userId of matrixUserIdsIn(title)) {
+      if (!seen.has(userId)) {
+        seen.add(userId);
+        requests.push({ userId });
+      }
+    }
+  }
+  return requests;
+}
+
+/** Nothing to ask about, as one identity so a memo does not see a new array. */
+export const NO_CHAT_PERSON_REQUESTS: readonly ChatPersonRequest[] = [];
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value === undefined || value.trim() === '' ? undefined : value;
+}
+
+/* ---------------------------------------------------------------------------
+ * Batching
+ * ------------------------------------------------------------------------- */
+
+/**
+ * How long a batch waits for company.
+ *
+ * Zero: the point is not to wait but to let the current tick finish. React
+ * renders a whole list before anything it started can settle, so every row's
+ * request is already in hand by the time a timer of zero fires — and a real
+ * delay would only make the names appear later.
+ */
+const BATCH_WINDOW_MS = 0;
+
+/**
+ * Turns many concurrent one-person questions into few many-person requests.
+ *
+ * The caching layer above this is React Query, one entry per person, which is
+ * what makes a member list that was already drawn in the conversation list cost
+ * nothing. But per-person cache entries mean per-person fetches, and thirty of
+ * those is the M+1 that `getUsersByIds` exists to prevent. This closes the gap:
+ * every id asked for within one tick is answered by one request.
+ *
+ * A failed request rejects every waiter in its batch rather than resolving them
+ * as "nobody". React Query is then free to retry, and — more importantly — a
+ * network blip does not get cached as thirty people who do not exist.
+ */
+export class ChatPeopleDirectory {
+  readonly #gateway: ChatPeopleGateway;
+  readonly #schedule: (flush: () => void) => void;
+  #waiting = new Map<string, Resolver[]>();
+  #scheduled = false;
+
+  /**
+   * @param schedule when to flush. Injectable so a test can drive the batching
+   * itself rather than sleeping, which is the only way to assert that thirty ids
+   * became one request and not thirty.
+   */
+  constructor(
+    gateway: ChatPeopleGateway,
+    schedule: (flush: () => void) => void = (flush) => {
+      setTimeout(flush, BATCH_WINDOW_MS);
+    },
+  ) {
+    this.#gateway = gateway;
+    this.#schedule = schedule;
+  }
+
+  /** The account with this Oxy id, or `null` if there is none. */
+  load(oxyUserId: string): Promise<OxyPersonProfile | null> {
+    return new Promise<OxyPersonProfile | null>((resolve, reject) => {
+      const waiters = this.#waiting.get(oxyUserId);
+      if (waiters === undefined) {
+        this.#waiting.set(oxyUserId, [{ resolve, reject }]);
+      } else {
+        waiters.push({ resolve, reject });
+      }
+      if (!this.#scheduled) {
+        this.#scheduled = true;
+        this.#schedule(() => {
+          void this.#flush();
+        });
+      }
+    });
+  }
+
+  async #flush(): Promise<void> {
+    const batch = this.#waiting;
+    // Taken before the request, not after: anything asked for while it is in
+    // flight belongs to the next batch, and must not be dropped by the answer to
+    // this one.
+    this.#waiting = new Map();
+    this.#scheduled = false;
+    if (batch.size === 0) {
+      return;
+    }
+
+    try {
+      const users = await this.#gateway.getUsersByIds([...batch.keys()]);
+      const byId = new Map(users.map((user) => [user.id, user]));
+      for (const [oxyUserId, waiters] of batch) {
+        const user = byId.get(oxyUserId);
+        const profile = user === undefined ? null : oxyPersonProfileOf(user, this.#gateway);
+        for (const waiter of waiters) {
+          waiter.resolve(profile);
+        }
+      }
+    } catch (error: unknown) {
+      for (const waiters of batch.values()) {
+        for (const waiter of waiters) {
+          waiter.reject(error);
+        }
+      }
+    }
+  }
+}
+
+interface Resolver {
+  readonly resolve: (profile: OxyPersonProfile | null) => void;
+  readonly reject: (error: unknown) => void;
+}

--- a/packages/frontend/lib/matrix/web/translate.ts
+++ b/packages/frontend/lib/matrix/web/translate.ts
@@ -260,7 +260,7 @@ export function toRoomPreview(
   return {
     sentAt: event.getTs(),
     sender,
-    senderDisplayName: event.sender?.name,
+    senderDisplayName: toSenderDisplayName(event.sender),
     isOwn: sender === viewerUserId,
     content: toEventContent(event),
   };
@@ -281,8 +281,32 @@ export interface TimelineEventFields {
   replacingEvent(): object | null;
   /** `null` for every event the homeserver has already accepted. */
   readonly status: SdkEventStatus | null;
-  /** The sender's room membership, once the SDK has resolved it. */
-  readonly sender: { readonly name: string } | null;
+  /**
+   * The sender's room membership, once the SDK has resolved it.
+   *
+   * `rawDisplayName` and not `name`, for the same reason `web/roomDetails.ts`
+   * reads the raw one: the SDK's `name` falls back to the user id when somebody
+   * has set no display name, and disambiguates two people with the same name by
+   * appending theirs — so `name` is an MXID, or a name with an MXID in
+   * brackets after it, exactly as often as somebody has no display name. On
+   * Allo's homeserver that is everybody, so every sender the port reported was
+   * an identifier while the field promised a name. `undefined` is what the port
+   * documents for "no name here", and it is now what it means.
+   */
+  readonly sender: { readonly rawDisplayName?: string } | null;
+}
+
+/**
+ * The sender's display name, or nothing.
+ *
+ * An empty string is not a name, and the SDK hands one over for a member whose
+ * `m.room.member` event carries `displayname: ""`.
+ */
+function toSenderDisplayName(
+  sender: { readonly rawDisplayName?: string } | null,
+): string | undefined {
+  const name = sender?.rawDisplayName;
+  return name === undefined || name === '' ? undefined : name;
 }
 
 /**
@@ -341,7 +365,7 @@ export function toTimelineItem(
     key: identity.key,
     id: identity.id,
     sender,
-    senderDisplayName: event.sender?.name,
+    senderDisplayName: toSenderDisplayName(event.sender),
     sentAt: event.getTs(),
     isOwn: sender === viewerUserId,
     sendState: toSendState(event.status),

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -702,6 +702,8 @@
   "Everyone here has an identity this device recognises, so messages can be sent.": "Everyone here has an identity this device recognises, so messages can be sent.",
   "Allo will not send here until this device is verified with your Oxy recovery phrase, in Settings.": "Allo will not send here until this device is verified with your Oxy recovery phrase, in Settings.",
   "Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.": "Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.",
+  "chat.person.unknown": "Unknown person",
+  "Allo will not send here: it does not recognise the identity of everybody in this conversation. Ask them to open Allo and finish setting up their account.": "Allo will not send here: it does not recognise the identity of everybody in this conversation. Ask them to open Allo and finish setting up their account.",
   "Allo could not change this setting": "Allo could not change this setting",
   "Messages disappear from this device after {{duration}}. Your own are deleted for everyone.": "Messages disappear from this device after {{duration}}. Your own are deleted for everyone.",
   "Identity verified by you": "Identity verified by you",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -670,6 +670,8 @@
   "Everyone here has an identity this device recognises, so messages can be sent.": "Todas las personas de aquí tienen una identidad que este dispositivo reconoce, así que se puede enviar.",
   "Allo will not send here until this device is verified with your Oxy recovery phrase, in Settings.": "Allo no enviará aquí hasta que este dispositivo esté verificado con tu frase de recuperación de Oxy, en Ajustes.",
   "Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.": "Allo no enviará aquí: no reconoce la identidad de {{people}}. Pídeles que abran Allo y terminen de configurar su cuenta.",
+  "chat.person.unknown": "Persona desconocida",
+  "Allo will not send here: it does not recognise the identity of everybody in this conversation. Ask them to open Allo and finish setting up their account.": "Allo no enviará aquí: no reconoce la identidad de todas las personas de esta conversación. Pídeles que abran Allo y terminen de configurar su cuenta.",
   "Allo could not change this setting": "Allo no ha podido cambiar este ajuste",
   "Messages disappear from this device after {{duration}}. Your own are deleted for everyone.": "Los mensajes desaparecen de este dispositivo tras {{duration}}. Los tuyos se borran para todo el mundo.",
   "Identity verified by you": "Identidad verificada por ti",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -664,6 +664,8 @@
   "Everyone here has an identity this device recognises, so messages can be sent.": "Tutti qui hanno un'identità che questo dispositivo riconosce, quindi si può inviare.",
   "Allo will not send here until this device is verified with your Oxy recovery phrase, in Settings.": "Allo non invierà qui finché questo dispositivo non sarà verificato con la tua frase di recupero di Oxy, in Impostazioni.",
   "Allo will not send here: it does not recognise the identity of {{people}}. Ask them to open Allo and finish setting up their account.": "Allo non invierà qui: non riconosce l'identità di {{people}}. Chiedi loro di aprire Allo e completare la configurazione dell'account.",
+  "chat.person.unknown": "Persona sconosciuta",
+  "Allo will not send here: it does not recognise the identity of everybody in this conversation. Ask them to open Allo and finish setting up their account.": "Allo non invierà qui: non riconosce l'identità di tutte le persone in questa conversazione. Chiedi loro di aprire Allo e completare la configurazione dell'account.",
   "Allo could not change this setting": "Allo non è riuscito a modificare questa impostazione",
   "Messages disappear from this device after {{duration}}. Your own are deleted for everyone.": "I messaggi spariscono da questo dispositivo dopo {{duration}}. I tuoi vengono eliminati per tutti.",
   "Identity verified by you": "Identità verificata da te",


### PR DESCRIPTION
## Summary

The owner opened a conversation and read `@<hex>:allo.you` where a person's name belongs. Five surfaces each reached for an identifier independently, because each had a name that might be absent and an id that never is — and on Allo's homeserver the name is **always** absent: MAS knows the Oxy subject only as a localpart and nothing in Allo ever sets a Matrix `displayname`.

The root cause is that `lib/chat/matrixIdentity.ts` only went one way. Its header argues for string arithmetic over a lookup table *because the derivation is deterministic in both directions*; only one of them was there.

- **`oxyUserIdFrom`** — the exact inverse of `matrixUserIdFor`, and as strict. A localpart that is not a well-formed Oxy id is refused, never repaired: a coerced lookup succeeds against a stranger. Bridge puppets, foreign homeservers and malformed localparts are all refused, and answer `undefined` rather than throwing because they are routine.
- **`lib/chat/people.ts`** — the one seam the whole of chat resolves a person through, so moving the five `oxyServices.*` calls behind `api.allo.you` is a change to one module. Asks `roomOrigin.ts` about bridges *before* looking at the localpart; renders a bridged contact from what Matrix says and nothing else.
- **`hooks/useChatPeople.ts`** — React Query, one cache entry per person; `ChatPeopleDirectory` coalesces a tick's worth of ids into a single `getUsersByIds`. Thirty people is one request; the second time it is none.

Pending draws nothing (a name that appears then changes says something false in between). Unresolvable reads as "Unknown person". Neither is ever the id.

Also fixed at the source: the web port reported `RoomMember.name` as `senderDisplayName` — the MXID for anybody without a display name — and a room's `mxc://` avatar was handed to `getFileDownloadUrl`, drawing a broken image on every Matrix room with a picture.

## Test plan

| | before | after |
|---|---|---|
| `bunx tsc --noEmit` | 0 errors | **0 errors** |
| `bunx jest --watchAll=false` | 87 suites / 1224 tests | **91 suites / 1304 tests, green** |
| `bunx expo lint` | 75 errors / 81 warnings | **75 / 81 — unchanged**, none in touched files |
| `bun run --cwd packages/frontend build` | — | **`Exported: dist`** |

**23 mutations applied, 23 caught.** Each was written to disk, the change on disk asserted before the suite ran, then restored and the restore asserted. Covers: the Oxy-id pattern, the homeserver check, the 255-byte cap, re-checking scanned candidates, bridge-before-Oxy ordering, the MXID fallback, trusting an MXID-shaped Matrix name, a partially-resolved title, looking bridged people up in Oxy, dropping the batching, caching a failed batch as "nobody exists", the `mxc://` avatar, offering a computed title for renaming, and each of the six render sites.

New tests: `people.test.ts` (39), `noMatrixIdsOnScreen.test.ts` (6), `ephemeralRefusalCopy.test.ts` (7), `personTranslations.test.ts` (6), plus round-trip and refusal cases in `matrixIdentity.test.ts`.

`noMatrixIdsOnScreen.test.ts` is a **source scan** rather than a render test: there is no rendering stack in this repo, and the regression is the *shape* of the expression — identical in all five places — so a scan sees every file whether or not anybody wrote a case for it. Same shape as `__tests__/routes/navigationTargets.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)