### PR TITLE
feat(backend): accept a Matrix token so Allo can collapse to one sign-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,30 @@ Two spikes back the decisions. Both live outside the workspaces, so a root
 
 ## Key features
 
+- **Authentication:** two ways in, told apart by the HTTP scheme.
+  `Authorization: Bearer` is an Oxy token and is what the app sends today;
+  `Authorization: MatrixBearer` is a Matrix Authentication Service token,
+  validated by RFC 7662 introspection in `packages/backend/src/middleware/matrixAuth.ts`
+  plus `src/services/auth/`. The scheme, and not a side header, carries the
+  discrimination: a proxy that strips an unknown header would otherwise separate
+  a credential from its issuer, and `oxy.auth()` reads a token only from a header
+  beginning with the exact string `"Bearer "`, so the two validators cannot see
+  each other's tokens. There is no fall-through between them. The MAS path is
+  **off unless `ALLO_MAS_ISSUER` is set**, and the introspection endpoint must be
+  same-origin with the issuer or the process refuses to boot — MAS sends no `iss`,
+  so where the question is asked IS the issuer verification. An introspection
+  answer is cached for at most 30 seconds, which is the bound on how long a
+  revoked token keeps working; MAS unreachable is 503 and never 401, because an
+  outage must not sign everybody out. **The Socket.IO handshake is not covered**
+  and still requires an Oxy token.
+- **People directory:** `/api/directory/*` (`packages/backend/src/routes/directory.ts`)
+  answers the five Oxy lookups the app makes — `getProfileByUsername`,
+  `getUserById`, `getUsersByIds`, `searchProfiles`, `getFileDownloadUrl` — so an
+  app with no Oxy session can still draw a person. **The frontend still calls Oxy
+  directly**; this is the surface it moves to. Every underlying Oxy route is
+  public, so no service credential is needed, and the responses are a PROJECTION
+  (`DirectoryUser` in `@allo/shared-types`) rather than the Oxy `User`, which
+  carries `email`, `phone`, `address` and `birthday`.
 - **E2E encryption:** `lib/signalProtocol.ts` does static ECDH (P-256) between
   identity keys, no KDF, AES-256-GCM. **It is not the Signal Protocol despite the
   filename:** no forward secrecy, prekeys generated but unused, and groups,

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,0 +1,108 @@
+# Allo backend — environment
+#
+# Copy to `.env` and fill in. NO VALUES ARE COMMITTED HERE, and none should be:
+# `.env` is gitignored, this file is not.
+#
+# Only the variables that are always needed, plus the two subsystems added by
+# the one-session work (Matrix Authentication Service, and Allo's own credential
+# for calling Oxy), are written out here. Bridges, push notifications and
+# CrowdSource each validate their own variables in `src/config/bridges.ts`,
+# `src/config/push.ts` and `src/config/crowdsource.ts`, with the reasoning next
+# to each rule — a second copy of those thirty-odd names in this file would be a
+# list that agrees with the schema until the day it does not, and the day it
+# does not is a deployment that boots with a variable that decides nothing.
+
+
+# ─── Core ────────────────────────────────────────────────────────────────────
+
+# MongoDB connection string. The DATABASE NAME is not in it: `utils/database.ts`
+# passes `dbName` built from the app name and NODE_ENV, so every Oxy app shares
+# one cluster URI and none share a database.
+MONGODB_URI=
+
+# `development` | `production`. Also half of the database name above.
+NODE_ENV=
+
+# Local development only. ECS injects 8080; `server.ts` defaults to 4140.
+PORT=
+
+
+# ─── Oxy ─────────────────────────────────────────────────────────────────────
+
+# The Oxy API base URL. Read by @oxyhq/core itself, not by any Allo module, and
+# defaults to https://api.oxy.so. Set it only to point at a non-production Oxy.
+OXY_API_URL=
+
+# Allo's own credential for calling the Oxy API as itself, minted at
+# console.oxy.so → Apps → Allo → Settings → Credentials with type `Service`.
+# The secret is shown exactly once.
+#
+# BOTH OR NEITHER — the process refuses to boot with one of the two.
+#
+# Optional. Every Oxy route the directory uses is public, so the lookups work
+# without a credential; what it changes is that bulk profile fetches take the
+# server-to-server path instead of an anonymous one, and that Oxy attributes the
+# traffic to Allo rather than to a datacentre IP. See `src/config/oxyService.ts`.
+ALLO_OXY_SERVICE_API_KEY=
+ALLO_OXY_SERVICE_API_SECRET=
+
+
+# ─── Matrix Authentication Service ───────────────────────────────────────────
+#
+# Setting ALLO_MAS_ISSUER is what makes this backend accept a Matrix access
+# token (`Authorization: MatrixBearer …`) alongside an Oxy one. Leave it empty
+# and only Oxy tokens are accepted, which is the shipped default and what is
+# deployed today. See `src/config/matrixAuth.ts`.
+
+# The OAuth 2.0 issuer identifier, exactly as MAS publishes it in
+# /.well-known/openid-configuration — trailing slash included. https only.
+ALLO_MAS_ISSUER=
+
+# The RFC 7662 introspection endpoint. MUST be same-origin with the issuer:
+# that check, made at boot, is the whole of Allo's issuer verification, because
+# MAS's introspection response carries no `iss` to check against.
+ALLO_MAS_INTROSPECTION_URL=
+
+# The OAuth client this backend authenticates to the introspection endpoint as,
+# and its secret. Configured on the MAS side, where the client must also be
+# permitted to introspect. MAS answers an unauthenticated introspection request
+# with 400 invalid_request, so both are required once the issuer is set.
+#
+# The secret must be at least 32 characters: it is a credential over every
+# user's session. `openssl rand -hex 32` clears it.
+ALLO_MAS_INTROSPECTION_CLIENT_ID=
+ALLO_MAS_INTROSPECTION_CLIENT_SECRET=
+
+# Optional. Comma-separated allowlist of the OAuth clients whose tokens are
+# accepted. Empty means any client of the configured issuer — which is the
+# realistic setting, because Allo registers with MAS dynamically and every
+# installation gets its own client id. Safe because a token carrying the Matrix
+# client-API scope already drives the whole account on the homeserver.
+ALLO_MAS_ALLOWED_CLIENT_IDS=
+
+# Optional. Comma-separated; ANY ONE of them in the token's scope is enough.
+# Defaults to both spellings of the MSC2967 client-API scope
+# (urn:matrix:org.matrix.msc2967.client:api:* and urn:matrix:client:api:*),
+# which is what stands in for an audience check on an opaque token. Override
+# only to narrow it.
+ALLO_MAS_ACCEPTED_SCOPES=
+
+# Optional. When set, the introspection response must carry an `aud` containing
+# it. MAS does not send `aud`, so setting this against MAS refuses every token;
+# it is here for an authorization server that does.
+ALLO_MAS_EXPECTED_AUDIENCE=
+
+# Optional. How long an introspection answer may be reused, in seconds.
+# Default 30, maximum 300. This is the bound on how long a REVOKED token keeps
+# working, so it is deliberately far shorter than the token's own lifetime.
+ALLO_MAS_INTROSPECTION_CACHE_SECONDS=
+
+# Optional. How long MAS gets to answer, in milliseconds. Default 5000.
+# An introspection that times out authenticates nobody — the request is
+# answered 503, never allowed through.
+ALLO_MAS_INTROSPECTION_TIMEOUT_MS=
+
+# The homeserver's server name, e.g. matrix.allo.you. Already used by the bridge
+# subsystem; the Matrix authentication path needs it too, but only to judge a
+# `username` that arrives from MAS carrying an `@` sigil.
+ALLO_MATRIX_SERVER_NAME=

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -97,6 +97,27 @@ CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS=
 ALLO_BRIDGES_ENABLED=
 ALLO_MATRIX_SERVER_NAME=allo.you
 
+# Matrix Authentication Service (optional; see "Authentication" below). Setting
+# ALLO_MAS_ISSUER is what makes this backend accept a Matrix access token
+# alongside an Oxy one. Empty means Oxy tokens only, which is the deployed
+# default. The introspection URL must be same-origin with the issuer or the
+# process refuses to boot.
+ALLO_MAS_ISSUER=
+ALLO_MAS_INTROSPECTION_URL=
+ALLO_MAS_INTROSPECTION_CLIENT_ID=
+ALLO_MAS_INTROSPECTION_CLIENT_SECRET=
+ALLO_MAS_ALLOWED_CLIENT_IDS=
+ALLO_MAS_ACCEPTED_SCOPES=
+ALLO_MAS_EXPECTED_AUDIENCE=
+ALLO_MAS_INTROSPECTION_CACHE_SECONDS=
+ALLO_MAS_INTROSPECTION_TIMEOUT_MS=
+
+# Allo's own credential for calling the Oxy API as itself (optional; both or
+# neither). Every Oxy route the directory uses is public, so the lookups work
+# without it — see "People directory" below.
+ALLO_OXY_SERVICE_API_KEY=
+ALLO_OXY_SERVICE_API_SECRET=
+
 # Tests only: point the vitest suite at an existing MongoDB replica set instead
 # of downloading a mongodb-memory-server binary. Honoured when already set —
 # see "Running the tests without a downloaded binary" below.
@@ -162,16 +183,84 @@ therefore pointless: the next deploy overwrites it. Change the GitHub secret.
 
 ### Authentication
 
-All authenticated endpoints require a Bearer token from Oxy. The middleware
-comes from `@oxyhq/core/server` — `createOxyAuthMiddleware(oxy)`, mounted on
-`/api` in `server.ts` — alongside `createOxyCors` and `createOxyRateLimit` from
-the same package. There is no local middleware directory.
+Two ways to be signed in, told apart by the **HTTP authentication scheme**:
+
+```
+Authorization: Bearer <oxy access token>          ← the default, and what ships
+Authorization: MatrixBearer <MAS access token>    ← opt-in, see below
+```
+
+The Oxy half is unchanged: `createOxyAuthMiddleware(oxy)` from
+`@oxyhq/core/server`, mounted on `/api` in `server.ts`, alongside
+`createOxyCors` and `createOxyRateLimit` from the same package.
+
+The Matrix half is `src/middleware/matrixAuth.ts`, mounted immediately ahead of
+it, and it answers **only** requests using the `MatrixBearer` scheme. Everything
+else passes straight through untouched. The scheme carries the discrimination
+rather than a side header because a side header can be stripped by a proxy and
+separated from the credential it describes; `oxy.auth()` extracts a token only
+from a header beginning with the exact string `"Bearer "`, so a MatrixBearer
+credential is structurally invisible to it, and a refused MatrixBearer request
+is never offered to the Oxy validator for a second opinion.
+
+The token itself is opaque, so it is validated by RFC 7662 introspection against
+MAS on every request, subject to a **30-second** cache (`exp` is an additional
+ceiling, never an extension). That window is the bound on how long a revoked
+token keeps working. Beyond `active`, the checks are: the token is an access
+token and not a refresh token, it carries the MSC2967 Matrix client-API scope,
+its `iss` and `aud` match when the response carries them, its `client_id` is in
+the allowlist when one is configured, and its `username` is a well-formed Oxy
+account id — a bridge ghost such as `whatsapp_447700900000` is refused, not
+coerced. MAS unreachable is **503, never 401**: an outage must not sign anybody
+out. See `src/config/matrixAuth.ts` for the boot-time rules and
+`src/services/auth/` for the rest.
+
+Both paths produce the same `req.userId` / `req.user`, so no route knows or
+cares which sign-in produced the request.
 
 Routes are split into two routers: `publicApiRouter` (health only) and
 `authenticatedApiRouter`, which carries `/profile`, `/conversations`,
-`/messages`, `/devices` and `/reports`. The CrowdSource webhook is mounted
-separately at `/webhooks/crowdsource`, ahead of the JSON body parser, because it
-needs the raw body to verify its signature.
+`/messages`, `/devices`, `/reports`, `/bridges`, `/push` and `/directory`. The
+CrowdSource webhook is mounted separately at `/webhooks/crowdsource`, ahead of
+the JSON body parser, because it needs the raw body to verify its signature.
+
+**The Socket.IO handshake is not covered.** It still authenticates with
+`oxy.authSocket()`, so a MAS token cannot open a websocket. That is deliberate:
+the realtime namespace belongs to the legacy transport, which the Matrix path
+replaces with `/sync` rather than authenticating into.
+
+### People directory
+
+`/api/directory/*` answers the five Oxy lookups the app makes today, so that an
+app authenticating only through MAS — and therefore holding no Oxy session —
+can still draw a person.
+
+| Route | Replaces |
+| --- | --- |
+| `GET /api/directory/profiles/username/:username` | `oxyServices.getProfileByUsername` |
+| `GET /api/directory/users/:userId` | `oxyServices.getUserById` |
+| `POST /api/directory/users/by-ids` (`{ ids }`, max 100) | `oxyServices.getUsersByIds` |
+| `GET /api/directory/profiles/search?query=&limit=&offset=` | `oxyServices.searchProfiles` |
+| `GET /api/directory/assets/:fileId/url?variant=` | `oxyServices.getFileDownloadUrl` |
+
+Every one answers a `DirectoryUser` (or a list of them) from
+`@allo/shared-types`, which is a **projection**: id, handle, display name,
+first/last, avatar id, resolved avatar URL, bio. The Oxy `User` carries `email`,
+`phone`, `address` and `birthday`, and this backend asks Oxy as itself, so
+anything it forwarded it would forward to every signed-in user.
+
+Each `DirectoryUser` already carries `avatarUrl`, so the fifteen places in the
+app that turn an avatar id into a URL become a field read rather than a request.
+The asset endpoint exists for an id that arrives from somewhere else.
+
+Authenticated, even though every underlying Oxy route is public: an
+unauthenticated profile lookup here would be an enumeration endpoint pointed at
+Oxy's whole user base with Allo's IP reputation in front of it.
+
+No service credential is required, for the same reason. Setting
+`ALLO_OXY_SERVICE_API_KEY` / `ALLO_OXY_SERVICE_API_SECRET` only changes how the
+bulk lookup authenticates; see `src/config/oxyService.ts`, which also documents
+the console.oxy.so step that mints them.
 
 ### Health Check
 

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -23,6 +23,10 @@ import pushRoutes from "./src/routes/push";
 import { createCrowdSourceWebhookRoutes } from "./src/routes/crowdSourceWebhook";
 import { createBridgeInternalRoutes } from "./src/routes/bridgesInternal";
 import { createPushGatewayRoutes } from "./src/routes/pushGateway";
+import { createDirectoryRoutes } from "./src/routes/directory";
+import { createOxyDirectoryService } from "./src/services/oxy/OxyDirectoryService";
+import { configureOxyServiceAuth } from "./src/config/oxyService";
+import { createMatrixAuthMiddleware } from "./src/middleware/matrixAuth";
 import { PUSH_GATEWAY_MOUNT_PATH } from "./src/config/push";
 import { startModerationOutboxDispatcher } from "./src/services/moderation/ModerationOutboxDispatcher";
 import { startBridgeStatusSweep } from "./src/services/bridges/BridgeStatusService";
@@ -51,6 +55,16 @@ const app = express();
 
 // Initialize Oxy client for authentication
 export const oxy = oxyClient;
+
+/**
+ * The same client, additionally configured to call Oxy AS ALLO when a service
+ * credential is present.
+ *
+ * A no-op without one, and the directory still works — every Oxy route it uses
+ * is public. See `src/config/oxyService.ts` for what a credential changes and
+ * for the human step that mints it.
+ */
+configureOxyServiceAuth(oxy);
 
 // --- Middleware ---
 
@@ -315,10 +329,27 @@ authenticatedApiRouter.use("/devices", devicesRoutes);
 authenticatedApiRouter.use("/reports", reportsRoutes);
 authenticatedApiRouter.use("/bridges", bridgesRoutes);
 authenticatedApiRouter.use("/push", pushRoutes);
+authenticatedApiRouter.use("/directory", createDirectoryRoutes({ service: createOxyDirectoryService(oxy) }));
 
 // Mount public and authenticated API routers
 app.use("/api", publicApiRouter);
-app.use("/api", createOxyAuthMiddleware(oxy), authenticatedApiRouter);
+
+/**
+ * Two ways to be signed in, one shape of `req.user`.
+ *
+ * `createMatrixAuthMiddleware` runs FIRST and answers only requests whose
+ * `Authorization` header uses the `MatrixBearer` scheme; every other request —
+ * which today is every request, because the app still sends an Oxy `Bearer` —
+ * passes straight through to `createOxyAuthMiddleware`, unchanged.
+ *
+ * The order is what makes the composition safe rather than merely convenient.
+ * `oxy.auth()` reads a token only from a header beginning with the exact string
+ * `"Bearer "`, so a MatrixBearer credential is INVISIBLE to it; and the Matrix
+ * middleware never calls `next()` after refusing one, so a token can never be
+ * offered to both validators. See `src/middleware/matrixAuth.ts` for the rest
+ * of the reasoning, including why this cannot sit ahead of the rate limiter.
+ */
+app.use("/api", createMatrixAuthMiddleware(), createOxyAuthMiddleware(oxy), authenticatedApiRouter);
 
 // --- Root API Welcome Route ---
 app.get("/", async (req, res) => {

--- a/packages/backend/src/__tests__/config/matrixAuth.test.ts
+++ b/packages/backend/src/__tests__/config/matrixAuth.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import { loadMatrixAuthConfig } from "../../config/matrixAuth";
+
+/**
+ * `config/matrixAuth.ts` — the boot-time checks on the MAS half of the one
+ * session.
+ *
+ * These are not preference checks. Each one below is a way a deployment could
+ * come up ACCEPTING TOKENS IT SHOULD NOT, so each is written as "this
+ * environment does not produce a running process" rather than as "this value is
+ * normalised to something safe".
+ */
+
+const ISSUER = "https://auth.allo.you/";
+const INTROSPECTION_URL = "https://auth.allo.you/oauth2/introspect";
+const CLIENT_ID = "allo-backend";
+const CLIENT_SECRET = "0123456789abcdef0123456789abcdef";
+
+function completeEnvironment(
+  overrides: Record<string, string | undefined> = {},
+): NodeJS.ProcessEnv {
+  return {
+    ALLO_MAS_ISSUER: ISSUER,
+    ALLO_MAS_INTROSPECTION_URL: INTROSPECTION_URL,
+    ALLO_MAS_INTROSPECTION_CLIENT_ID: CLIENT_ID,
+    ALLO_MAS_INTROSPECTION_CLIENT_SECRET: CLIENT_SECRET,
+    ...overrides,
+  };
+}
+
+describe("matrix auth configuration", () => {
+  it("is disabled, and boots, when no issuer is configured", () => {
+    const config = loadMatrixAuthConfig({});
+
+    expect(config.enabled).toBe(false);
+  });
+
+  it("ignores every other MAS variable when the issuer is absent", () => {
+    /**
+     * A deployment that once accepted MAS tokens and no longer does turns the
+     * issuer off and leaves the rest behind. Refusing to boot over a variable
+     * that now decides nothing would make that a two-step change with an
+     * outage in the middle.
+     */
+    const config = loadMatrixAuthConfig({
+      ALLO_MAS_INTROSPECTION_URL: INTROSPECTION_URL,
+      ALLO_MAS_INTROSPECTION_CLIENT_ID: CLIENT_ID,
+      ALLO_MAS_INTROSPECTION_CLIENT_SECRET: CLIENT_SECRET,
+    });
+
+    expect(config.enabled).toBe(false);
+  });
+
+  it("enables the MAS path when every required variable is present", () => {
+    const config = loadMatrixAuthConfig(completeEnvironment());
+
+    expect(config.enabled).toBe(true);
+    expect(config.issuer).toBe(ISSUER);
+    expect(config.introspectionUrl).toBe(INTROSPECTION_URL);
+    expect(config.clientId).toBe(CLIENT_ID);
+  });
+
+  it("refuses an introspection endpoint on another origin", () => {
+    /**
+     * The single most important check in the file. MAS sends no `iss`, so
+     * "which server answered" IS the issuer verification; an endpoint on
+     * another host is a stranger being asked to authenticate our users.
+     */
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({ ALLO_MAS_INTROSPECTION_URL: "https://evil.example/oauth2/introspect" }),
+      ),
+    ).toThrow(/same-origin/);
+  });
+
+  it("refuses an introspection endpoint that differs only by port", () => {
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({
+          ALLO_MAS_INTROSPECTION_URL: "https://auth.allo.you:8443/oauth2/introspect",
+        }),
+      ),
+    ).toThrow(/same-origin/);
+  });
+
+  it("refuses a plaintext issuer", () => {
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({
+          ALLO_MAS_ISSUER: "http://auth.allo.you/",
+          ALLO_MAS_INTROSPECTION_URL: "http://auth.allo.you/oauth2/introspect",
+        }),
+      ),
+    ).toThrow(/https/);
+  });
+
+  it("refuses an issuer carrying credentials", () => {
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({ ALLO_MAS_ISSUER: "https://user:pass@auth.allo.you/" }),
+      ),
+    ).toThrow();
+  });
+
+  it("refuses an issuer without an introspection endpoint", () => {
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({ ALLO_MAS_INTROSPECTION_URL: undefined }),
+      ),
+    ).toThrow(/ALLO_MAS_INTROSPECTION_URL/);
+  });
+
+  it("refuses an issuer without introspection credentials", () => {
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({
+          ALLO_MAS_INTROSPECTION_CLIENT_ID: undefined,
+          ALLO_MAS_INTROSPECTION_CLIENT_SECRET: undefined,
+        }),
+      ),
+    ).toThrow(/ALLO_MAS_INTROSPECTION_CLIENT_ID/);
+  });
+
+  it("refuses a client secret shorter than 32 characters", () => {
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({ ALLO_MAS_INTROSPECTION_CLIENT_SECRET: "short-secret" }),
+      ),
+    ).toThrow();
+  });
+
+  it("treats a blank variable as absent rather than as an empty value", () => {
+    /**
+     * An unset variable and a variable set to the empty string reach a process
+     * the same way through most deployment tooling, and one of the two reading
+     * as "a client id of length zero" would be a 400 from MAS on every request.
+     */
+    const config = loadMatrixAuthConfig({ ALLO_MAS_ISSUER: "   " });
+
+    expect(config.enabled).toBe(false);
+  });
+
+  it("defaults to both spellings of the MSC2967 client-API scope", () => {
+    const config = loadMatrixAuthConfig(completeEnvironment());
+
+    expect(config.acceptedScopes).toEqual([
+      "urn:matrix:org.matrix.msc2967.client:api:*",
+      "urn:matrix:client:api:*",
+    ]);
+  });
+
+  it("parses comma-separated lists and drops blank entries", () => {
+    const config = loadMatrixAuthConfig(
+      completeEnvironment({
+        ALLO_MAS_ALLOWED_CLIENT_IDS: " one , , two ",
+        ALLO_MAS_ACCEPTED_SCOPES: "urn:matrix:client:api:*",
+      }),
+    );
+
+    expect(config.allowedClientIds).toEqual(["one", "two"]);
+    expect(config.acceptedScopes).toEqual(["urn:matrix:client:api:*"]);
+  });
+
+  it("defaults the cache window to 30 seconds", () => {
+    expect(loadMatrixAuthConfig(completeEnvironment()).cacheSeconds).toBe(30);
+  });
+
+  it("refuses a cache window longer than five minutes", () => {
+    /**
+     * The cache window is the bound on how long a revoked token keeps working.
+     * A deployment must not be able to widen it into "until the token would
+     * have expired anyway", which is what caching for `exp` would mean.
+     */
+    expect(() =>
+      loadMatrixAuthConfig(
+        completeEnvironment({ ALLO_MAS_INTROSPECTION_CACHE_SECONDS: "3600" }),
+      ),
+    ).toThrow();
+  });
+
+  it("refuses a cache window of zero", () => {
+    expect(() =>
+      loadMatrixAuthConfig(completeEnvironment({ ALLO_MAS_INTROSPECTION_CACHE_SECONDS: "0" })),
+    ).toThrow();
+  });
+
+  it("freezes the result so no caller can widen it at runtime", () => {
+    const config = loadMatrixAuthConfig(completeEnvironment());
+
+    expect(Object.isFrozen(config)).toBe(true);
+  });
+});

--- a/packages/backend/src/__tests__/config/oxyService.test.ts
+++ b/packages/backend/src/__tests__/config/oxyService.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { configureOxyServiceAuth, loadOxyServiceCredential } from "../../config/oxyService";
+
+/**
+ * Allo's own credential for calling Oxy as itself.
+ *
+ * Optional — every Oxy route the directory uses is public — so the tests are
+ * about the two ways a deployment can be wrong about it: half-configured, which
+ * must not boot, and configured with something that is not a credential.
+ */
+
+const API_KEY = "oxy_dk_0123456789abcdef0123456789abcdef0123456789abcdef";
+const API_SECRET = "9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c5b4a3928";
+
+describe("the Oxy service credential", () => {
+  it("is absent when neither variable is set", () => {
+    expect(loadOxyServiceCredential({})).toBeUndefined();
+  });
+
+  it("is read when both are set", () => {
+    expect(
+      loadOxyServiceCredential({
+        ALLO_OXY_SERVICE_API_KEY: API_KEY,
+        ALLO_OXY_SERVICE_API_SECRET: API_SECRET,
+      }),
+    ).toEqual({ apiKey: API_KEY, apiSecret: API_SECRET });
+  });
+
+  it("refuses a key without its secret", () => {
+    /**
+     * Half a credential is a service token that can never be minted, and the
+     * way that shows up in production is every bulk profile lookup quietly
+     * returning nothing — `getUsersByIds` logs a failed chunk and carries on.
+     */
+    expect(() => loadOxyServiceCredential({ ALLO_OXY_SERVICE_API_KEY: API_KEY })).toThrow(
+      /ALLO_OXY_SERVICE_API_SECRET/,
+    );
+  });
+
+  it("refuses a secret without its key", () => {
+    expect(() => loadOxyServiceCredential({ ALLO_OXY_SERVICE_API_SECRET: API_SECRET })).toThrow(
+      /ALLO_OXY_SERVICE_API_KEY/,
+    );
+  });
+
+  it("refuses something that is not an Oxy credential public key", () => {
+    expect(() =>
+      loadOxyServiceCredential({
+        ALLO_OXY_SERVICE_API_KEY: "not-an-oxy-key",
+        ALLO_OXY_SERVICE_API_SECRET: API_SECRET,
+      }),
+    ).toThrow(/oxy_dk_/);
+  });
+
+  it("refuses a secret too short to be one", () => {
+    expect(() =>
+      loadOxyServiceCredential({
+        ALLO_OXY_SERVICE_API_KEY: API_KEY,
+        ALLO_OXY_SERVICE_API_SECRET: "short",
+      }),
+    ).toThrow();
+  });
+
+  it("treats blank variables as absent", () => {
+    expect(
+      loadOxyServiceCredential({
+        ALLO_OXY_SERVICE_API_KEY: "  ",
+        ALLO_OXY_SERVICE_API_SECRET: "",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("handing the credential to the SDK", () => {
+  it("configures the client and says so", () => {
+    const client = { configureServiceAuth: vi.fn() };
+
+    const configured = configureOxyServiceAuth(client, {
+      ALLO_OXY_SERVICE_API_KEY: API_KEY,
+      ALLO_OXY_SERVICE_API_SECRET: API_SECRET,
+    });
+
+    expect(configured).toBe(true);
+    expect(client.configureServiceAuth).toHaveBeenCalledWith(API_KEY, API_SECRET);
+  });
+
+  it("leaves the client alone when there is no credential", () => {
+    const client = { configureServiceAuth: vi.fn() };
+
+    expect(configureOxyServiceAuth(client, {})).toBe(false);
+    expect(client.configureServiceAuth).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/middleware/matrixAuth.test.ts
+++ b/packages/backend/src/__tests__/middleware/matrixAuth.test.ts
@@ -1,0 +1,491 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { oxyClient } from "@oxyhq/core";
+import { createOxyAuthMiddleware, getOxyUserId } from "@oxyhq/core/server";
+
+import { loadMatrixAuthConfig, type MatrixAuthConfig } from "../../config/matrixAuth";
+import {
+  createMatrixAuthMiddleware,
+  MATRIX_AUTH_SCHEME,
+  readPresentedCredential,
+} from "../../middleware/matrixAuth";
+import {
+  MasCredentialError,
+  MasProtocolError,
+  MasUnreachableError,
+} from "../../services/auth/masIntrospection";
+import type {
+  MatrixTokenAuthenticator,
+  MatrixTokenResult,
+} from "../../services/auth/matrixTokenAuthenticator";
+
+/**
+ * The authentication boundary, assembled the way `server.ts` assembles it.
+ *
+ * The REAL `createOxyAuthMiddleware` is mounted behind the Matrix one here,
+ * rather than a stand-in, because the most important property under test is a
+ * property of the two together: an Oxy token and a MAS token cannot be confused
+ * for one another. A fake Oxy middleware could be written to agree with any
+ * claim about that, which is exactly why it is not used.
+ *
+ * No test below reaches the network. `oxy.auth()` extracts a token only from a
+ * header beginning with the exact string `"Bearer "`, and then decodes it as a
+ * JWT before it would validate a session — every Oxy-path case here stops at
+ * one of those two steps.
+ */
+
+const ISSUER = "https://auth.allo.you/";
+const OXY_USER_ID = "507f1f77bcf86cd799439011";
+const MATRIX_TOKEN = "mct_aVeryOpaqueMatrixAccessToken";
+
+/**
+ * An Oxy access token, in the shape `oxy.auth()` looks for: a JWT.
+ *
+ * The signature is invented, and `oxy.auth()` DOES NOT CARE — see the last
+ * test in this file. That is a defect in `@oxyhq/core`, not a property this
+ * change relies on; it is used here only because it is the cheapest way to
+ * produce a header the Oxy validator engages with, and every assertion that
+ * uses it is about ROUTING rather than about the Oxy verdict.
+ */
+const OXY_TOKEN = [
+  Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url"),
+  Buffer.from(JSON.stringify({ userId: OXY_USER_ID, exp: 4_000_000_000 })).toString("base64url"),
+  "not-a-real-signature",
+].join(".");
+
+function enabledConfig(overrides: Record<string, string> = {}): MatrixAuthConfig {
+  return loadMatrixAuthConfig({
+    ALLO_MAS_ISSUER: ISSUER,
+    ALLO_MAS_INTROSPECTION_URL: "https://auth.allo.you/oauth2/introspect",
+    ALLO_MAS_INTROSPECTION_CLIENT_ID: "allo-backend",
+    ALLO_MAS_INTROSPECTION_CLIENT_SECRET: "0123456789abcdef0123456789abcdef",
+    ...overrides,
+  });
+}
+
+const DISABLED_CONFIG = loadMatrixAuthConfig({});
+
+let seenTokens: string[];
+let routeHits: number;
+
+function authenticatorReturning(result: MatrixTokenResult): MatrixTokenAuthenticator {
+  return {
+    authenticate: vi.fn(async (token: string) => {
+      seenTokens.push(token);
+      return result;
+    }),
+  };
+}
+
+function authenticatorThrowing(error: unknown): MatrixTokenAuthenticator {
+  return {
+    authenticate: vi.fn(async (token: string) => {
+      seenTokens.push(token);
+      throw error;
+    }),
+  };
+}
+
+/**
+ * `/api` exactly as `server.ts` mounts it: Matrix authentication, then Oxy
+ * authentication, then the routes.
+ */
+function api(options: {
+  config?: MatrixAuthConfig;
+  authenticator?: MatrixTokenAuthenticator;
+}): express.Express {
+  const app = express();
+  const router = express.Router();
+  router.get("/whoami", (req, res) => {
+    routeHits += 1;
+    res.json({ userId: getOxyUserId(req) });
+  });
+
+  app.use(
+    "/api",
+    createMatrixAuthMiddleware({
+      config: options.config ?? enabledConfig(),
+      ...(options.authenticator === undefined ? {} : { authenticator: options.authenticator }),
+    }),
+    createOxyAuthMiddleware(oxyClient),
+    router,
+  );
+  return app;
+}
+
+const ACCEPTED: MatrixTokenResult = {
+  outcome: "accepted",
+  oxyUserId: OXY_USER_ID,
+  deviceId: "ABCDEFGH",
+};
+
+beforeEach(() => {
+  seenTokens = [];
+  routeHits = 0;
+});
+
+describe("how a request declares which token it carries", () => {
+  it("reads a MatrixBearer credential", () => {
+    expect(readPresentedCredential(`${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`)).toEqual({
+      kind: "matrix",
+      token: MATRIX_TOKEN,
+    });
+  });
+
+  it("accepts the scheme in any case, because RFC 7235 says schemes are", () => {
+    expect(readPresentedCredential(`matrixbearer ${MATRIX_TOKEN}`)).toEqual({
+      kind: "matrix",
+      token: MATRIX_TOKEN,
+    });
+    expect(readPresentedCredential(`MATRIXBEARER ${MATRIX_TOKEN}`)).toEqual({
+      kind: "matrix",
+      token: MATRIX_TOKEN,
+    });
+  });
+
+  it("leaves a Bearer credential alone", () => {
+    expect(readPresentedCredential(`Bearer ${OXY_TOKEN}`)).toEqual({ kind: "other-scheme" });
+  });
+
+  it("leaves an absent header alone", () => {
+    expect(readPresentedCredential(undefined)).toEqual({ kind: "other-scheme" });
+  });
+
+  it("does not mistake a scheme that merely starts the same way", () => {
+    /**
+     * `MatrixBearerish` is not `MatrixBearer`. A `startsWith` check on the
+     * scheme without the separator would claim it, and would then hand whatever
+     * followed to MAS as a token.
+     */
+    expect(readPresentedCredential(`MatrixBearerish ${MATRIX_TOKEN}`)).toEqual({
+      kind: "other-scheme",
+    });
+  });
+
+  it("notices a scheme with no credentials after it", () => {
+    /**
+     * Including the bare header with nothing after it at all. A client that
+     * meant to present a Matrix token and sent none must not be answered by the
+     * Oxy validator with "Authentication required", which names the wrong
+     * problem and has sent people looking for a header that was present.
+     */
+    expect(readPresentedCredential(MATRIX_AUTH_SCHEME)).toEqual({ kind: "matrix-empty" });
+    expect(readPresentedCredential(`${MATRIX_AUTH_SCHEME} `)).toEqual({ kind: "matrix-empty" });
+    expect(readPresentedCredential(`${MATRIX_AUTH_SCHEME}   `)).toEqual({ kind: "matrix-empty" });
+  });
+
+  it("considers only the first of a repeated header", () => {
+    /**
+     * A request that presents two credentials must not have the friendlier one
+     * chosen for it. Node surfaces a repeated header as an array; only index
+     * zero is read.
+     */
+    expect(
+      readPresentedCredential([`Bearer ${OXY_TOKEN}`, `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`]),
+    ).toEqual({ kind: "other-scheme" });
+  });
+});
+
+describe("a MatrixBearer credential", () => {
+  it("authenticates the Oxy account the token names", async () => {
+    const response = await request(api({ authenticator: authenticatorReturning(ACCEPTED) }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ userId: OXY_USER_ID });
+  });
+
+  it("produces the same request shape a route already expects", async () => {
+    /**
+     * `getOxyUserId` is what every route reaches for, through
+     * `getRequiredOxyUserId`. That it answers means no route has to know which
+     * of the two sign-ins produced the request.
+     */
+    const response = await request(api({ authenticator: authenticatorReturning(ACCEPTED) }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.body.userId).toBe(OXY_USER_ID);
+    expect(routeHits).toBe(1);
+  });
+
+  it("passes the token through unchanged", async () => {
+    await request(api({ authenticator: authenticatorReturning(ACCEPTED) }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME}   ${MATRIX_TOKEN}  `);
+
+    expect(seenTokens).toEqual([MATRIX_TOKEN]);
+  });
+
+  it("is refused, and reaches no route, when the authenticator says no", async () => {
+    const refused = authenticatorReturning({ outcome: "refused", reason: "inactive" });
+
+    const response = await request(api({ authenticator: refused }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(401);
+    expect(routeHits).toBe(0);
+  });
+
+  it("never tells the client which check refused it", async () => {
+    /**
+     * Ten reasons, one body. Which of an attacker's guesses came closest is
+     * exactly the feedback that makes the next guess better.
+     */
+    const reasons = [
+      "inactive",
+      "expired",
+      "wrong-issuer",
+      "wrong-audience",
+      "missing-scope",
+      "not-an-oxy-account",
+    ] as const;
+
+    const bodies = new Set<string>();
+    for (const reason of reasons) {
+      const response = await request(
+        api({ authenticator: authenticatorReturning({ outcome: "refused", reason }) }),
+      )
+        .get("/api/whoami")
+        .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+      bodies.add(JSON.stringify(response.body));
+    }
+
+    expect(bodies.size).toBe(1);
+  });
+
+  it("is refused when the scheme carries no credentials", async () => {
+    const response = await request(api({ authenticator: authenticatorReturning(ACCEPTED) }))
+      .get("/api/whoami")
+      .set("Authorization", MATRIX_AUTH_SCHEME);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("INVALID_MATRIX_TOKEN");
+    expect(seenTokens).toEqual([]);
+  });
+});
+
+describe("the two token types cannot be confused", () => {
+  it("refuses an Oxy token presented under the Matrix scheme", async () => {
+    /**
+     * MAS has never heard of an Oxy JWT, so it answers `active: false` and the
+     * request is refused. The fake authenticator stands in for that answer; the
+     * point of the test is the ROUTING — that the Oxy validator is not reached
+     * and does not get a second opinion.
+     */
+    const refused = authenticatorReturning({ outcome: "refused", reason: "inactive" });
+
+    const response = await request(api({ authenticator: refused }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${OXY_TOKEN}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe("INVALID_MATRIX_TOKEN");
+    expect(routeHits).toBe(0);
+  });
+
+  it("refuses a MAS token presented under the Bearer scheme", async () => {
+    /**
+     * The real `oxy.auth()` refuses it: a MAS access token is opaque, so
+     * `jwtDecode` fails and the middleware answers INVALID_TOKEN_FORMAT. No
+     * network call happens, and this middleware never sees the request.
+     */
+    const response = await request(api({ authenticator: authenticatorReturning(ACCEPTED) }))
+      .get("/api/whoami")
+      .set("Authorization", `Bearer ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(401);
+    expect(seenTokens).toEqual([]);
+    expect(routeHits).toBe(0);
+  });
+
+  it("does not fall through to the Oxy validator after refusing", async () => {
+    /**
+     * The property that keeps the boundary from being the WEAKER of the two
+     * validators. A refused MatrixBearer request is answered here; it is not
+     * offered to `oxy.auth()` for a second opinion, which the distinct error
+     * code proves — `oxy.auth()` would have answered MISSING_TOKEN.
+     */
+    const refused = authenticatorReturning({ outcome: "refused", reason: "not-an-oxy-account" });
+
+    const response = await request(api({ authenticator: refused }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.body.error).toBe("INVALID_MATRIX_TOKEN");
+    expect(response.body.error).not.toBe("Unauthorized");
+  });
+
+  it("leaves a request with no Authorization header to the Oxy validator", async () => {
+    const response = await request(api({ authenticator: authenticatorReturning(ACCEPTED) })).get(
+      "/api/whoami",
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("Unauthorized");
+    expect(seenTokens).toEqual([]);
+  });
+});
+
+describe("when MAS cannot answer", () => {
+  it("answers 503 rather than 401 when MAS is unreachable", async () => {
+    /**
+     * 401 would tell every client its session had ended, and a chat app answers
+     * that by signing the user out. An outage must not log anybody out.
+     */
+    const failing = authenticatorThrowing(new MasUnreachableError("ECONNREFUSED"));
+
+    const response = await request(api({ authenticator: failing }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(503);
+    expect(response.headers["retry-after"]).toBe("5");
+    expect(routeHits).toBe(0);
+  });
+
+  it("answers 503 when MAS rejects this backend's own credentials", async () => {
+    const failing = authenticatorThrowing(new MasCredentialError(401));
+
+    const response = await request(api({ authenticator: failing }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(503);
+    expect(routeHits).toBe(0);
+  });
+
+  it("tells the client nothing about which upstream failure it was", async () => {
+    const unreachable = await request(
+      api({ authenticator: authenticatorThrowing(new MasUnreachableError("ECONNREFUSED")) }),
+    )
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+    const credentials = await request(
+      api({ authenticator: authenticatorThrowing(new MasCredentialError(401)) }),
+    )
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(unreachable.body).toEqual(credentials.body);
+  });
+
+  it("answers 502 when MAS returns something unparseable", async () => {
+    const failing = authenticatorThrowing(new MasProtocolError("the body was not JSON"));
+
+    const response = await request(api({ authenticator: failing }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(502);
+    expect(routeHits).toBe(0);
+  });
+
+  it("answers 500 and authenticates nobody when this middleware itself breaks", async () => {
+    const failing = authenticatorThrowing(new Error("something nobody predicted"));
+
+    const response = await request(api({ authenticator: failing }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(500);
+    expect(routeHits).toBe(0);
+  });
+});
+
+describe("a deployment that accepts no Matrix token", () => {
+  it("refuses the scheme with a reason that names the real problem", async () => {
+    const response = await request(api({ config: DISABLED_CONFIG }))
+      .get("/api/whoami")
+      .set("Authorization", `${MATRIX_AUTH_SCHEME} ${MATRIX_TOKEN}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe("MATRIX_AUTH_NOT_CONFIGURED");
+    expect(routeHits).toBe(0);
+  });
+
+  it("leaves the Oxy path exactly as it was", async () => {
+    /**
+     * The whole promise of this change: a build where the app still sends Oxy
+     * tokens keeps working, which is what is deployed.
+     */
+    const response = await request(api({ config: DISABLED_CONFIG }))
+      .get("/api/whoami")
+      .set("Authorization", `Bearer ${OXY_TOKEN}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ userId: OXY_USER_ID });
+  });
+
+  it("leaves an unauthenticated request exactly as it was", async () => {
+    const response = await request(api({ config: DISABLED_CONFIG })).get("/api/whoami");
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("Unauthorized");
+  });
+
+  it("leaves an unparseable Bearer credential to the Oxy validator", async () => {
+    /**
+     * `createOxyAuthMiddleware` resolves the session optionally and then guards
+     * with `requireOxyAuth`, so every Oxy refusal — missing, malformed or
+     * expired — arrives as the same `Unauthorized` body. That is the shape a
+     * MatrixBearer refusal is contrasted against above.
+     */
+    const response = await request(api({ config: DISABLED_CONFIG }))
+      .get("/api/whoami")
+      .set("Authorization", "Bearer not-a-jwt-at-all");
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("Unauthorized");
+  });
+});
+
+describe("the Oxy path's own hole, recorded rather than relied on", () => {
+  it("accepts a FORGED, UNSIGNED Oxy JWT — a defect in @oxyhq/core, not in this change", async () => {
+    /**
+     * ## Read this before touching the assertion below
+     *
+     * `oxy.auth()` in `@oxyhq/core@19.1.2` decodes the bearer JWT with
+     * `jwtDecode`, which verifies NOTHING, and then — for a payload carrying no
+     * `sessionId` — takes its "non-session token: use local validation only"
+     * branch and trusts the `userId` claim outright. Service tokens are
+     * signature-checked and session tokens are validated against the Oxy API;
+     * a user token with no `sessionId` is checked against nothing at all.
+     *
+     * So the token below, whose signature is the literal string
+     * `not-a-real-signature`, authenticates as whoever it names. That is an
+     * account takeover on `api.allo.you` as deployed, and it exists on the OXY
+     * path — the path this change does not touch. It is reported to
+     * `@oxyhq/core` for a fix at the source and is deliberately NOT patched
+     * around here; a local workaround would leave every other Oxy backend
+     * exposed while making this one look fine.
+     *
+     * The assertion is written the way it is on purpose. When core is fixed and
+     * the dependency bumped, this test goes RED, and whoever bumps it reads
+     * this comment and deletes the test. A test that tolerated both answers
+     * would let the fix land unnoticed and this note rot in place.
+     *
+     * Note what it also demonstrates about the Matrix path: a MAS token is
+     * opaque and is checked against MAS on every request inside a bounded
+     * window, so there is no local-claims branch here for the same mistake to
+     * be made in.
+     */
+    const forged = [
+      Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url"),
+      Buffer.from(JSON.stringify({ userId: "aaaaaaaaaaaaaaaaaaaaaaaa", exp: 4_000_000_000 })).toString(
+        "base64url",
+      ),
+      "AAAAcompletely-invented-signature",
+    ].join(".");
+
+    const response = await request(api({ authenticator: authenticatorReturning(ACCEPTED) }))
+      .get("/api/whoami")
+      .set("Authorization", `Bearer ${forged}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ userId: "aaaaaaaaaaaaaaaaaaaaaaaa" });
+  });
+});

--- a/packages/backend/src/__tests__/routes/directory.test.ts
+++ b/packages/backend/src/__tests__/routes/directory.test.ts
@@ -1,0 +1,430 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchProfilesResponse, User } from "@oxyhq/core";
+
+import { createDirectoryRoutes } from "../../routes/directory";
+import {
+  createOxyDirectoryService,
+  toDirectoryUser,
+  type OxyDirectoryClient,
+} from "../../services/oxy/OxyDirectoryService";
+
+/**
+ * `GET /api/directory/*` — the five Oxy lookups, moved behind this backend.
+ *
+ * The Oxy SDK is replaced by a fake that satisfies {@link OxyDirectoryClient}
+ * structurally, so these tests cover what this router is responsible for: what
+ * it lets in, what it lets OUT, and what it does with an upstream that says no.
+ * They deliberately do not cover whether Oxy answers correctly, which is not
+ * this codebase's claim to make.
+ */
+
+const OXY_USER_ID = "507f1f77bcf86cd799439011";
+const OTHER_USER_ID = "507f191e810c19729de860ea";
+const AVATAR_ID = "65f0c1a2b3c4d5e6f7a8b9c0";
+const CLOUD_ORIGIN = "https://cloud.oxy.so";
+
+/**
+ * An Oxy user as the API really returns one — contact details included.
+ *
+ * They are here so that the projection test has something real to fail on. An
+ * Oxy `User` carries `email`, `phone`, `address` and `birthday`, and this
+ * backend asks Oxy AS ITSELF, so anything it forwards it forwards to every
+ * signed-in user.
+ */
+function oxyUser(overrides: Partial<User> = {}): User {
+  return {
+    id: OXY_USER_ID,
+    publicKey: "a-public-key",
+    username: "nate",
+    email: "nate@example.com",
+    phone: "+34600000000",
+    address: "1 Somewhere Street",
+    birthday: "1990-01-01",
+    avatar: AVATAR_ID,
+    bio: "encrypted messaging",
+    name: { displayName: "Nate Isern", first: "Nate", last: "Isern" },
+    ...overrides,
+  } as User;
+}
+
+interface FakeClient extends OxyDirectoryClient {
+  readonly calls: string[];
+}
+
+let failure: unknown;
+let searchResult: SearchProfilesResponse;
+let byIdsResult: User[];
+
+function fakeClient(): FakeClient {
+  const calls: string[] = [];
+  const refuseIfAsked = (): void => {
+    if (failure !== undefined) throw failure;
+  };
+
+  return {
+    calls,
+    getProfileByUsername: vi.fn(async (username: string) => {
+      calls.push(`getProfileByUsername:${username}`);
+      refuseIfAsked();
+      return oxyUser({ username });
+    }),
+    getUserById: vi.fn(async (userId: string) => {
+      calls.push(`getUserById:${userId}`);
+      refuseIfAsked();
+      return oxyUser({ id: userId });
+    }),
+    getUsersByIds: vi.fn(async (ids: string[]) => {
+      calls.push(`getUsersByIds:${ids.join(",")}`);
+      refuseIfAsked();
+      return byIdsResult;
+    }),
+    searchProfiles: vi.fn(async (query: string, pagination?: { limit?: number; offset?: number }) => {
+      calls.push(`searchProfiles:${query}:${pagination?.limit}:${pagination?.offset}`);
+      refuseIfAsked();
+      return searchResult;
+    }),
+    getFileDownloadUrl: (fileId: string, variant?: string) =>
+      `${CLOUD_ORIGIN}/${fileId}${variant === undefined ? "" : `?variant=${variant}`}`,
+  };
+}
+
+let client: FakeClient;
+
+function directoryApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/directory", createDirectoryRoutes({ service: createOxyDirectoryService(client) }));
+  return app;
+}
+
+beforeEach(() => {
+  failure = undefined;
+  client = fakeClient();
+  byIdsResult = [oxyUser(), oxyUser({ id: OTHER_USER_ID, username: "lady" })];
+  searchResult = {
+    data: [oxyUser()],
+    pagination: { total: 1, limit: 20, offset: 0, hasMore: false },
+  };
+});
+
+describe("what leaves the directory", () => {
+  it("never forwards an email, a phone, an address or a birthday", async () => {
+    /**
+     * The single most important assertion in this file. Every underlying Oxy
+     * route is public, so this backend cannot claim the API filtered anything
+     * for it — the projection is the whole of the protection.
+     */
+    const response = await request(directoryApp()).get(
+      `/api/directory/profiles/username/nate`,
+    );
+
+    expect(response.status).toBe(200);
+    const serialized = JSON.stringify(response.body);
+    expect(serialized).not.toContain("nate@example.com");
+    expect(serialized).not.toContain("+34600000000");
+    expect(serialized).not.toContain("Somewhere Street");
+    expect(serialized).not.toContain("1990-01-01");
+  });
+
+  it("emits exactly the fields the directory contract names", async () => {
+    const response = await request(directoryApp()).get("/api/directory/profiles/username/nate");
+
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      "avatar",
+      "avatarUrl",
+      "bio",
+      "displayName",
+      "firstName",
+      "id",
+      "lastName",
+      "username",
+    ]);
+  });
+
+  it("resolves the avatar id into a CDN url so the app does not have to", async () => {
+    const response = await request(directoryApp()).get("/api/directory/profiles/username/nate");
+
+    expect(response.body.data.avatar).toBe(AVATAR_ID);
+    expect(response.body.data.avatarUrl).toBe(`${CLOUD_ORIGIN}/${AVATAR_ID}?variant=thumb`);
+  });
+
+  it("omits both avatar fields for an account with no avatar", async () => {
+    const projected = toDirectoryUser(oxyUser({ avatar: null }), client);
+
+    expect(projected).not.toHaveProperty("avatar");
+    expect(projected).not.toHaveProperty("avatarUrl");
+  });
+
+  it("falls back to the handle when Oxy resolves no display name", async () => {
+    const projected = toDirectoryUser(
+      oxyUser({ name: { displayName: "", first: "", last: "" } }),
+      client,
+    );
+
+    expect(projected.displayName).toBe("nate");
+  });
+
+  it("does not recompose a display name from the parts", async () => {
+    /**
+     * `utils/oxyUserDisplay.ts` settled this for the conversation participants:
+     * the canonical string is Oxy's, and a second answer here would name the
+     * same person differently on the two screens they appear on.
+     */
+    const projected = toDirectoryUser(
+      oxyUser({ username: "", name: { displayName: "", first: "Nate", last: "Isern" } }),
+      client,
+    );
+
+    expect(projected.displayName).toBe("Unknown");
+  });
+});
+
+describe("a profile by handle", () => {
+  it("answers with the account", async () => {
+    const response = await request(directoryApp()).get("/api/directory/profiles/username/nate");
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.username).toBe("nate");
+  });
+
+  it("refuses a handle carrying the sigil", async () => {
+    const response = await request(directoryApp()).get("/api/directory/profiles/username/@nate");
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("refuses a handle longer than any Oxy handle", async () => {
+    const response = await request(directoryApp()).get(
+      `/api/directory/profiles/username/${"a".repeat(65)}`,
+    );
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("answers 404 when Oxy says there is no such account", async () => {
+    failure = { status: 404, message: "not found" };
+
+    const response = await request(directoryApp()).get("/api/directory/profiles/username/nobody");
+
+    expect(response.status).toBe(404);
+  });
+
+  it("answers 502 rather than 500 when Oxy fails", async () => {
+    /**
+     * The request was fine and this codebase is not at fault; a 500 would send
+     * whoever is on call looking here.
+     */
+    failure = new Error("upstream exploded");
+
+    const response = await request(directoryApp()).get("/api/directory/profiles/username/nate");
+
+    expect(response.status).toBe(502);
+  });
+});
+
+describe("an account by id", () => {
+  it("answers with the account", async () => {
+    const response = await request(directoryApp()).get(`/api/directory/users/${OXY_USER_ID}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.id).toBe(OXY_USER_ID);
+  });
+
+  it("refuses anything that is not an Oxy account id", async () => {
+    /**
+     * Oxy's own route also accepts a public key, which Allo has never had. The
+     * shape is checked with `isOxyUserId` — the SAME function the Matrix
+     * authentication boundary uses — so the two cannot come to different
+     * conclusions about the same string.
+     */
+    for (const candidate of ["nate", "oxy_dk_abcdef", OXY_USER_ID.toUpperCase(), "507f1f77"]) {
+      const response = await request(directoryApp()).get(`/api/directory/users/${candidate}`);
+      expect(response.status).toBe(400);
+    }
+    expect(client.calls).toEqual([]);
+  });
+});
+
+describe("several accounts at once", () => {
+  it("answers with each account it could resolve", async () => {
+    const response = await request(directoryApp())
+      .post("/api/directory/users/by-ids")
+      .send({ ids: [OXY_USER_ID, OTHER_USER_ID] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.users.map((user: { id: string }) => user.id)).toEqual([
+      OXY_USER_ID,
+      OTHER_USER_ID,
+    ]);
+  });
+
+  it("answers with fewer than asked for rather than padding the gaps", async () => {
+    byIdsResult = [oxyUser()];
+
+    const response = await request(directoryApp())
+      .post("/api/directory/users/by-ids")
+      .send({ ids: [OXY_USER_ID, OTHER_USER_ID] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.users).toHaveLength(1);
+  });
+
+  it("is not shadowed by the by-id route", async () => {
+    /**
+     * `/users/by-ids` and `/users/:userId` share a prefix, and declaring them
+     * the other way round would capture `by-ids` as an id. It would be refused
+     * as a malformed id rather than mis-served, but the 400 would name the
+     * wrong problem.
+     */
+    const response = await request(directoryApp())
+      .post("/api/directory/users/by-ids")
+      .send({ ids: [OXY_USER_ID] });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("refuses an empty list", async () => {
+    const response = await request(directoryApp())
+      .post("/api/directory/users/by-ids")
+      .send({ ids: [] });
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("refuses more ids than one upstream call can carry", async () => {
+    const ids = Array.from({ length: 101 }, () => OXY_USER_ID);
+
+    const response = await request(directoryApp())
+      .post("/api/directory/users/by-ids")
+      .send({ ids });
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("refuses the whole request when one id is malformed", async () => {
+    const response = await request(directoryApp())
+      .post("/api/directory/users/by-ids")
+      .send({ ids: [OXY_USER_ID, "nate"] });
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("refuses a body that is not a list of ids", async () => {
+    for (const body of [{}, { ids: "not-a-list" }, { ids: [{ $ne: null }] }]) {
+      const response = await request(directoryApp())
+        .post("/api/directory/users/by-ids")
+        .send(body);
+      expect(response.status).toBe(400);
+    }
+    expect(client.calls).toEqual([]);
+  });
+});
+
+describe("searching for people", () => {
+  it("answers with the page and how much more there is", async () => {
+    searchResult = {
+      data: [oxyUser()],
+      pagination: { total: 42, limit: 20, offset: 0, hasMore: true },
+    };
+
+    const response = await request(directoryApp()).get(
+      "/api/directory/profiles/search?query=nate",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.total).toBe(42);
+    expect(response.body.data.hasMore).toBe(true);
+    expect(response.body.data.users).toHaveLength(1);
+  });
+
+  it("defaults the page size rather than letting the caller omit it upstream", async () => {
+    await request(directoryApp()).get("/api/directory/profiles/search?query=nate");
+
+    expect(client.calls).toEqual(["searchProfiles:nate:20:0"]);
+  });
+
+  it("refuses an empty query", async () => {
+    const response = await request(directoryApp()).get("/api/directory/profiles/search?query=");
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("refuses a missing query", async () => {
+    const response = await request(directoryApp()).get("/api/directory/profiles/search");
+
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses a page larger than the ceiling", async () => {
+    const response = await request(directoryApp()).get(
+      "/api/directory/profiles/search?query=nate&limit=5000",
+    );
+
+    expect(response.status).toBe(400);
+    expect(client.calls).toEqual([]);
+  });
+
+  it("refuses a negative offset", async () => {
+    const response = await request(directoryApp()).get(
+      "/api/directory/profiles/search?query=nate&offset=-1",
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("an avatar's address", () => {
+  it("answers with the CDN url for an asset id", async () => {
+    const response = await request(directoryApp()).get(
+      `/api/directory/assets/${AVATAR_ID}/url`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.url).toBe(`${CLOUD_ORIGIN}/${AVATAR_ID}?variant=thumb`);
+  });
+
+  it("honours a requested variant", async () => {
+    const response = await request(directoryApp()).get(
+      `/api/directory/assets/${AVATAR_ID}/url?variant=full`,
+    );
+
+    expect(response.body.data.url).toBe(`${CLOUD_ORIGIN}/${AVATAR_ID}?variant=full`);
+  });
+
+  it("refuses an asset id containing path characters", async () => {
+    /**
+     * Not because a traversal would work — the SDK percent-encodes the id — but
+     * because an endpoint that mints a URL for any string a caller invents is
+     * a URL generator wearing Allo's name.
+     */
+    const response = await request(directoryApp()).get(
+      "/api/directory/assets/..%2F..%2Fetc%2Fpasswd/url",
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses an absolute URL where an asset id belongs", async () => {
+    const response = await request(directoryApp()).get(
+      `/api/directory/assets/${encodeURIComponent("https://evil.example/x")}/url`,
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses a variant that is not a variant name", async () => {
+    const response = await request(directoryApp()).get(
+      `/api/directory/assets/${AVATAR_ID}/url?variant=${encodeURIComponent("../../secret")}`,
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/packages/backend/src/__tests__/services/auth/masIntrospection.test.ts
+++ b/packages/backend/src/__tests__/services/auth/masIntrospection.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadMatrixAuthConfig, type MatrixAuthConfig } from "../../../config/matrixAuth";
+import {
+  introspectAccessToken,
+  MasCredentialError,
+  MasProtocolError,
+  MasUnreachableError,
+  type HttpFetch,
+} from "../../../services/auth/masIntrospection";
+
+/**
+ * The one HTTP call the Matrix authentication path makes.
+ *
+ * What is tested here is the SHAPE of the request — because MAS answers a
+ * malformed one with a 400 that reads exactly like a wrong secret — and the way
+ * each kind of failure is separated, because collapsing "MAS is down" into
+ * "your token is invalid" signs every user out of every device the moment MAS
+ * restarts.
+ */
+
+const ISSUER = "https://auth.allo.you/";
+const INTROSPECTION_URL = "https://auth.allo.you/oauth2/introspect";
+const CLIENT_ID = "allo-backend";
+const CLIENT_SECRET = "0123456789abcdef0123456789abcdef";
+const TOKEN = "mct_aVeryOpaqueMatrixAccessToken";
+
+function config(overrides: Record<string, string> = {}): MatrixAuthConfig {
+  return loadMatrixAuthConfig({
+    ALLO_MAS_ISSUER: ISSUER,
+    ALLO_MAS_INTROSPECTION_URL: INTROSPECTION_URL,
+    ALLO_MAS_INTROSPECTION_CLIENT_ID: CLIENT_ID,
+    ALLO_MAS_INTROSPECTION_CLIENT_SECRET: CLIENT_SECRET,
+    ...overrides,
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * The rejection value, as a value.
+ *
+ * `rejects.toThrow(matcher)` was used here first and is a trap: `toThrow` takes
+ * a string, a RegExp, an Error or a class, and an asymmetric matcher handed to
+ * it asserts nothing at all — the test passes whatever the message says. These
+ * assertions are about what a message must NOT contain, so they are made
+ * against the value directly, where a wrong answer is a failure.
+ */
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject, and it resolved");
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function respondingWith(response: Response): { fetch: HttpFetch; calls: RequestInit[] } {
+  const calls: RequestInit[] = [];
+  const fetch: HttpFetch = vi.fn(async (_url, init) => {
+    calls.push(init);
+    return response;
+  });
+  return { fetch, calls };
+}
+
+describe("MAS token introspection", () => {
+  it("POSTs form-encoded to the configured endpoint and nowhere else", async () => {
+    const urls: string[] = [];
+    const httpFetch: HttpFetch = vi.fn(async (url, _init) => {
+      urls.push(url);
+      return jsonResponse({ active: false });
+    });
+
+    await introspectAccessToken(TOKEN, config(), httpFetch);
+
+    expect(urls).toEqual([INTROSPECTION_URL]);
+  });
+
+  it("never puts the token in the URL", async () => {
+    /**
+     * A token in a query string is a token in an access log, in a proxy's
+     * metrics and in a browser's history. RFC 7662 puts it in the body; this
+     * test is what keeps it there.
+     */
+    const urls: string[] = [];
+    const httpFetch: HttpFetch = vi.fn(async (url, _init) => {
+      urls.push(url);
+      return jsonResponse({ active: false });
+    });
+
+    await introspectAccessToken(TOKEN, config(), httpFetch);
+
+    expect(urls[0]).not.toContain(TOKEN);
+  });
+
+  it("sends the token and the access-token hint in a form body", async () => {
+    const { fetch, calls } = respondingWith(jsonResponse({ active: false }));
+
+    await introspectAccessToken(TOKEN, config(), fetch);
+
+    const [init] = calls;
+    expect(init.method).toBe("POST");
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get("token")).toBe(TOKEN);
+    expect(body.get("token_type_hint")).toBe("access_token");
+  });
+
+  it("authenticates with client_secret_basic", async () => {
+    const { fetch, calls } = respondingWith(jsonResponse({ active: false }));
+
+    await introspectAccessToken(TOKEN, config(), fetch);
+
+    const headers = calls[0]?.headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("application/x-www-form-urlencoded");
+    const [scheme, credentials] = headers.authorization.split(" ");
+    expect(scheme).toBe("Basic");
+    expect(Buffer.from(credentials, "base64").toString("utf8")).toBe(
+      `${CLIENT_ID}:${CLIENT_SECRET}`,
+    );
+  });
+
+  it("form-urlencodes a client secret before base64, as RFC 6749 requires", async () => {
+    /**
+     * A secret containing a colon, joined raw, produces credentials MAS splits
+     * in the wrong place — and the resulting 401 reads as "wrong secret",
+     * which sends whoever is debugging it to rotate a perfectly good one.
+     */
+    const awkwardSecret = "aa:bb cc+dd%ee0123456789abcdef0123456789";
+    const { fetch, calls } = respondingWith(jsonResponse({ active: false }));
+
+    await introspectAccessToken(
+      TOKEN,
+      config({ ALLO_MAS_INTROSPECTION_CLIENT_SECRET: awkwardSecret }),
+      fetch,
+    );
+
+    const headers = calls[0]?.headers as Record<string, string>;
+    const decoded = Buffer.from(headers.authorization.split(" ")[1], "base64").toString("utf8");
+    const [encodedId, encodedSecret] = decoded.split(":");
+    expect(encodedId).toBe(CLIENT_ID);
+    expect(decodeURIComponent(encodedSecret.replace(/\+/g, " "))).toBe(awkwardSecret);
+  });
+
+  it("returns the parsed response for a live token", async () => {
+    const { fetch } = respondingWith(
+      jsonResponse({
+        active: true,
+        scope: "urn:matrix:client:api:*",
+        username: "507f1f77bcf86cd799439011",
+        device_id: "ABCDEFGH",
+        exp: 4_000_000_000,
+      }),
+    );
+
+    const response = await introspectAccessToken(TOKEN, config(), fetch);
+
+    expect(response.active).toBe(true);
+    expect(response.username).toBe("507f1f77bcf86cd799439011");
+    expect(response.device_id).toBe("ABCDEFGH");
+  });
+
+  it("returns the bare inactive answer RFC 7662 specifies", async () => {
+    const { fetch } = respondingWith(jsonResponse({ active: false }));
+
+    expect(await introspectAccessToken(TOKEN, config(), fetch)).toEqual({ active: false });
+  });
+
+  it("drops a field MAS adds that this module does not know about", async () => {
+    /**
+     * `passthrough` is deliberately not used: a field nobody decided to trust
+     * must not be able to reach a decision just because MAS started sending it.
+     */
+    const { fetch } = respondingWith(
+      jsonResponse({ active: true, some_future_field: "whatever", username: "x" }),
+    );
+
+    const response = await introspectAccessToken(TOKEN, config(), fetch);
+
+    expect(response).not.toHaveProperty("some_future_field");
+  });
+
+  it("raises a credential error, not a token error, when MAS answers 401", async () => {
+    const { fetch } = respondingWith(new Response("", { status: 401 }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toBeInstanceOf(
+      MasCredentialError,
+    );
+  });
+
+  it("raises a credential error when MAS answers 403", async () => {
+    const { fetch } = respondingWith(new Response("", { status: 403 }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toBeInstanceOf(
+      MasCredentialError,
+    );
+  });
+
+  it("names the two variables to check in the credential error", async () => {
+    const { fetch } = respondingWith(new Response("", { status: 401 }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toThrow(
+      /ALLO_MAS_INTROSPECTION_CLIENT_ID/,
+    );
+  });
+
+  it("never puts the client secret in the credential error", async () => {
+    const { fetch } = respondingWith(new Response("", { status: 401 }));
+
+    const error = await rejectionOf(introspectAccessToken(TOKEN, config(), fetch));
+
+    expect(error).toBeInstanceOf(MasCredentialError);
+    expect(messageOf(error)).not.toContain(CLIENT_SECRET);
+  });
+
+  it("raises unreachable when MAS answers 5xx", async () => {
+    const { fetch } = respondingWith(new Response("", { status: 502 }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toBeInstanceOf(
+      MasUnreachableError,
+    );
+  });
+
+  it("raises unreachable when the request itself fails", async () => {
+    const httpFetch: HttpFetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await expect(introspectAccessToken(TOKEN, config(), httpFetch)).rejects.toBeInstanceOf(
+      MasUnreachableError,
+    );
+  });
+
+  it("never puts the token in the unreachable error", async () => {
+    /**
+     * A fetch failure's own message can quote the request, and the request body
+     * is the user's access token. Only the error's CLASS NAME is used.
+     */
+    const httpFetch: HttpFetch = vi.fn(async () => {
+      throw new TypeError(`fetch failed for body token=${TOKEN}`);
+    });
+
+    const error = await rejectionOf(introspectAccessToken(TOKEN, config(), httpFetch));
+
+    expect(error).toBeInstanceOf(MasUnreachableError);
+    expect(messageOf(error)).not.toContain(TOKEN);
+  });
+
+  it("abandons a request that outlives the timeout", async () => {
+    const httpFetch: HttpFetch = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+
+    await expect(
+      introspectAccessToken(
+        TOKEN,
+        config({ ALLO_MAS_INTROSPECTION_TIMEOUT_MS: "500" }),
+        httpFetch,
+      ),
+    ).rejects.toBeInstanceOf(MasUnreachableError);
+  });
+
+  it("raises a protocol error when the body is not JSON", async () => {
+    const { fetch } = respondingWith(new Response("<html>maintenance</html>", { status: 200 }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toBeInstanceOf(
+      MasProtocolError,
+    );
+  });
+
+  it("raises a protocol error when `active` is missing", async () => {
+    const { fetch } = respondingWith(jsonResponse({ username: "507f1f77bcf86cd799439011" }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toBeInstanceOf(
+      MasProtocolError,
+    );
+  });
+
+  it("raises a protocol error when `active` is a string", async () => {
+    /**
+     * `"false"` is truthy. A schema that coerced it would authenticate every
+     * refused token an authorization server ever reported.
+     */
+    const { fetch } = respondingWith(jsonResponse({ active: "false" }));
+
+    await expect(introspectAccessToken(TOKEN, config(), fetch)).rejects.toBeInstanceOf(
+      MasProtocolError,
+    );
+  });
+
+  it("never quotes the response body in a protocol error", async () => {
+    const { fetch } = respondingWith(
+      jsonResponse({ active: "yes", username: "507f1f77bcf86cd799439011" }),
+    );
+
+    const error = await rejectionOf(introspectAccessToken(TOKEN, config(), fetch));
+
+    expect(error).toBeInstanceOf(MasProtocolError);
+    expect(messageOf(error)).not.toContain("507f1f77bcf86cd799439011");
+  });
+});

--- a/packages/backend/src/__tests__/services/auth/matrixTokenAuthenticator.test.ts
+++ b/packages/backend/src/__tests__/services/auth/matrixTokenAuthenticator.test.ts
@@ -1,0 +1,556 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { loadMatrixAuthConfig, type MatrixAuthConfig } from "../../../config/matrixAuth";
+import {
+  MasUnreachableError,
+  type HttpFetch,
+  type MasIntrospectionResponse as Introspection,
+} from "../../../services/auth/masIntrospection";
+import {
+  createMatrixTokenAuthenticator,
+  evaluateIntrospection,
+} from "../../../services/auth/matrixTokenAuthenticator";
+import { BRIDGE_NETWORK_IDS } from "../../../config/bridges";
+
+/**
+ * What an introspection answer MEANS, and how long it may be remembered.
+ *
+ * Split in two on purpose. {@link evaluateIntrospection} is pure, so every rule
+ * below is one call with no HTTP and no clock; the cache tests then drive the
+ * real authenticator with a fake `fetch` and a fake clock, and count round
+ * trips, which is the only way to prove a bound rather than assert it.
+ */
+
+const ISSUER = "https://auth.allo.you/";
+const CLIENT_SECRET = "0123456789abcdef0123456789abcdef";
+const OXY_USER_ID = "507f1f77bcf86cd799439011";
+const MATRIX_SCOPE = "urn:matrix:org.matrix.msc2967.client:api:*";
+const NOW_SECONDS = 1_800_000_000;
+
+function config(overrides: Record<string, string> = {}): MatrixAuthConfig {
+  return loadMatrixAuthConfig({
+    ALLO_MAS_ISSUER: ISSUER,
+    ALLO_MAS_INTROSPECTION_URL: "https://auth.allo.you/oauth2/introspect",
+    ALLO_MAS_INTROSPECTION_CLIENT_ID: "allo-backend",
+    ALLO_MAS_INTROSPECTION_CLIENT_SECRET: CLIENT_SECRET,
+    ...overrides,
+  });
+}
+
+/** A live, ordinary Matrix session for an ordinary Allo account. */
+function liveToken(overrides: Partial<Introspection> = {}): Introspection {
+  return {
+    active: true,
+    scope: `openid ${MATRIX_SCOPE} urn:matrix:org.matrix.msc2967.client:device:ABCDEFGH`,
+    username: OXY_USER_ID,
+    client_id: "01HXYZDYNAMICALLYREGISTERED",
+    token_type: "access_token",
+    device_id: "ABCDEFGH",
+    exp: NOW_SECONDS + 3600,
+    ...overrides,
+  };
+}
+
+function evaluate(
+  response: Introspection,
+  configuration: MatrixAuthConfig = config(),
+): ReturnType<typeof evaluateIntrospection> {
+  return evaluateIntrospection(response, configuration, NOW_SECONDS);
+}
+
+describe("what an introspection answer means", () => {
+  it("accepts a live Matrix session and names the Oxy account", () => {
+    expect(evaluate(liveToken())).toEqual({
+      outcome: "accepted",
+      oxyUserId: OXY_USER_ID,
+      deviceId: "ABCDEFGH",
+    });
+  });
+
+  it("accepts a session MAS reports without a device", () => {
+    const result = evaluate(liveToken({ device_id: undefined }));
+
+    expect(result).toEqual({ outcome: "accepted", oxyUserId: OXY_USER_ID, deviceId: undefined });
+  });
+
+  it("refuses an inactive token", () => {
+    expect(evaluate({ active: false })).toEqual({ outcome: "refused", reason: "inactive" });
+  });
+
+  it("refuses an inactive token even when every other field looks right", () => {
+    /**
+     * MAS answers a revoked token with a bare `{"active": false}`, but an
+     * authorization server is free to echo the rest back, and a check that ran
+     * the other rules first and forgot this one would accept a signed-out
+     * device.
+     */
+    expect(evaluate(liveToken({ active: false }))).toEqual({
+      outcome: "refused",
+      reason: "inactive",
+    });
+  });
+
+  it("refuses a token that has already expired", () => {
+    expect(evaluate(liveToken({ exp: NOW_SECONDS - 1 }))).toEqual({
+      outcome: "refused",
+      reason: "expired",
+    });
+  });
+
+  it("refuses a token at the exact second it expires", () => {
+    expect(evaluate(liveToken({ exp: NOW_SECONDS }))).toEqual({
+      outcome: "refused",
+      reason: "expired",
+    });
+  });
+
+  it("refuses a token that is not valid yet", () => {
+    expect(evaluate(liveToken({ nbf: NOW_SECONDS + 60 }))).toEqual({
+      outcome: "refused",
+      reason: "not-yet-valid",
+    });
+  });
+
+  it("refuses a refresh token presented as a bearer credential", () => {
+    /**
+     * A refresh token introspects as ACTIVE. It is only ever meant to be
+     * exchanged at the token endpoint, and it outlives every access token, so
+     * accepting one here would turn the longest-lived credential in the system
+     * into an API key.
+     */
+    expect(evaluate(liveToken({ token_type: "refresh_token" }))).toEqual({
+      outcome: "refused",
+      reason: "wrong-token-type",
+    });
+  });
+
+  it("accepts the RFC 6750 spelling of an access token", () => {
+    expect(evaluate(liveToken({ token_type: "Bearer" })).outcome).toBe("accepted");
+  });
+
+  it("accepts a token whose type MAS did not report", () => {
+    expect(evaluate(liveToken({ token_type: undefined })).outcome).toBe("accepted");
+  });
+
+  it("refuses a token another issuer vouched for", () => {
+    expect(evaluate(liveToken({ iss: "https://auth.evil.example/" }))).toEqual({
+      outcome: "refused",
+      reason: "wrong-issuer",
+    });
+  });
+
+  it("accepts our own issuer whether or not it carries a trailing slash", () => {
+    expect(evaluate(liveToken({ iss: "https://auth.allo.you" })).outcome).toBe("accepted");
+    expect(evaluate(liveToken({ iss: "https://auth.allo.you/" })).outcome).toBe("accepted");
+  });
+
+  it("refuses a token for another audience when an audience is expected", () => {
+    const withAudience = config({ ALLO_MAS_EXPECTED_AUDIENCE: "https://api.allo.you" });
+
+    expect(evaluate(liveToken({ aud: "https://api.somewhere.else" }), withAudience)).toEqual({
+      outcome: "refused",
+      reason: "wrong-audience",
+    });
+  });
+
+  it("refuses a token with no audience at all when an audience is expected", () => {
+    const withAudience = config({ ALLO_MAS_EXPECTED_AUDIENCE: "https://api.allo.you" });
+
+    expect(evaluate(liveToken(), withAudience)).toEqual({
+      outcome: "refused",
+      reason: "wrong-audience",
+    });
+  });
+
+  it("accepts an audience list containing the expected one", () => {
+    const withAudience = config({ ALLO_MAS_EXPECTED_AUDIENCE: "https://api.allo.you" });
+    const response = liveToken({ aud: ["https://matrix.allo.you", "https://api.allo.you"] });
+
+    expect(evaluate(response, withAudience).outcome).toBe("accepted");
+  });
+
+  it("refuses a token carrying no Matrix client-API scope", () => {
+    /**
+     * The audience check for an opaque token. A MAS admin token and a bare
+     * `openid` token from another client of the same issuer are both `active`,
+     * and neither is a Matrix session.
+     */
+    expect(evaluate(liveToken({ scope: "openid email" }))).toEqual({
+      outcome: "refused",
+      reason: "missing-scope",
+    });
+  });
+
+  it("refuses a token with no scope at all", () => {
+    expect(evaluate(liveToken({ scope: undefined }))).toEqual({
+      outcome: "refused",
+      reason: "missing-scope",
+    });
+  });
+
+  it("refuses a scope that merely contains an accepted one as a substring", () => {
+    /**
+     * `urn:matrix:client:api:*:readonly` is not `urn:matrix:client:api:*`.
+     * Scopes are space-delimited tokens and are matched whole; a substring
+     * match would accept anything an authorization server invents that happens
+     * to start with the right prefix.
+     */
+    expect(evaluate(liveToken({ scope: "urn:matrix:client:api:*:readonly" }))).toEqual({
+      outcome: "refused",
+      reason: "missing-scope",
+    });
+  });
+
+  it("accepts either spelling of the MSC2967 client-API scope", () => {
+    expect(evaluate(liveToken({ scope: "urn:matrix:client:api:*" })).outcome).toBe("accepted");
+    expect(
+      evaluate(liveToken({ scope: "urn:matrix:org.matrix.msc2967.client:api:*" })).outcome,
+    ).toBe("accepted");
+  });
+
+  it("accepts any client of the issuer when no allowlist is configured", () => {
+    expect(evaluate(liveToken({ client_id: "somebody-elses-client" })).outcome).toBe("accepted");
+  });
+
+  it("refuses a client outside the allowlist when one is configured", () => {
+    const pinned = config({ ALLO_MAS_ALLOWED_CLIENT_IDS: "allo-web,allo-native" });
+
+    expect(evaluate(liveToken({ client_id: "somebody-elses-client" }), pinned)).toEqual({
+      outcome: "refused",
+      reason: "client-not-allowed",
+    });
+  });
+
+  it("refuses a token with no client at all when an allowlist is configured", () => {
+    const pinned = config({ ALLO_MAS_ALLOWED_CLIENT_IDS: "allo-web" });
+
+    expect(evaluate(liveToken({ client_id: undefined }), pinned)).toEqual({
+      outcome: "refused",
+      reason: "client-not-allowed",
+    });
+  });
+
+  it("accepts a client inside the allowlist", () => {
+    const pinned = config({ ALLO_MAS_ALLOWED_CLIENT_IDS: "allo-web,allo-native" });
+
+    expect(evaluate(liveToken({ client_id: "allo-native" }), pinned).outcome).toBe("accepted");
+  });
+
+  it("refuses a response naming no subject", () => {
+    expect(evaluate(liveToken({ username: undefined }))).toEqual({
+      outcome: "refused",
+      reason: "no-subject",
+    });
+  });
+
+  it("refuses a blank subject", () => {
+    expect(evaluate(liveToken({ username: "   " }))).toEqual({
+      outcome: "refused",
+      reason: "no-subject",
+    });
+  });
+
+  it("refuses a localpart that is not an Oxy account id", () => {
+    expect(evaluate(liveToken({ username: "alice" }))).toEqual({
+      outcome: "refused",
+      reason: "not-an-oxy-account",
+    });
+  });
+
+  it("refuses an ObjectId-shaped subject with uppercase hex", () => {
+    /**
+     * A Matrix localpart is lowercase-only, so `507F1F77BCF86CD799439011` is
+     * not a localpart any homeserver would mint — and accepting it would mean
+     * one Oxy account has two spellings on this boundary.
+     */
+    expect(evaluate(liveToken({ username: OXY_USER_ID.toUpperCase() }))).toEqual({
+      outcome: "refused",
+      reason: "not-an-oxy-account",
+    });
+  });
+
+  it("refuses a subject that is too short to be an Oxy account id", () => {
+    expect(evaluate(liveToken({ username: "507f1f77bcf86cd7994390" }))).toEqual({
+      outcome: "refused",
+      reason: "not-an-oxy-account",
+    });
+  });
+
+  it("refuses a subject that is longer than an Oxy account id", () => {
+    expect(evaluate(liveToken({ username: `${OXY_USER_ID}00` }))).toEqual({
+      outcome: "refused",
+      reason: "not-an-oxy-account",
+    });
+  });
+
+  it("refuses every bridge puppet in the catalogue", () => {
+    /**
+     * Nobody behind `@whatsapp_447700900000` or `@whatsappbot` ever signed up
+     * to Allo, so neither names an account that could be authenticated. Derived
+     * from the catalogue rather than listed, so a network added there cannot be
+     * forgotten here.
+     */
+    for (const network of BRIDGE_NETWORK_IDS) {
+      expect(evaluate(liveToken({ username: `${network}_447700900000` }))).toEqual({
+        outcome: "refused",
+        reason: "not-an-oxy-account",
+      });
+      expect(evaluate(liveToken({ username: `${network}bot` }))).toEqual({
+        outcome: "refused",
+        reason: "not-an-oxy-account",
+      });
+    }
+  });
+
+  it("refuses an MXID from another homeserver", () => {
+    /**
+     * MAS reports a bare localpart, so a sigil arriving at all is unusual — and
+     * it is judged as a full MXID rather than shrugged at. The server name is
+     * unset in this suite, so no MXID can be judged to belong to us, and the
+     * safe answer to "I cannot tell" is no.
+     */
+    expect(evaluate(liveToken({ username: `@${OXY_USER_ID}:elsewhere.example` }))).toEqual({
+      outcome: "refused",
+      reason: "not-an-oxy-account",
+    });
+  });
+
+  it("refuses an MXID even for our own account when no server name is configured", () => {
+    expect(evaluate(liveToken({ username: `@${OXY_USER_ID}:allo.you` }))).toEqual({
+      outcome: "refused",
+      reason: "not-an-oxy-account",
+    });
+  });
+});
+
+describe("the introspection cache", () => {
+  let clock: number;
+  let responses: Introspection[];
+  let calls: number;
+
+  function httpFetchReturning(): HttpFetch {
+    return async () => {
+      const body = responses[Math.min(calls, responses.length - 1)];
+      calls += 1;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+  }
+
+  function authenticator(configuration: MatrixAuthConfig = config()) {
+    return createMatrixTokenAuthenticator({
+      config: configuration,
+      httpFetch: httpFetchReturning(),
+      now: () => clock,
+    });
+  }
+
+  beforeEach(() => {
+    clock = NOW_SECONDS * 1000;
+    calls = 0;
+    responses = [liveToken()];
+  });
+
+  it("asks MAS once and reuses the answer inside the window", async () => {
+    const auth = authenticator();
+
+    await auth.authenticate("token-a");
+    await auth.authenticate("token-a");
+    await auth.authenticate("token-a");
+
+    expect(calls).toBe(1);
+  });
+
+  it("asks again once the window has passed", async () => {
+    const auth = authenticator();
+
+    await auth.authenticate("token-a");
+    clock += 30_001;
+    await auth.authenticate("token-a");
+
+    expect(calls).toBe(2);
+  });
+
+  it("stops accepting a revoked token within the cache window", async () => {
+    /**
+     * The property the whole bound exists for. MAS is told the token is dead
+     * one millisecond after it was cached alive, and the authenticator keeps
+     * saying yes — for at most 30 seconds, and then no.
+     */
+    const auth = authenticator();
+    responses = [liveToken(), { active: false }];
+
+    expect((await auth.authenticate("token-a")).outcome).toBe("accepted");
+
+    clock += 29_000;
+    expect((await auth.authenticate("token-a")).outcome).toBe("accepted");
+
+    clock += 2_000;
+    expect((await auth.authenticate("token-a")).outcome).toBe("refused");
+  });
+
+  it("honours a configured window shorter than the default", async () => {
+    const auth = authenticator(config({ ALLO_MAS_INTROSPECTION_CACHE_SECONDS: "5" }));
+    responses = [liveToken(), { active: false }];
+
+    expect((await auth.authenticate("token-a")).outcome).toBe("accepted");
+    clock += 5_001;
+    expect((await auth.authenticate("token-a")).outcome).toBe("refused");
+  });
+
+  it("never caches past the token's own expiry", async () => {
+    /**
+     * A token with four seconds left is cached for four, not for thirty. `exp`
+     * is a ceiling ON TOP of the configured ceiling; without that, the cache
+     * would keep serving a token that had run out.
+     */
+    const auth = authenticator();
+    responses = [liveToken({ exp: NOW_SECONDS + 4 }), { active: false }];
+
+    expect((await auth.authenticate("token-a")).outcome).toBe("accepted");
+    clock += 4_001;
+    await auth.authenticate("token-a");
+
+    expect(calls).toBe(2);
+  });
+
+  it("keeps one answer per token", async () => {
+    const auth = authenticator();
+
+    await auth.authenticate("token-a");
+    await auth.authenticate("token-b");
+
+    expect(calls).toBe(2);
+  });
+
+  it("remembers a refusal only briefly", async () => {
+    const auth = authenticator();
+    responses = [{ active: false }];
+
+    await auth.authenticate("token-a");
+    clock += 4_000;
+    await auth.authenticate("token-a");
+    expect(calls).toBe(1);
+
+    clock += 2_000;
+    await auth.authenticate("token-a");
+    expect(calls).toBe(2);
+  });
+
+  it("collapses a burst of concurrent requests into one round trip", async () => {
+    const auth = authenticator();
+
+    const results = await Promise.all([
+      auth.authenticate("token-a"),
+      auth.authenticate("token-a"),
+      auth.authenticate("token-a"),
+      auth.authenticate("token-a"),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(results.every((result) => result.outcome === "accepted")).toBe(true);
+  });
+
+  it("never caches an upstream failure", async () => {
+    /**
+     * MAS being down is not evidence about a token. If a failure were cached,
+     * a single blip would refuse every request for the length of the window
+     * even after MAS came back.
+     */
+    let attempt = 0;
+    const auth = createMatrixTokenAuthenticator({
+      config: config(),
+      now: () => clock,
+      httpFetch: async () => {
+        attempt += 1;
+        if (attempt === 1) throw new TypeError("fetch failed");
+        return new Response(JSON.stringify(liveToken()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    await expect(auth.authenticate("token-a")).rejects.toBeInstanceOf(MasUnreachableError);
+    expect((await auth.authenticate("token-a")).outcome).toBe("accepted");
+  });
+
+  it("hands every concurrent caller the same upstream failure", async () => {
+    let attempts = 0;
+    const auth = createMatrixTokenAuthenticator({
+      config: config(),
+      now: () => clock,
+      httpFetch: async () => {
+        attempts += 1;
+        throw new TypeError("fetch failed");
+      },
+    });
+
+    const outcomes = await Promise.allSettled([
+      auth.authenticate("token-a"),
+      auth.authenticate("token-a"),
+    ]);
+
+    expect(attempts).toBe(1);
+    expect(outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+  });
+
+  it("evicts oldest-first rather than growing without limit", async () => {
+    /**
+     * A cache keyed by an attacker-supplied string with no ceiling is a memory
+     * exhaustion primitive: twelve thousand invented tokens would be twelve
+     * thousand live entries.
+     *
+     * A bound is only testable through what it EVICTS, so that is what is
+     * asserted. After the spray, the oldest sprayed token has to cost a fresh
+     * round trip and the newest must not — which is false both if the ceiling
+     * is removed (nothing evicted) and if eviction ran the wrong way round.
+     */
+    const auth = authenticator();
+    responses = [{ active: false }];
+
+    for (let index = 0; index < 12_000; index += 1) {
+      await auth.authenticate(`sprayed-token-${index}`);
+    }
+    expect(calls).toBe(12_000);
+
+    calls = 0;
+    await auth.authenticate("sprayed-token-11999");
+    expect(calls).toBe(0);
+
+    await auth.authenticate("sprayed-token-0");
+    expect(calls).toBe(1);
+  });
+
+  it("keeps answering correctly after a spray", async () => {
+    const auth = authenticator();
+    responses = [{ active: false }];
+    for (let index = 0; index < 12_000; index += 1) {
+      await auth.authenticate(`sprayed-token-${index}`);
+    }
+
+    responses = [liveToken()];
+    calls = 0;
+
+    expect((await auth.authenticate("a-real-token")).outcome).toBe("accepted");
+    expect((await auth.authenticate("a-real-token")).outcome).toBe("accepted");
+    expect(calls).toBe(1);
+  });
+
+  it("does not confuse two tokens that share a prefix", async () => {
+    const auth = authenticator();
+    responses = [liveToken(), liveToken({ username: "aaaaaaaaaaaaaaaaaaaaaaaa" })];
+
+    const first = await auth.authenticate("token-a");
+    const second = await auth.authenticate("token-aa");
+
+    expect(first).toEqual({ outcome: "accepted", oxyUserId: OXY_USER_ID, deviceId: "ABCDEFGH" });
+    expect(second).toEqual({
+      outcome: "accepted",
+      oxyUserId: "aaaaaaaaaaaaaaaaaaaaaaaa",
+      deviceId: "ABCDEFGH",
+    });
+  });
+});

--- a/packages/backend/src/__tests__/services/bridges/matrixIdentity.test.ts
+++ b/packages/backend/src/__tests__/services/bridges/matrixIdentity.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { BRIDGE_NETWORK_IDS } from "../../../config/bridges";
 import {
+  isOxyUserId,
   MatrixIdentityError,
   matrixUserIdForOxyUser,
+  oxyAccountIdFromMatrixUserId,
+  oxyUserIdFromMatrixLocalpart,
   oxyUserIdFromMatrixUserId,
 } from "../../../services/bridges/matrixIdentity";
 
@@ -110,4 +114,91 @@ describe("reading an Oxy id back out of a Matrix id", () => {
       expect(oxyUserIdFromMatrixUserId(candidate, SERVER)).toBeUndefined();
     },
   );
+
+  it("still hands back a bridge ghost's localpart, which the moderation path needs", () => {
+    /**
+     * The looser function stays loose ON PURPOSE.
+     * `services/moderation/subjectIdentity.ts` reads the raw localpart so it can
+     * recognise a ghost and say WHICH network it came from; tightening this
+     * would replace that specific, useful reason with "this homeserver does not
+     * own that identifier", which is false. The strict answer lives in
+     * {@link oxyAccountIdFromMatrixUserId} below.
+     */
+    expect(oxyUserIdFromMatrixUserId("@whatsapp_447700900000:allo.you", SERVER)).toBe(
+      "whatsapp_447700900000",
+    );
+  });
+});
+
+describe("deciding whether a localpart names an Oxy ACCOUNT", () => {
+  /**
+   * The direction that authenticates somebody, added for
+   * `middleware/matrixAuth.ts`. Everything above answers "could a homeserver
+   * hold this string?"; everything below answers "is this a person on this
+   * platform?", and a wrong yes here is a request authenticated as somebody
+   * else's account.
+   */
+
+  it("accepts a 24-character hexadecimal ObjectId", () => {
+    expect(isOxyUserId("507f1f77bcf86cd799439011")).toBe(true);
+    expect(oxyUserIdFromMatrixLocalpart("507f1f77bcf86cd799439011")).toBe(
+      "507f1f77bcf86cd799439011",
+    );
+  });
+
+  it.each([
+    ["alice", "a perfectly legal localpart that is not an id"],
+    ["507f1f77bcf86cd79943901", "one character short"],
+    ["507f1f77bcf86cd7994390111", "one character long"],
+    ["507F1F77BCF86CD799439011", "uppercase, which no localpart may contain"],
+    ["507f1f77bcf86cd79943901g", "a character outside hexadecimal"],
+    ["507f1f77-bcf86cd79943901", "a hyphen where a digit belongs"],
+    ["", "empty"],
+    ["   ", "blank"],
+  ])("refuses %s (%s)", (localpart) => {
+    expect(isOxyUserId(localpart)).toBe(false);
+    expect(oxyUserIdFromMatrixLocalpart(localpart)).toBeUndefined();
+  });
+
+  it("refuses every bridge puppet the catalogue can produce", () => {
+    /**
+     * A mautrix bridge owns one ghost per remote user (`whatsapp_<remote id>`)
+     * and one bot per bridge (`whatsappbot`). Nobody behind either ever signed
+     * up to Allo, so neither names an account that can be authenticated.
+     * Derived from `BRIDGE_NETWORK_IDS` rather than listed, so a network added
+     * to the catalogue cannot be forgotten here.
+     */
+    for (const network of BRIDGE_NETWORK_IDS) {
+      expect(oxyUserIdFromMatrixLocalpart(`${network}_447700900000`)).toBeUndefined();
+      expect(oxyUserIdFromMatrixLocalpart(`${network}bot`)).toBeUndefined();
+      expect(
+        oxyAccountIdFromMatrixUserId(`@${network}_447700900000:allo.you`, SERVER),
+      ).toBeUndefined();
+      expect(oxyAccountIdFromMatrixUserId(`@${network}bot:allo.you`, SERVER)).toBeUndefined();
+    }
+  });
+
+  it("accepts one of our own users by full MXID", () => {
+    expect(oxyAccountIdFromMatrixUserId("@507f1f77bcf86cd799439011:allo.you", SERVER)).toBe(
+      "507f1f77bcf86cd799439011",
+    );
+  });
+
+  it("refuses one of our own account ids on another homeserver", () => {
+    expect(
+      oxyAccountIdFromMatrixUserId("@507f1f77bcf86cd799439011:elsewhere.example", SERVER),
+    ).toBeUndefined();
+  });
+
+  it("is not fooled by a server name that merely ends with ours", () => {
+    expect(
+      oxyAccountIdFromMatrixUserId("@507f1f77bcf86cd799439011:notallo.you", SERVER),
+    ).toBeUndefined();
+  });
+
+  it("round-trips an id it would itself derive", () => {
+    const mxid = matrixUserIdForOxyUser("507f1f77bcf86cd799439011", SERVER);
+
+    expect(oxyAccountIdFromMatrixUserId(mxid, SERVER)).toBe("507f1f77bcf86cd799439011");
+  });
 });

--- a/packages/backend/src/config/matrixAuth.ts
+++ b/packages/backend/src/config/matrixAuth.ts
@@ -1,0 +1,330 @@
+import * as z from "zod";
+
+/**
+ * Accepting a Matrix Authentication Service access token at `api.allo.you`.
+ *
+ * ## Why this exists
+ *
+ * Allo signs a person in twice today: once to Oxy for this backend, and once
+ * through Matrix Authentication Service for chat. Two tokens for one person is
+ * two identities that have to be kept pointing at the same account, and the
+ * account-switch bug that shipped in #104 is what happens when they stop. The
+ * end state is one sign-in — MAS — and this module is the half that lets this
+ * backend believe the token it produces.
+ *
+ * ## Same shape as `config/push.ts` and `config/bridges.ts`
+ *
+ * Validated with zod ONCE, memoised, frozen. Here the reason is sharper than in
+ * either of those: every variable below decides whether a stranger's token is
+ * accepted as a user, so a typo that reads as `undefined` at the point of use
+ * would not degrade a feature, it would open an authentication boundary. All of
+ * it or none of it, checked in `superRefine`, and a deployment that asks for
+ * half does not boot.
+ *
+ * ## Why there is no OIDC discovery
+ *
+ * The introspection endpoint could be discovered from
+ * `${issuer}/.well-known/openid-configuration`, and that is how a general OAuth
+ * client would find it. It is configured explicitly here instead, for two
+ * reasons that both matter on an authentication path:
+ *
+ * 1. Discovery is a network call, so it is a way for authentication to fail
+ *    that has nothing to do with the token being presented, and a cache of the
+ *    result is one more thing that can be stale at the wrong moment.
+ * 2. The only property discovery would establish — that the endpoint answering
+ *    introspection belongs to the issuer we pinned — is checked HERE, at boot,
+ *    with no network: {@link ALLO_MAS_INTROSPECTION_URL} must be same-origin
+ *    with {@link ALLO_MAS_ISSUER}. A process configured to ask a stranger about
+ *    our users' tokens does not start.
+ *
+ * That same-origin rule is the whole of Allo's issuer verification, and it is
+ * deliberate rather than a shortcut: MAS's introspection response carries no
+ * `iss` and no `aud` (RFC 7662 makes both optional). There is nothing in the
+ * answer to check, so the guarantee has to come from WHERE THE QUESTION WAS
+ * ASKED. `services/auth/masIntrospection.ts` still checks `iss` and `aud` when
+ * a response does carry them, so a future MAS that starts emitting them is
+ * checked rather than ignored — but nothing rests on that today.
+ */
+
+/**
+ * The scopes that say a token is a Matrix client-API token.
+ *
+ * This is Allo's audience check, and it needs the explanation. An opaque MAS
+ * access token has no `aud`; under MSC2967 what a Matrix access token is FOR is
+ * expressed as scope, and `…client:api:*` is "the Matrix client-server API on
+ * this homeserver". Requiring it refuses three things that would otherwise walk
+ * straight through an `active: true`: a MAS admin token, a bare `openid` token
+ * minted by some other client of the same issuer, and a device-scoped token
+ * carrying no API grant at all.
+ *
+ * Two spellings, and any one of them is enough. MAS emitted the
+ * `org.matrix.msc2967` unstable prefix before the MSC stabilised and emits the
+ * short form after; which one arrives is a property of the deployed MAS
+ * version, not of the token's meaning, and pinning the wrong one is an outage
+ * on the day MAS is upgraded.
+ */
+const DEFAULT_ACCEPTED_SCOPES = [
+  "urn:matrix:org.matrix.msc2967.client:api:*",
+  "urn:matrix:client:api:*",
+] as const;
+
+/**
+ * How long an introspection answer may be reused, at most.
+ *
+ * MAS answers with the token's `exp`, which for a Matrix access token is hours
+ * away, and caching for that long would mean a signed-out device keeps working
+ * until its token would have expired anyway — the cache would have UNDONE
+ * revocation. So `exp` is a ceiling and this is the real bound: after 30
+ * seconds the answer is asked for again, so a revoked token stops working
+ * within 30 seconds of the revocation everywhere, on every instance, with no
+ * invalidation channel to build or to get wrong.
+ *
+ * Thirty seconds and not five: a chat client makes several API calls per
+ * screen, so the window's job is to collapse a burst of them into one round
+ * trip, and a burst is seconds long. Not five minutes: that is long enough for
+ * somebody to notice a stolen phone, sign the device out, and still be watched.
+ */
+const DEFAULT_CACHE_SECONDS = 30;
+
+/** The ceiling on the ceiling. See {@link DEFAULT_CACHE_SECONDS}. */
+const MAXIMUM_CACHE_SECONDS = 300;
+
+/** How long MAS gets to answer before the request is abandoned. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * The shortest introspection client secret this deployment will accept.
+ *
+ * The secret is what lets this backend ask MAS about anybody's token, so it is
+ * a credential over the whole user base. Thirty-two characters is the same
+ * floor the push gateway secrets use, and `openssl rand -hex 32` clears it.
+ */
+const MINIMUM_CLIENT_SECRET_LENGTH = 32;
+
+const emptyAsUndefined = (value: unknown): unknown =>
+  typeof value === "string" && value.trim().length === 0 ? undefined : value;
+
+const optionalString = (minimumLength = 1) =>
+  z.preprocess(emptyAsUndefined, z.string().trim().min(minimumLength).optional());
+
+/**
+ * An OAuth 2.0 issuer identifier: absolute, https, no query and no fragment.
+ *
+ * http is refused rather than allowed for local development. A token is a
+ * bearer credential and introspecting it over cleartext hands it to the
+ * network; there is no development convenience worth an environment where that
+ * is possible, and a local MAS can be given a certificate.
+ */
+const issuerUrl = z
+  .string()
+  .trim()
+  .url()
+  .refine((value) => new URL(value).protocol === "https:", "must use https://")
+  .refine((value) => {
+    const url = new URL(value);
+    return url.search.length === 0 && url.hash.length === 0;
+  }, "must carry no query string and no fragment")
+  .refine((value) => {
+    const url = new URL(value);
+    return url.username.length === 0 && url.password.length === 0;
+  }, "must carry no credentials — the client secret goes in ALLO_MAS_INTROSPECTION_CLIENT_SECRET");
+
+/** A comma-separated list, trimmed, with empty entries dropped. */
+const stringList = z.preprocess(
+  emptyAsUndefined,
+  z
+    .string()
+    .trim()
+    .transform((value) =>
+      value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    )
+    .pipe(z.array(z.string().min(1)).min(1))
+    .optional(),
+);
+
+const cacheSeconds = z.preprocess(
+  emptyAsUndefined,
+  z.coerce.number().int().min(1).max(MAXIMUM_CACHE_SECONDS).default(DEFAULT_CACHE_SECONDS),
+);
+
+const timeoutMs = z.preprocess(
+  emptyAsUndefined,
+  z.coerce.number().int().min(500).max(30_000).default(DEFAULT_TIMEOUT_MS),
+);
+
+function buildMatrixAuthEnvSchema() {
+  return z
+    .object({
+      ALLO_MAS_ISSUER: z.preprocess(emptyAsUndefined, issuerUrl.optional()),
+      ALLO_MAS_INTROSPECTION_URL: z.preprocess(emptyAsUndefined, issuerUrl.optional()),
+      ALLO_MAS_INTROSPECTION_CLIENT_ID: optionalString(),
+      ALLO_MAS_INTROSPECTION_CLIENT_SECRET: optionalString(MINIMUM_CLIENT_SECRET_LENGTH),
+      ALLO_MAS_ALLOWED_CLIENT_IDS: stringList,
+      ALLO_MAS_ACCEPTED_SCOPES: stringList,
+      ALLO_MAS_EXPECTED_AUDIENCE: optionalString(),
+      ALLO_MAS_INTROSPECTION_CACHE_SECONDS: cacheSeconds,
+      ALLO_MAS_INTROSPECTION_TIMEOUT_MS: timeoutMs,
+    })
+    .superRefine((environment, context) => {
+      if (environment.ALLO_MAS_ISSUER === undefined) {
+        /**
+         * No issuer asked for. Not an error — it is a deployment that accepts
+         * Oxy tokens only, which is every deployment today. Anything else set
+         * alongside it is inert, and refusing to boot over a variable that
+         * decides nothing would be worse than ignoring it.
+         */
+        return;
+      }
+
+      if (environment.ALLO_MAS_INTROSPECTION_URL === undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["ALLO_MAS_INTROSPECTION_URL"],
+          message:
+            "is required once ALLO_MAS_ISSUER is set — without it there is no way to ask whether " +
+            "a token is still live, and a token nobody can revoke is not an authentication scheme",
+        });
+      } else if (new URL(environment.ALLO_MAS_INTROSPECTION_URL).origin !== new URL(environment.ALLO_MAS_ISSUER).origin) {
+        context.addIssue({
+          code: "custom",
+          path: ["ALLO_MAS_INTROSPECTION_URL"],
+          message:
+            "must be same-origin with ALLO_MAS_ISSUER. Asking a different host whether our users' " +
+            "tokens are valid is asking a stranger to authenticate them, and because MAS returns " +
+            "no `iss` in its introspection response, this check is the only thing that binds an " +
+            "answer to the issuer we trust",
+        });
+      }
+
+      if (environment.ALLO_MAS_INTROSPECTION_CLIENT_ID === undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["ALLO_MAS_INTROSPECTION_CLIENT_ID"],
+          message:
+            "is required once ALLO_MAS_ISSUER is set — MAS answers an unauthenticated introspection " +
+            "request with 400 invalid_request, so a deployment without it accepts no token at all",
+        });
+      }
+
+      if (environment.ALLO_MAS_INTROSPECTION_CLIENT_SECRET === undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["ALLO_MAS_INTROSPECTION_CLIENT_SECRET"],
+          message:
+            `is required once ALLO_MAS_ISSUER is set, and must be at least ${MINIMUM_CLIENT_SECRET_LENGTH} ` +
+            "characters — it is the credential that lets this backend ask MAS about anybody's token",
+        });
+      }
+    });
+}
+
+export interface MatrixAuthConfig {
+  /** Whether a MAS token can be presented at all. False means Oxy tokens only. */
+  readonly enabled: boolean;
+  /** The OAuth 2.0 issuer identifier, exactly as MAS publishes it. */
+  readonly issuer: string;
+  /** RFC 7662 introspection endpoint. Same-origin with {@link issuer}. */
+  readonly introspectionUrl: string;
+  /** The client this backend authenticates to the introspection endpoint as. */
+  readonly clientId: string;
+  /** Its secret. A credential: never logged, never returned by an endpoint. */
+  readonly clientSecret: string;
+  /**
+   * Which OAuth clients' tokens are accepted, or empty for "any client of the
+   * configured issuer".
+   *
+   * Empty is the realistic default and it is worth being plain about why. Allo
+   * registers with MAS DYNAMICALLY (`client.web.ts` posts to the registration
+   * endpoint), so the `client_id` differs per installation and no list written
+   * in advance could contain them all. What makes empty acceptable is that a
+   * token with the Matrix client-API scope already drives the whole account on
+   * the homeserver — reading every message, sending as the user — so accepting
+   * one here grants an attacker nothing they did not already have. A deployment
+   * that pins its clients statically SHOULD fill this in.
+   */
+  readonly allowedClientIds: readonly string[];
+  /** Any one of these in the token's scope is enough. See the constant. */
+  readonly acceptedScopes: readonly string[];
+  /**
+   * The audience the token must name, when the introspection response carries
+   * one at all. MAS does not, so this is normally unset — see the module
+   * comment, and {@link acceptedScopes} for what stands in its place.
+   */
+  readonly expectedAudience: string | undefined;
+  /** The ceiling on how long an introspection answer is reused. */
+  readonly cacheSeconds: number;
+  readonly timeoutMs: number;
+}
+
+/** The shape of a deployment that accepts no MAS token. */
+const DISABLED: MatrixAuthConfig = Object.freeze({
+  enabled: false,
+  issuer: "",
+  introspectionUrl: "",
+  clientId: "",
+  clientSecret: "",
+  allowedClientIds: Object.freeze([]),
+  acceptedScopes: Object.freeze([...DEFAULT_ACCEPTED_SCOPES]),
+  expectedAudience: undefined,
+  cacheSeconds: DEFAULT_CACHE_SECONDS,
+  timeoutMs: DEFAULT_TIMEOUT_MS,
+});
+
+export function loadMatrixAuthConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): MatrixAuthConfig {
+  const parsed = buildMatrixAuthEnvSchema().parse(environment);
+
+  if (
+    parsed.ALLO_MAS_ISSUER === undefined ||
+    parsed.ALLO_MAS_INTROSPECTION_URL === undefined ||
+    parsed.ALLO_MAS_INTROSPECTION_CLIENT_ID === undefined ||
+    parsed.ALLO_MAS_INTROSPECTION_CLIENT_SECRET === undefined
+  ) {
+    /**
+     * Unreachable when the issuer is set — `superRefine` above has already
+     * failed the parse for each missing companion. Written out anyway because
+     * it is what narrows the four values to `string` for the object below, and
+     * a non-null assertion here would be an authentication boundary asserting
+     * something it had not checked.
+     */
+    return DISABLED;
+  }
+
+  return Object.freeze({
+    enabled: true,
+    issuer: parsed.ALLO_MAS_ISSUER,
+    introspectionUrl: parsed.ALLO_MAS_INTROSPECTION_URL,
+    clientId: parsed.ALLO_MAS_INTROSPECTION_CLIENT_ID,
+    clientSecret: parsed.ALLO_MAS_INTROSPECTION_CLIENT_SECRET,
+    allowedClientIds: Object.freeze([...(parsed.ALLO_MAS_ALLOWED_CLIENT_IDS ?? [])]),
+    acceptedScopes: Object.freeze([
+      ...(parsed.ALLO_MAS_ACCEPTED_SCOPES ?? DEFAULT_ACCEPTED_SCOPES),
+    ]),
+    expectedAudience: parsed.ALLO_MAS_EXPECTED_AUDIENCE,
+    cacheSeconds: parsed.ALLO_MAS_INTROSPECTION_CACHE_SECONDS,
+    timeoutMs: parsed.ALLO_MAS_INTROSPECTION_TIMEOUT_MS,
+  });
+}
+
+let cached: MatrixAuthConfig | undefined;
+
+/**
+ * The process-wide MAS configuration, parsed on first use.
+ *
+ * Lazy for the same reason the push and bridge ones are: importing an
+ * authentication module must not crash a process whose environment has nothing
+ * to do with MAS.
+ */
+export function matrixAuthConfig(): MatrixAuthConfig {
+  if (!cached) cached = loadMatrixAuthConfig();
+  return cached;
+}
+
+/** Resets the memoised config. Tests only; there is no runtime reconfiguration. */
+export function resetMatrixAuthConfigForTests(): void {
+  cached = undefined;
+}

--- a/packages/backend/src/config/oxyService.ts
+++ b/packages/backend/src/config/oxyService.ts
@@ -1,0 +1,126 @@
+import * as z from "zod";
+
+import { logger } from "../utils/logger";
+
+/**
+ * Allo's own credential for calling the Oxy API as itself.
+ *
+ * ## Optional, and worth saying why
+ *
+ * Every lookup `services/oxy/OxyDirectoryService.ts` makes is a PUBLIC Oxy
+ * route — `GET /profiles/username/:username`, `GET /users/:userId` and
+ * `GET /profiles/search` carry no authentication middleware, and
+ * `POST /users/by-ids` accepts an anonymous caller and answers with the same
+ * public payload it gives a service. So the directory works with nothing set
+ * here, and this file exists for what a credential changes rather than for what
+ * it enables:
+ *
+ * - `getUsersByIds` takes the server-to-server path (`Authorization: Bearer
+ *   <service token>`) instead of the anonymous one, which saves the
+ *   `GET /csrf-token` round trip the SDK otherwise makes before every
+ *   state-changing request without a bearer.
+ * - Oxy attributes the traffic to Allo rather than to a datacentre IP, which is
+ *   what its own rate limiting keys on.
+ *
+ * ## Provisioning is a human step and cannot be done from here
+ *
+ * A service credential is minted at `console.oxy.so` → Apps → Allo → Settings →
+ * Credentials, with type `Service`, by somebody holding `owner`, `admin` or
+ * `developer` on the account that owns the Allo application. The secret is
+ * shown exactly once. Oxy will only mint one for a TRUSTED application
+ * (`isTrustedApplication`: `isOfficial`, `isInternal`, or `type` one of
+ * `first_party` / `internal` / `system`); Allo is seeded `first_party`, so this
+ * should succeed, and a `403 Service credentials are only available to trusted
+ * applications` means the application row is not what the seed says it is —
+ * which only Oxy platform staff can put right.
+ *
+ * ## Both or neither
+ *
+ * A key without a secret is not half-configured, it is a call that throws at
+ * the first lookup. Refusing to boot is the only way that shows up before a
+ * user does.
+ */
+
+const emptyAsUndefined = (value: unknown): unknown =>
+  typeof value === "string" && value.trim().length === 0 ? undefined : value;
+
+/** Oxy application credential public keys are minted as `oxy_dk_<48 hex>`. */
+const apiKey = z
+  .string()
+  .trim()
+  .regex(/^oxy_dk_[0-9a-f]{8,}$/, "must be an Oxy application credential public key (oxy_dk_…)");
+
+/** The secret is 32 random bytes as hex. A credential: never logged. */
+const apiSecret = z.string().trim().min(32);
+
+function buildOxyServiceEnvSchema() {
+  return z
+    .object({
+      ALLO_OXY_SERVICE_API_KEY: z.preprocess(emptyAsUndefined, apiKey.optional()),
+      ALLO_OXY_SERVICE_API_SECRET: z.preprocess(emptyAsUndefined, apiSecret.optional()),
+    })
+    .superRefine((environment, context) => {
+      const hasKey = environment.ALLO_OXY_SERVICE_API_KEY !== undefined;
+      const hasSecret = environment.ALLO_OXY_SERVICE_API_SECRET !== undefined;
+      if (hasKey === hasSecret) return;
+
+      context.addIssue({
+        code: "custom",
+        path: [hasKey ? "ALLO_OXY_SERVICE_API_SECRET" : "ALLO_OXY_SERVICE_API_KEY"],
+        message:
+          "ALLO_OXY_SERVICE_API_KEY and ALLO_OXY_SERVICE_API_SECRET must be set together — a key " +
+          "without its secret is a service token that can never be minted, which shows up as every " +
+          "bulk profile lookup returning nothing",
+      });
+    });
+}
+
+export interface OxyServiceCredential {
+  readonly apiKey: string;
+  readonly apiSecret: string;
+}
+
+export function loadOxyServiceCredential(
+  environment: NodeJS.ProcessEnv = process.env,
+): OxyServiceCredential | undefined {
+  const parsed = buildOxyServiceEnvSchema().parse(environment);
+  if (
+    parsed.ALLO_OXY_SERVICE_API_KEY === undefined ||
+    parsed.ALLO_OXY_SERVICE_API_SECRET === undefined
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    apiKey: parsed.ALLO_OXY_SERVICE_API_KEY,
+    apiSecret: parsed.ALLO_OXY_SERVICE_API_SECRET,
+  });
+}
+
+/** The one method of the Oxy SDK this module touches. */
+export interface ServiceAuthConfigurable {
+  configureServiceAuth(apiKey: string, apiSecret: string): void;
+}
+
+/**
+ * Hands the credential to the SDK, if there is one. Returns whether it did.
+ *
+ * The log line names neither value — not even the public key, which identifies
+ * the credential to anybody who later has to be told it was rotated.
+ */
+export function configureOxyServiceAuth(
+  client: ServiceAuthConfigurable,
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const credential = loadOxyServiceCredential(environment);
+  if (credential === undefined) {
+    logger.info(
+      "[Oxy] no service credential configured — directory lookups will call Oxy anonymously, " +
+        "which every one of those routes allows",
+    );
+    return false;
+  }
+
+  client.configureServiceAuth(credential.apiKey, credential.apiSecret);
+  logger.info("[Oxy] service credential configured");
+  return true;
+}

--- a/packages/backend/src/middleware/matrixAuth.ts
+++ b/packages/backend/src/middleware/matrixAuth.ts
@@ -1,0 +1,292 @@
+import type { RequestHandler } from "express";
+import type { OxyAuthRequest } from "@oxyhq/core/server";
+
+import { matrixAuthConfig, type MatrixAuthConfig } from "../config/matrixAuth";
+import {
+  MasCredentialError,
+  MasProtocolError,
+  MasUnreachableError,
+} from "../services/auth/masIntrospection";
+import {
+  createMatrixTokenAuthenticator,
+  type MatrixTokenAuthenticator,
+} from "../services/auth/matrixTokenAuthenticator";
+import { logger } from "../utils/logger";
+
+/**
+ * Accepting a Matrix Authentication Service token where an Oxy token used to be
+ * the only option.
+ *
+ * ## How a request says which token it is carrying
+ *
+ * By the **HTTP authentication scheme**, and by nothing else:
+ *
+ *     Authorization: Bearer <oxy access token>            ← unchanged, the default
+ *     Authorization: MatrixBearer <MAS access token>      ← this middleware
+ *
+ * The alternative — one `Bearer` header and a side channel such as
+ * `X-Allo-Token-Issuer` saying which kind it is — was rejected for two reasons.
+ * The first is that a side header can be separated from the credential it
+ * describes: any proxy, CDN or client library that drops an unrecognised header
+ * turns a MAS request into an Oxy one, and the credential and its issuer must
+ * travel together or not at all. The second is that RFC 7235 already put the
+ * name of the authentication framework in front of the credentials, which is
+ * exactly this question, and inventing a second place to answer it means two
+ * places that can disagree.
+ *
+ * ## Why the two cannot be confused
+ *
+ * Three separate reasons, and each alone would be enough:
+ *
+ * 1. **The prefixes are disjoint.** `@oxyhq/core`'s `oxy.auth()` extracts a
+ *    token only from a header starting with the exact string `"Bearer "`; a
+ *    `MatrixBearer` header does not, so it is invisible to the Oxy validator —
+ *    a structural property of the composition, not a check anybody has to
+ *    remember to write. `__tests__/middleware/matrixAuth.test.ts` pins it.
+ * 2. **There is no fall-through.** A request that declares `MatrixBearer` is
+ *    answered by this middleware and never continues to the Oxy one, whatever
+ *    the outcome. A chain that tried the other validator after a refusal would
+ *    make every token's security the WEAKER of the two.
+ * 3. **Neither validator can be fooled by the other's token.** An Oxy token
+ *    presented as `MatrixBearer` is unknown to MAS, which answers
+ *    `active: false`. A MAS access token presented as `Bearer` is opaque, so
+ *    `jwtDecode` fails and `oxy.auth()` refuses it. Both are tested.
+ *
+ * So the scheme is client-controlled, and that is fine: it selects a validator,
+ * it never grants anything. Mis-declaring a token can only produce a 401.
+ *
+ * ## Why it produces the same `req.user` as the Oxy path
+ *
+ * `createOxyAuthMiddleware` short-circuits when a previous middleware has
+ * already resolved a user, so setting `req.userId` and `req.user` here is all
+ * that is needed for every existing route to work unchanged — none of them can
+ * tell which sign-in produced the request, and none of them should have to.
+ *
+ * ## What this does NOT cover
+ *
+ * The Socket.IO handshake. `server.ts` authenticates sockets with
+ * `oxy.authSocket()`, which is untouched, so a MAS token cannot open a
+ * websocket. That is not an oversight: the realtime namespace belongs to the
+ * legacy transport, and the Matrix path replaces it with `/sync` rather than
+ * authenticating into it.
+ *
+ * The per-user rate limiter is also untouched, and it runs BEFORE this
+ * middleware because `createOxyRateLimit` resolves its own session and
+ * overwrites `req.userId` with `null` when it finds no `Bearer` header. A
+ * MatrixBearer request is therefore counted against the anonymous per-IP
+ * bucket rather than a per-user one. Nothing sends MatrixBearer today, so
+ * nothing is affected yet; it has to be resolved in `@oxyhq/core` (by making
+ * the limiter's session resolution idempotent, which its own doc comment
+ * already claims it is) before the frontend switches over.
+ */
+
+/**
+ * The scheme. Compared case-insensitively, because RFC 7235 says schemes are
+ * case-insensitive and a client that sends `matrixbearer` is not attacking us.
+ */
+export const MATRIX_AUTH_SCHEME = "MatrixBearer";
+
+const MATRIX_AUTH_SCHEME_LOWERCASE = MATRIX_AUTH_SCHEME.toLowerCase();
+
+/** What the `Authorization` header of an incoming request turned out to be. */
+type PresentedCredential =
+  | { readonly kind: "other-scheme" }
+  | { readonly kind: "matrix"; readonly token: string }
+  | { readonly kind: "matrix-empty" };
+
+/**
+ * Reads the `Authorization` header, and decides only whether it is ours.
+ *
+ * `other-scheme` covers an absent header, a `Bearer` one, and anything else.
+ * All three mean the same thing here: not this middleware's business.
+ */
+export function readPresentedCredential(
+  rawHeader: string | string[] | undefined,
+): PresentedCredential {
+  /**
+   * Node allows a repeated header to arrive as an array. Only the first is
+   * considered — concatenating them, or searching them for one that parses,
+   * would let a request present two credentials and have the friendlier one
+   * chosen for it.
+   */
+  const header = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+  if (typeof header !== "string") return { kind: "other-scheme" };
+
+  /**
+   * The scheme ends at the first run of whitespace, or at the end of the header
+   * when it carries nothing else. Both are ours to answer: a bare
+   * `Authorization: MatrixBearer` is a client that meant to present a Matrix
+   * token and sent none, and letting it fall through to the Oxy validator would
+   * answer it with "Authentication required", which names the wrong problem.
+   */
+  const separator = header.search(/\s/);
+  const scheme = separator < 0 ? header : header.slice(0, separator);
+  if (scheme.toLowerCase() !== MATRIX_AUTH_SCHEME_LOWERCASE) return { kind: "other-scheme" };
+
+  const token = separator < 0 ? "" : header.slice(separator + 1).trim();
+  return token.length === 0 ? { kind: "matrix-empty" } : { kind: "matrix", token };
+}
+
+/** The one body a refused request gets, whatever the reason. */
+const UNAUTHORIZED_BODY = {
+  error: "INVALID_MATRIX_TOKEN",
+  message: "Matrix access token is not valid",
+  code: "INVALID_MATRIX_TOKEN",
+} as const;
+
+/**
+ * The one body an upstream failure gets.
+ *
+ * Deliberately the same for "MAS is down" and "MAS rejected OUR credentials",
+ * because a client can do nothing different about them and an unauthenticated
+ * caller has no business learning which of the two it is. The two are told
+ * apart in the log, at different severities, which is where the answer is
+ * actually needed.
+ */
+const UNAVAILABLE_BODY = {
+  error: "MATRIX_AUTH_UNAVAILABLE",
+  message: "Matrix authentication is temporarily unavailable",
+  code: "MATRIX_AUTH_UNAVAILABLE",
+} as const;
+
+/** How long a client is asked to wait after a 503. Seconds. */
+const RETRY_AFTER_SECONDS = 5;
+
+export interface MatrixAuthMiddlewareOptions {
+  readonly config?: MatrixAuthConfig;
+  readonly authenticator?: MatrixTokenAuthenticator;
+}
+
+export function createMatrixAuthMiddleware(
+  options: MatrixAuthMiddlewareOptions = {},
+): RequestHandler {
+  const config = options.config ?? matrixAuthConfig();
+
+  /**
+   * Built once, and only when the path is enabled: the authenticator owns the
+   * introspection cache, so one per process is what makes the cache worth
+   * having. A disabled deployment builds nothing.
+   */
+  const authenticator: MatrixTokenAuthenticator | undefined = config.enabled
+    ? (options.authenticator ?? createMatrixTokenAuthenticator({ config }))
+    : options.authenticator;
+
+  return (req, res, next) => {
+    const presented = readPresentedCredential(req.headers.authorization);
+
+    if (presented.kind === "other-scheme") {
+      next();
+      return;
+    }
+
+    if (!config.enabled || authenticator === undefined) {
+      /**
+       * The scheme was used against a deployment that accepts no MAS token.
+       * Refused rather than passed through: falling through would answer with
+       * the Oxy middleware's "Access token required", which points at the wrong
+       * problem and has sent people looking for a missing header that was
+       * present all along.
+       */
+      res.status(401).json({
+        error: "MATRIX_AUTH_NOT_CONFIGURED",
+        message: "This deployment does not accept Matrix access tokens",
+        code: "MATRIX_AUTH_NOT_CONFIGURED",
+      });
+      return;
+    }
+
+    if (presented.kind === "matrix-empty") {
+      res.status(401).json(UNAUTHORIZED_BODY);
+      return;
+    }
+
+    const resolvedAuthenticator = authenticator;
+
+    /**
+     * Started and deliberately not awaited: an Express handler is synchronous,
+     * and every path inside either answers the response or calls `next()`. The
+     * `void` says the floating promise is intentional rather than forgotten.
+     */
+    void authenticate(presented.token);
+    return;
+
+    async function authenticate(token: string): Promise<void> {
+      try {
+        const result = await resolvedAuthenticator.authenticate(token);
+
+        if (result.outcome === "refused") {
+          /**
+           * The reason is logged and the client is told nothing beyond "no".
+           * Which check refused a guess is a hint about how to make the next
+           * one better.
+           */
+          logger.warn("[MatrixAuth] access token refused", { reason: result.reason });
+          res.status(401).json(UNAUTHORIZED_BODY);
+          return;
+        }
+
+        /**
+         * The same two fields `oxy.auth()` sets, so `createOxyAuthMiddleware`
+         * downstream finds a resolved session and lets the request through
+         * without re-checking anything, and so no route can tell the two
+         * sign-ins apart.
+         *
+         * `accessToken` is deliberately NOT set. The Oxy path puts the Oxy
+         * bearer there for code that calls Oxy as the user; a MAS token is not
+         * an Oxy credential, and leaving the field empty makes any such caller
+         * fail visibly instead of sending the wrong token to the wrong service.
+         */
+        const authRequest: OxyAuthRequest = req;
+        authRequest.userId = result.oxyUserId;
+        authRequest.user = { id: result.oxyUserId };
+        next();
+      } catch (error) {
+        respondToUpstreamFailure(error);
+      }
+    }
+
+    function respondToUpstreamFailure(error: unknown): void {
+      if (error instanceof MasCredentialError) {
+        /**
+         * `error` and not `warn`: this is not a user's problem, it is this
+         * deployment's client id or secret being wrong, and while it lasts NO
+         * MAS token is accepted at all. The message names the variables; the
+         * secret itself is never in it.
+         */
+        logger.error("[MatrixAuth] MAS rejected this backend's introspection credentials", error);
+        res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+        res.status(503).json(UNAVAILABLE_BODY);
+        return;
+      }
+
+      if (error instanceof MasUnreachableError) {
+        logger.warn("[MatrixAuth] MAS unreachable", { reason: error.message });
+        res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+        res.status(503).json(UNAVAILABLE_BODY);
+        return;
+      }
+
+      if (error instanceof MasProtocolError) {
+        /**
+         * 502 rather than 503: MAS answered, and what it said was not RFC 7662.
+         * A different status because it is a different day's problem — an
+         * upgrade that changed a response shape, not an outage.
+         */
+        logger.error("[MatrixAuth] MAS returned an unusable introspection response", error);
+        res.status(502).json(UNAVAILABLE_BODY);
+        return;
+      }
+
+      /**
+       * Nothing else is expected, so nothing else is interpreted. A 500 that
+       * authenticates nobody is the correct outcome for a bug in this file.
+       */
+      logger.error("[MatrixAuth] unexpected failure while authenticating a Matrix token", error);
+      res.status(500).json({
+        error: "MATRIX_AUTH_INTERNAL_ERROR",
+        message: "Internal authentication error",
+        code: "MATRIX_AUTH_INTERNAL_ERROR",
+      });
+    }
+  };
+}

--- a/packages/backend/src/routes/directory.ts
+++ b/packages/backend/src/routes/directory.ts
@@ -1,0 +1,235 @@
+import { Router, type Response } from "express";
+import type { OxyAuthRequest } from "@oxyhq/core/server";
+import * as z from "zod";
+
+import { isOxyUserId } from "../services/bridges/matrixIdentity";
+import type { OxyDirectoryService } from "../services/oxy/OxyDirectoryService";
+import { sendErrorResponse, sendSuccessResponse } from "../utils/apiHelpers";
+import { getErrorMessage, isOxyUserNotFound } from "../utils/oxyUserDisplay";
+import { logger } from "../utils/logger";
+
+/**
+ * `GET /api/directory/*` — who somebody is, answered by this backend instead of
+ * by Oxy directly.
+ *
+ * See `services/oxy/OxyDirectoryService.ts` for why these five exist and why
+ * they need no service credential. This file is the boundary: it validates what
+ * arrives, maps an upstream failure onto a status, and never lets an Oxy `User`
+ * out unprojected.
+ *
+ * ## Authenticated, deliberately, even though Oxy answers anonymously
+ *
+ * Every underlying Oxy route is public, so these could be too. They are not,
+ * because a public profile lookup on `api.allo.you` would be an unauthenticated
+ * enumeration endpoint pointed at Oxy's whole user base with Allo's own IP
+ * reputation in front of it. Mounted inside the authenticated router, the
+ * per-user rate limiter has a user to key on and the caller is somebody.
+ *
+ * ## Why an id is refused rather than passed through
+ *
+ * `GET /users/:userId` on Oxy also accepts a public key, and `resolveUserId`
+ * there maps it. Allo has never had one: every id it holds is a 24-character
+ * ObjectId, and it is the SAME shape the Matrix authentication boundary
+ * requires of an MXID localpart — so it is checked with the same function,
+ * `isOxyUserId`, rather than with a second regular expression that could come
+ * to a different conclusion.
+ */
+
+/** Oxy handles. Bounded, and without the `@` — see `lib/profile/handle.ts`. */
+const usernameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[A-Za-z0-9._-]+$/,
+    "must be a bare handle: letters, digits, dot, underscore and hyphen, and no leading @",
+  );
+
+const oxyUserIdSchema = z
+  .string()
+  .trim()
+  .refine(isOxyUserId, "must be a 24-character hexadecimal Oxy account id");
+
+/**
+ * The same ceiling `@oxyhq/core` chunks at, so one request here is one request
+ * upstream. Asking for more would not fail — it would quietly become several
+ * upstream calls, of which one can drop out.
+ */
+const MAX_USERS_BY_IDS = 100;
+
+const usersByIdsSchema = z.object({
+  ids: z.array(oxyUserIdSchema).min(1).max(MAX_USERS_BY_IDS),
+});
+
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 50;
+
+const searchSchema = z.object({
+  query: z.string().trim().min(1).max(100),
+  limit: z.coerce.number().int().min(1).max(MAX_SEARCH_LIMIT).default(DEFAULT_SEARCH_LIMIT),
+  offset: z.coerce.number().int().min(0).max(10_000).default(0),
+});
+
+/**
+ * An Oxy asset id, bounded and with no path characters in it.
+ *
+ * The id is interpolated into a CDN URL. `@oxyhq/core` percent-encodes it, so
+ * this is not the thing standing between us and a traversal — it is what stops
+ * this endpoint from minting a URL for any string a caller invents, which is
+ * how an avatar endpoint becomes an open redirect generator.
+ */
+const fileIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/, "must be an Oxy asset id");
+
+const variantSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(32)
+  .regex(/^[a-z0-9_-]+$/, "must be an asset variant name")
+  .optional();
+
+export interface DirectoryRoutesOptions {
+  readonly service: OxyDirectoryService;
+}
+
+/** The first zod issue, as a message. Field paths only, never values. */
+function firstIssue(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (issue === undefined) return "invalid request";
+  const path = issue.path.join(".");
+  return path.length > 0 ? `${path}: ${issue.message}` : issue.message;
+}
+
+/**
+ * Turns an Oxy SDK failure into a status.
+ *
+ * A 404 upstream is a 404 here. Everything else is 502: the request was fine,
+ * the dependency was not, and answering 500 would send the operator looking in
+ * this codebase for a fault that is not in it.
+ */
+function respondToUpstreamFailure(res: Response, operation: string, error: unknown): Response {
+  if (isOxyUserNotFound(error)) {
+    return sendErrorResponse(res, 404, "Not Found", "No such account");
+  }
+  logger.error(`[Directory] ${operation} failed`, {
+    reason: getErrorMessage(error) ?? "unknown",
+  });
+  return sendErrorResponse(res, 502, "Bad Gateway", "The directory is temporarily unavailable");
+}
+
+export function createDirectoryRoutes(options: DirectoryRoutesOptions): Router {
+  const router = Router();
+  const { service } = options;
+
+  /** `GET /api/directory/profiles/username/:username` — a profile by handle. */
+  router.get("/profiles/username/:username", async (req: OxyAuthRequest, res: Response) => {
+    const parsed = usernameSchema.safeParse(req.params.username);
+    if (!parsed.success) {
+      return sendErrorResponse(res, 400, "Bad Request", firstIssue(parsed.error));
+    }
+
+    try {
+      return sendSuccessResponse(res, 200, await service.profileByUsername(parsed.data));
+    } catch (error) {
+      return respondToUpstreamFailure(res, "profileByUsername", error);
+    }
+  });
+
+  /**
+   * `GET /api/directory/profiles/search?query=&limit=&offset=`
+   *
+   * Declared before `/users/:userId` has no bearing here — the paths do not
+   * overlap — but it IS declared before the by-ids route below, which shares
+   * the `/users` prefix and would otherwise be shadowed by `:userId`.
+   */
+  router.get("/profiles/search", async (req: OxyAuthRequest, res: Response) => {
+    const parsed = searchSchema.safeParse(req.query);
+    if (!parsed.success) {
+      return sendErrorResponse(res, 400, "Bad Request", firstIssue(parsed.error));
+    }
+
+    try {
+      const { query, limit, offset } = parsed.data;
+      const result = await service.searchProfiles(query, { limit, offset });
+      return sendSuccessResponse(res, 200, result);
+    } catch (error) {
+      return respondToUpstreamFailure(res, "searchProfiles", error);
+    }
+  });
+
+  /**
+   * `POST /api/directory/users/by-ids` — several accounts in one call.
+   *
+   * A POST for a read, because the body is up to a hundred ids and a query
+   * string that long is at the mercy of every proxy between here and the
+   * client. It matches the shape of Oxy's own `POST /users/by-ids`.
+   *
+   * Declared BEFORE `/users/:userId` so that `by-ids` is not captured as an id.
+   * It would be refused as a malformed id rather than mis-served, but the 400
+   * would name the wrong problem.
+   */
+  router.post("/users/by-ids", async (req: OxyAuthRequest, res: Response) => {
+    const parsed = usersByIdsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendErrorResponse(res, 400, "Bad Request", firstIssue(parsed.error));
+    }
+
+    try {
+      const users = await service.usersByIds(parsed.data.ids);
+      /**
+       * Fewer users than ids is normal and is not an error: an id can name a
+       * deleted account. The caller maps by `id` — nothing is padded out with a
+       * placeholder, because a placeholder is indistinguishable from an answer.
+       */
+      return sendSuccessResponse(res, 200, { users });
+    } catch (error) {
+      return respondToUpstreamFailure(res, "usersByIds", error);
+    }
+  });
+
+  /** `GET /api/directory/users/:userId` — one account by id. */
+  router.get("/users/:userId", async (req: OxyAuthRequest, res: Response) => {
+    const parsed = oxyUserIdSchema.safeParse(req.params.userId);
+    if (!parsed.success) {
+      return sendErrorResponse(res, 400, "Bad Request", firstIssue(parsed.error));
+    }
+
+    try {
+      return sendSuccessResponse(res, 200, await service.userById(parsed.data));
+    } catch (error) {
+      return respondToUpstreamFailure(res, "userById", error);
+    }
+  });
+
+  /**
+   * `GET /api/directory/assets/:fileId/url?variant=` — an avatar's address.
+   *
+   * The only one of the five that reaches nothing: `getFileDownloadUrl` is a
+   * pure string builder over the Oxy CDN origin. It exists as an endpoint
+   * anyway because an app with no Oxy SDK does not know that origin. Most
+   * avatars should never need it — every {@link DirectoryUser} this router
+   * returns already carries `avatarUrl` — and it is here for the id that
+   * arrives from somewhere other than a directory lookup.
+   */
+  router.get("/assets/:fileId/url", (req: OxyAuthRequest, res: Response) => {
+    const fileId = fileIdSchema.safeParse(req.params.fileId);
+    if (!fileId.success) {
+      return sendErrorResponse(res, 400, "Bad Request", firstIssue(fileId.error));
+    }
+
+    const variant = variantSchema.safeParse(req.query.variant);
+    if (!variant.success) {
+      return sendErrorResponse(res, 400, "Bad Request", firstIssue(variant.error));
+    }
+
+    return sendSuccessResponse(res, 200, { url: service.assetUrl(fileId.data, variant.data) });
+  });
+
+  return router;
+}

--- a/packages/backend/src/services/auth/masIntrospection.ts
+++ b/packages/backend/src/services/auth/masIntrospection.ts
@@ -1,0 +1,204 @@
+import * as z from "zod";
+
+import type { MatrixAuthConfig } from "../../config/matrixAuth";
+
+/**
+ * Asking Matrix Authentication Service whether an access token is still live.
+ *
+ * RFC 7662 token introspection, and nothing more: this module makes the call,
+ * refuses to believe an answer it cannot parse, and hands the result to
+ * `matrixTokenAuthenticator.ts`, which decides what the answer MEANS. The split
+ * is deliberate — one module that can be tested against a fake HTTP layer, and
+ * one that can be tested with no HTTP layer at all.
+ *
+ * ## A MAS access token is opaque
+ *
+ * It is not a JWT. There is no signature to check locally and no claim to read,
+ * so there is no fast path: the only way to learn anything about the token is to
+ * ask the server that minted it. That is why the caching in
+ * `matrixTokenAuthenticator.ts` is not an optimisation but a requirement.
+ *
+ * ## Nothing here is ever logged
+ *
+ * Not the token, not the response, not the client secret. An introspection
+ * response names a user, a device and a scope, so a log line carrying one is a
+ * session log with a credential attached to it. Callers get a typed error whose
+ * message says what kind of failure it was and nothing about who it happened to.
+ */
+
+/**
+ * An introspection answer, as far as this module is willing to parse it.
+ *
+ * Only `active` is required, which is RFC 7662's own rule: a response for an
+ * unknown or revoked token is `{"active": false}` and carries nothing else.
+ * Every other field is validated if present and dropped if not — `passthrough`
+ * is deliberately not used, so a field MAS adds later cannot reach a decision
+ * without somebody adding it here on purpose.
+ */
+const introspectionResponseSchema = z.object({
+  active: z.boolean(),
+  scope: z.string().optional(),
+  client_id: z.string().optional(),
+  username: z.string().optional(),
+  token_type: z.string().optional(),
+  exp: z.number().int().optional(),
+  iat: z.number().int().optional(),
+  nbf: z.number().int().optional(),
+  sub: z.string().optional(),
+  aud: z.union([z.string(), z.array(z.string())]).optional(),
+  iss: z.string().optional(),
+  jti: z.string().optional(),
+  device_id: z.string().optional(),
+});
+
+export type MasIntrospectionResponse = z.infer<typeof introspectionResponseSchema>;
+
+/**
+ * MAS could not be reached, or did not answer in time, or answered 5xx.
+ *
+ * Distinct from every other failure because it says nothing at all about the
+ * token. Treating it as "invalid token" would sign every user out of every
+ * device the moment MAS restarts, so the middleware answers 503 for this one
+ * and 401 for the rest.
+ */
+export class MasUnreachableError extends Error {
+  constructor(reason: string) {
+    super(`Matrix Authentication Service could not be reached: ${reason}`);
+    this.name = "MasUnreachableError";
+  }
+}
+
+/**
+ * MAS refused OUR credentials, or refused the request itself.
+ *
+ * A 401 or 403 here is this backend's client id and secret being wrong, not the
+ * user's token — MAS answers an unknown token with `200 {"active": false}`. The
+ * distinction is the difference between one user re-authenticating and every
+ * user being signed out by a bad deploy, so it gets its own error and its own
+ * loud log at the point of use.
+ */
+export class MasCredentialError extends Error {
+  constructor(readonly status: number) {
+    super(
+      `Matrix Authentication Service rejected this backend's introspection credentials (HTTP ${status}). ` +
+        "Check ALLO_MAS_INTROSPECTION_CLIENT_ID and ALLO_MAS_INTROSPECTION_CLIENT_SECRET, and that the " +
+        "client is allowed to introspect on the MAS side",
+    );
+    this.name = "MasCredentialError";
+  }
+}
+
+/** MAS answered, but not with something RFC 7662 describes. */
+export class MasProtocolError extends Error {
+  constructor(reason: string) {
+    super(`Matrix Authentication Service returned an unusable introspection response: ${reason}`);
+    this.name = "MasProtocolError";
+  }
+}
+
+/**
+ * The slice of `fetch` this module uses.
+ *
+ * Narrowed to a function type rather than taken from the global so a test can
+ * supply one without touching `globalThis`, and so the compiler checks the two
+ * arguments that matter at every call site.
+ */
+export type HttpFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+/**
+ * `client_secret_basic`, encoded the way RFC 6749 §2.3.1 requires.
+ *
+ * The id and the secret are form-urlencoded BEFORE they are joined with a colon
+ * and base64'd. Skipping that step works right up until a secret contains a
+ * colon or a non-ASCII character, at which point every introspection fails with
+ * a 401 that reads as "wrong secret" — which it is not.
+ */
+function basicAuthorization(clientId: string, clientSecret: string): string {
+  const encoded = `${formUrlEncode(clientId)}:${formUrlEncode(clientSecret)}`;
+  return `Basic ${Buffer.from(encoded, "utf8").toString("base64")}`;
+}
+
+function formUrlEncode(value: string): string {
+  const prefix = "v=";
+  return new URLSearchParams({ v: value }).toString().slice(prefix.length);
+}
+
+/**
+ * One introspection round trip. No caching, no interpretation, no retry.
+ *
+ * No retry on purpose: this sits inside a user's request, a retry would double
+ * the latency of an outage rather than hide it, and the caller already has the
+ * right answer for a failed call — refuse, and let the client try again.
+ */
+export async function introspectAccessToken(
+  token: string,
+  config: MatrixAuthConfig,
+  httpFetch: HttpFetch = globalThis.fetch,
+): Promise<MasIntrospectionResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  let response: Response;
+  try {
+    response = await httpFetch(config.introspectionUrl, {
+      method: "POST",
+      headers: {
+        authorization: basicAuthorization(config.clientId, config.clientSecret),
+        "content-type": "application/x-www-form-urlencoded",
+        accept: "application/json",
+      },
+      body: new URLSearchParams({
+        token,
+        token_type_hint: "access_token",
+      }).toString(),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    /**
+     * The caught error is named by its class and never by its message. A fetch
+     * failure's text can carry the request, and the request body is the user's
+     * access token.
+     */
+    throw new MasUnreachableError(error instanceof Error ? error.name : "request failed");
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new MasCredentialError(response.status);
+  }
+  if (!response.ok) {
+    throw new MasUnreachableError(`HTTP ${response.status}`);
+  }
+
+  let rawBody: string;
+  try {
+    rawBody = await response.text();
+  } catch (error) {
+    throw new MasUnreachableError(
+      `response body could not be read (${error instanceof Error ? error.name : "unknown"})`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    throw new MasProtocolError("the body was not JSON");
+  }
+
+  const parsed = introspectionResponseSchema.safeParse(payload);
+  if (!parsed.success) {
+    /**
+     * Only the field paths and zod's own messages, never the values. An
+     * introspection body names a user and a device even when it is malformed.
+     */
+    throw new MasProtocolError(
+      parsed.error.issues
+        .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; "),
+    );
+  }
+
+  return parsed.data;
+}

--- a/packages/backend/src/services/auth/matrixTokenAuthenticator.ts
+++ b/packages/backend/src/services/auth/matrixTokenAuthenticator.ts
@@ -1,0 +1,357 @@
+import { createHash } from "crypto";
+
+import { matrixAuthConfig, type MatrixAuthConfig } from "../../config/matrixAuth";
+import {
+  MatrixIdentityError,
+  oxyAccountIdFromMatrixUserId,
+  oxyUserIdFromMatrixLocalpart,
+} from "../bridges/matrixIdentity";
+import {
+  introspectAccessToken,
+  type HttpFetch,
+  type MasIntrospectionResponse,
+} from "./masIntrospection";
+
+/**
+ * Turning a Matrix Authentication Service access token into the Oxy account it
+ * names, or into the reason it names none.
+ *
+ * `masIntrospection.ts` asks the question. This module decides what the answer
+ * means, and remembers it for a bounded moment.
+ *
+ * ## Every refusal has its own name
+ *
+ * Not for the client's benefit — the middleware collapses them all into one 401
+ * body, because telling a caller WHY their token was refused tells an attacker
+ * which of their guesses was closest. They are named for the operator's: eight
+ * distinguishable reasons in a log line and in a test, so that "nobody can sign
+ * in" can be diagnosed without a debugger, and so that each refusal has a test
+ * that fails if the check that produces it is removed.
+ *
+ * ## What is checked beyond `active`
+ *
+ * `active: true` alone means "this string is a live credential at this
+ * issuer" — not "this is an Allo user's Matrix session". The gap between those
+ * two is where the interesting attacks live, so:
+ *
+ * - **Token type.** A REFRESH token introspects as active. Accepting one as a
+ *   bearer credential would make a long-lived token that is only ever meant to
+ *   be exchanged at the token endpoint into an API credential.
+ * - **Scope.** See {@link MatrixAuthConfig.acceptedScopes}: this is the audience
+ *   check for an opaque token, and it is what refuses a MAS admin token or a
+ *   bare `openid` token from another client of the same issuer.
+ * - **Issuer and audience**, whenever the response carries them. MAS does not
+ *   send either — the binding to the issuer is that we only ever ASK the
+ *   issuer, enforced at boot by `config/matrixAuth.ts` — but a response that
+ *   does carry them and disagrees is refused rather than ignored.
+ * - **The subject is an Oxy account.** `docs/matrix/data-model.md` §6.2 makes
+ *   the MXID localpart the Oxy account id, so this direction is string
+ *   arithmetic — and it is the direction that has to refuse rather than repair,
+ *   because a localpart accepted here is a request authenticated as that
+ *   account. A bridge ghost is not a person on this platform.
+ */
+
+/** Why a token was refused. Never sent to a client; logged and tested. */
+export type MatrixTokenRefusalReason =
+  | "inactive"
+  | "not-yet-valid"
+  | "expired"
+  | "wrong-token-type"
+  | "wrong-issuer"
+  | "wrong-audience"
+  | "missing-scope"
+  | "client-not-allowed"
+  | "no-subject"
+  | "not-an-oxy-account";
+
+export interface MatrixTokenAccepted {
+  readonly outcome: "accepted";
+  /** The Oxy account id, in the shape every route already expects. */
+  readonly oxyUserId: string;
+  /** The Matrix device the token was issued to, when MAS reports one. */
+  readonly deviceId: string | undefined;
+}
+
+export interface MatrixTokenRefused {
+  readonly outcome: "refused";
+  readonly reason: MatrixTokenRefusalReason;
+}
+
+export type MatrixTokenResult = MatrixTokenAccepted | MatrixTokenRefused;
+
+export interface MatrixTokenAuthenticator {
+  /**
+   * Resolves to the account the token names, or to the reason it names none.
+   *
+   * THROWS — rather than resolving to a refusal — when the failure says nothing
+   * about the token: MAS unreachable, MAS rejecting this backend's own
+   * credentials, MAS answering something unparseable. See the error classes in
+   * `masIntrospection.ts` for why those must not collapse into "invalid token".
+   */
+  authenticate(token: string): Promise<MatrixTokenResult>;
+}
+
+/**
+ * How many distinct tokens may be remembered at once.
+ *
+ * A cache keyed by an attacker-supplied string is a memory-exhaustion primitive
+ * unless it is bounded: a spray of ten million invented tokens would otherwise
+ * be ten million entries. Ten thousand is far more than the concurrent devices
+ * one instance serves inside a 30-second window, and eviction is oldest-first.
+ */
+const MAX_CACHE_ENTRIES = 10_000;
+
+/**
+ * How long a REFUSAL is remembered, at most.
+ *
+ * Shorter than the positive window, and separate from it, because the two have
+ * opposite risks. A stale acceptance is a revoked token that still works; a
+ * stale refusal is a valid token that does not, which the user cannot clear by
+ * retrying. Five seconds is enough to blunt a spray of one guessed token
+ * against MAS and short enough that no legitimate client notices it.
+ */
+const NEGATIVE_CACHE_SECONDS = 5;
+
+interface CacheEntry {
+  readonly expiresAtMs: number;
+  readonly result: MatrixTokenResult;
+}
+
+export interface MatrixTokenAuthenticatorOptions {
+  readonly config?: MatrixAuthConfig;
+  readonly httpFetch?: HttpFetch;
+  /** Injectable clock. `Date.now`, except in the tests that pin the cache. */
+  readonly now?: () => number;
+}
+
+/**
+ * The cache key.
+ *
+ * SHA-256 of the token, so that a heap dump, a debugger or an accidental
+ * iteration over the map cannot yield a working credential. The digest is never
+ * logged either — it is a stable identifier for one session, which is exactly
+ * the kind of thing that turns an operational log into a tracking log.
+ */
+function cacheKeyFor(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+/** RFC 8414 issuers differ only by a trailing slash far too often to care. */
+function normalizeIssuer(issuer: string): string {
+  return issuer.endsWith("/") ? issuer.slice(0, -1) : issuer;
+}
+
+/**
+ * Whether the introspected token is an ACCESS token.
+ *
+ * RFC 7662 makes `token_type` optional, and an absent one is not evidence of
+ * anything, so it is accepted. A present one that says something else is
+ * refused: MAS spells an access token `access_token` and RFC 6750 spells the
+ * same thing `Bearer`, and both are the same claim about the same token.
+ */
+function isAccessTokenType(tokenType: string | undefined): boolean {
+  if (tokenType === undefined) return true;
+  const normalized = tokenType.trim().toLowerCase();
+  return normalized === "bearer" || normalized === "access_token";
+}
+
+/** Whether the token's scope contains at least one scope we accept. */
+function hasAcceptedScope(scope: string | undefined, accepted: readonly string[]): boolean {
+  if (scope === undefined) return false;
+  const granted = new Set(scope.split(/\s+/).filter((entry) => entry.length > 0));
+  return accepted.some((candidate) => granted.has(candidate));
+}
+
+function audienceContains(audience: string | readonly string[], expected: string): boolean {
+  return typeof audience === "string" ? audience === expected : audience.includes(expected);
+}
+
+/**
+ * The Oxy account the response names.
+ *
+ * `username` and nothing else, deliberately. MAS reports the Matrix localpart
+ * there, and §6.2 makes the localpart the Oxy account id; `sub` is MAS's own
+ * internal subject, which is a different namespace and is not an Oxy id. A
+ * fallback from one to the other would be an authentication boundary guessing
+ * which namespace it is in, and getting that wrong once is an account takeover.
+ *
+ * A `username` that already carries the `@` sigil is treated as a full MXID and
+ * has to belong to OUR homeserver, which is one more thing that cannot be true
+ * by accident.
+ */
+function oxyAccountFor(response: MasIntrospectionResponse): string | undefined {
+  const username = response.username?.trim();
+  if (username === undefined || username.length === 0) return undefined;
+
+  if (!username.startsWith("@")) {
+    return oxyUserIdFromMatrixLocalpart(username);
+  }
+
+  try {
+    return oxyAccountIdFromMatrixUserId(username);
+  } catch (error) {
+    /**
+     * Only `MatrixIdentityError`, which is "ALLO_MATRIX_SERVER_NAME is not
+     * configured, so no MXID can be judged". Refusing is the only answer
+     * available: without a server name there is no way to tell our homeserver's
+     * users from anybody else's. Anything else rethrows, because an unexpected
+     * error inside an authentication decision must not read as a refusal.
+     */
+    if (error instanceof MatrixIdentityError) return undefined;
+    throw error;
+  }
+}
+
+/** Applies every rule to one introspection response. Pure; no I/O, no cache. */
+export function evaluateIntrospection(
+  response: MasIntrospectionResponse,
+  config: MatrixAuthConfig,
+  nowSeconds: number,
+): MatrixTokenResult {
+  if (!response.active) {
+    return { outcome: "refused", reason: "inactive" };
+  }
+  if (!isAccessTokenType(response.token_type)) {
+    return { outcome: "refused", reason: "wrong-token-type" };
+  }
+  if (response.nbf !== undefined && nowSeconds < response.nbf) {
+    return { outcome: "refused", reason: "not-yet-valid" };
+  }
+  /**
+   * `<=` and not `<`: a token is dead at the second it expires. MAS would
+   * normally have answered `active: false` already, so reaching this means a
+   * clock disagreement between MAS and this process, and the safe direction of
+   * a disagreement about expiry is to expire.
+   */
+  if (response.exp !== undefined && response.exp <= nowSeconds) {
+    return { outcome: "refused", reason: "expired" };
+  }
+  if (
+    response.iss !== undefined &&
+    normalizeIssuer(response.iss) !== normalizeIssuer(config.issuer)
+  ) {
+    return { outcome: "refused", reason: "wrong-issuer" };
+  }
+  if (config.expectedAudience !== undefined) {
+    if (response.aud === undefined || !audienceContains(response.aud, config.expectedAudience)) {
+      return { outcome: "refused", reason: "wrong-audience" };
+    }
+  }
+  if (!hasAcceptedScope(response.scope, config.acceptedScopes)) {
+    return { outcome: "refused", reason: "missing-scope" };
+  }
+  if (config.allowedClientIds.length > 0) {
+    if (response.client_id === undefined || !config.allowedClientIds.includes(response.client_id)) {
+      return { outcome: "refused", reason: "client-not-allowed" };
+    }
+  }
+
+  const username = response.username?.trim();
+  if (username === undefined || username.length === 0) {
+    return { outcome: "refused", reason: "no-subject" };
+  }
+
+  const oxyUserId = oxyAccountFor(response);
+  if (oxyUserId === undefined) {
+    return { outcome: "refused", reason: "not-an-oxy-account" };
+  }
+
+  return { outcome: "accepted", oxyUserId, deviceId: response.device_id };
+}
+
+/**
+ * How long this result may be reused, in milliseconds. Zero means "do not
+ * cache", which is what an already-expired token gets.
+ */
+function cacheWindowMs(
+  result: MatrixTokenResult,
+  response: MasIntrospectionResponse,
+  config: MatrixAuthConfig,
+  nowMs: number,
+): number {
+  if (result.outcome === "refused") {
+    return Math.min(config.cacheSeconds, NEGATIVE_CACHE_SECONDS) * 1000;
+  }
+
+  const ceilingMs = config.cacheSeconds * 1000;
+  if (response.exp === undefined) return ceilingMs;
+
+  /**
+   * `exp` is a ceiling on top of the configured ceiling, never an extension of
+   * it: a token with fifty minutes left is still re-checked every 30 seconds,
+   * and a token with four seconds left is cached for four. Without the second
+   * half of that, the cache would keep serving a token past its own expiry.
+   */
+  const untilExpiryMs = response.exp * 1000 - nowMs;
+  return Math.max(0, Math.min(ceilingMs, untilExpiryMs));
+}
+
+export function createMatrixTokenAuthenticator(
+  options: MatrixTokenAuthenticatorOptions = {},
+): MatrixTokenAuthenticator {
+  const config = options.config ?? matrixAuthConfig();
+  const now = options.now ?? Date.now;
+  const httpFetch = options.httpFetch;
+
+  const cache = new Map<string, CacheEntry>();
+  /**
+   * One introspection per token per burst.
+   *
+   * Opening a screen fires several API calls at once, and without this each of
+   * them would be its own round trip to MAS for the same answer. Callers that
+   * arrive while one is in flight await the same promise. A rejected promise is
+   * shared too, and that is correct: an outage should not become N retries.
+   */
+  const inFlight = new Map<string, Promise<MatrixTokenResult>>();
+
+  function remember(key: string, result: MatrixTokenResult, windowMs: number): void {
+    if (windowMs <= 0) return;
+    /**
+     * Insertion order is eviction order. `Map` iterates in insertion order and
+     * an entry is never re-inserted while it is live, so the first key is the
+     * oldest — which is the one whose answer is closest to being re-asked
+     * anyway.
+     */
+    while (cache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = cache.keys().next();
+      if (oldest.done === true) break;
+      cache.delete(oldest.value);
+    }
+    cache.set(key, { expiresAtMs: now() + windowMs, result });
+  }
+
+  return {
+    async authenticate(token: string): Promise<MatrixTokenResult> {
+      const key = cacheKeyFor(token);
+
+      const cached = cache.get(key);
+      if (cached !== undefined) {
+        if (cached.expiresAtMs > now()) return cached.result;
+        cache.delete(key);
+      }
+
+      const pending = inFlight.get(key);
+      if (pending !== undefined) return await pending;
+
+      const request = (async (): Promise<MatrixTokenResult> => {
+        const response = await introspectAccessToken(token, config, httpFetch);
+        const nowMs = now();
+        const result = evaluateIntrospection(response, config, Math.floor(nowMs / 1000));
+        remember(key, result, cacheWindowMs(result, response, config, nowMs));
+        return result;
+      })();
+
+      inFlight.set(key, request);
+      try {
+        return await request;
+      } finally {
+        /**
+         * Cleared whether the call succeeded or threw. A failed introspection is
+         * deliberately not cached at all — MAS being down is not evidence about
+         * a token — so the next request must be free to ask again.
+         */
+        inFlight.delete(key);
+      }
+    },
+  };
+}

--- a/packages/backend/src/services/bridges/matrixIdentity.ts
+++ b/packages/backend/src/services/bridges/matrixIdentity.ts
@@ -30,6 +30,73 @@ import { bridgesConfig } from "../../config/bridges";
 const LOCALPART_PATTERN = /^[a-z0-9._=/+-]+$/;
 
 /**
+ * The grammar of an Oxy account id: a 24-character lowercase hexadecimal
+ * MongoDB ObjectId.
+ *
+ * Separate from {@link LOCALPART_PATTERN} because they answer different
+ * questions, and conflating them is the bug this constant exists to prevent.
+ * `LOCALPART_PATTERN` asks "could a homeserver hold this string?" — to which
+ * `whatsapp_447700900000` and `telegrambot` both answer yes. This one asks "is
+ * this an account on Allo?", to which they answer no: nobody behind a bridge
+ * ghost ever signed up, and there is no Oxy user whose id that is.
+ */
+const OXY_USER_ID_PATTERN = /^[0-9a-f]{24}$/;
+
+/**
+ * Whether a string is an Oxy account id.
+ *
+ * The single place the shape is written down, so that the authentication
+ * boundary in `middleware/matrixAuth.ts` and the moderation and bridge paths
+ * cannot come to different conclusions about the same string.
+ */
+export function isOxyUserId(candidate: string): boolean {
+  return OXY_USER_ID_PATTERN.test(candidate);
+}
+
+/**
+ * The Oxy account named by a Matrix localpart, or `undefined` for a localpart
+ * that names no Oxy account.
+ *
+ * This is the direction that has to REFUSE rather than repair. Coming the other
+ * way, {@link matrixUserIdForOxyUser} refuses an id it cannot express because
+ * two ids mangled into one localpart would provision one user's bridge account
+ * for another. Coming this way the same mistake is larger: a localpart accepted
+ * as an account id is a request AUTHENTICATED AS that account. A bridge ghost's
+ * `whatsapp_447700900000` is not a person on this platform, and neither is the
+ * bridge's own `whatsappbot`; the hexadecimal grammar refuses both, along with
+ * every other localpart a homeserver might legally hold.
+ *
+ * Note that {@link oxyUserIdFromMatrixUserId} deliberately does NOT apply this
+ * check. Its caller in `services/moderation/subjectIdentity.ts` needs the raw
+ * localpart precisely so it can recognise a bridge ghost and say which network
+ * it came from, and a refusal there would replace a specific, useful reason
+ * with "this homeserver does not own that identifier", which is false.
+ */
+export function oxyUserIdFromMatrixLocalpart(localpart: string): string | undefined {
+  if (!LOCALPART_PATTERN.test(localpart)) return undefined;
+  if (!isOxyUserId(localpart)) return undefined;
+  return localpart;
+}
+
+/**
+ * The Oxy account named by a full Matrix user id, or `undefined`.
+ *
+ * {@link oxyUserIdFromMatrixUserId} composed with
+ * {@link oxyUserIdFromMatrixLocalpart}: this homeserver must own the identifier
+ * AND the localpart must be an Oxy account id. Use this wherever the answer
+ * decides what somebody is allowed to do; use the looser pair where the answer
+ * only decides what to tell them.
+ */
+export function oxyAccountIdFromMatrixUserId(
+  matrixUserId: string,
+  serverName: string = requireMatrixServerName(),
+): string | undefined {
+  const localpart = oxyUserIdFromMatrixUserId(matrixUserId, serverName);
+  if (localpart === undefined) return undefined;
+  return oxyUserIdFromMatrixLocalpart(localpart);
+}
+
+/**
  * Matrix user ids are capped at 255 bytes including the sigil and server name,
  * so the localpart budget depends on the server name's length.
  */

--- a/packages/backend/src/services/oxy/OxyDirectoryService.ts
+++ b/packages/backend/src/services/oxy/OxyDirectoryService.ts
@@ -1,0 +1,148 @@
+import type { DirectoryUser } from "@allo/shared-types";
+import type { SearchProfilesResponse, User } from "@oxyhq/core";
+
+/**
+ * The five Oxy lookups the app makes today, moved behind this backend.
+ *
+ * ## Why they move at all
+ *
+ * Allo is collapsing to one sign-in. Once the app authenticates only through
+ * Matrix Authentication Service it holds no Oxy session, so an Oxy SDK call
+ * from a screen has nothing to authenticate with — and the app should not carry
+ * a second identity provider's client just to draw an avatar. These five are
+ * the whole of what it asks Oxy for: `getProfileByUsername` (6 call sites),
+ * `getUserById` (5), `getUsersByIds` (2), `searchProfiles` (2) and
+ * `getFileDownloadUrl` (15, all avatars).
+ *
+ * **The app still calls Oxy directly today.** This is the surface it moves to,
+ * built and tested before anything depends on it.
+ *
+ * ## Why no service credential is required
+ *
+ * All five underlying Oxy routes are public. `GET /profiles/username/:username`,
+ * `GET /users/:userId` and `GET /profiles/search` carry no auth middleware at
+ * all; `POST /users/by-ids` is `optionalUserOrServiceAuth` and returns the same
+ * public payload to an anonymous caller; and an avatar URL is a pure string
+ * built against the Oxy CDN with no network call in it. So this service works
+ * with no provisioning step, and configuring a service credential
+ * (`config/oxyService.ts`) only changes HOW the by-ids call authenticates, not
+ * whether it works.
+ *
+ * ## Why it projects instead of forwarding
+ *
+ * See `@allo/shared-types`' `directory.ts`. The Oxy `User` carries `email`,
+ * `phone`, `address` and `birthday`; this backend asks Oxy AS ITSELF, so
+ * whatever it forwards, it forwards to every signed-in user. {@link toDirectoryUser}
+ * is the only way a user leaves this module, and it names its fields
+ * one at a time.
+ */
+
+/**
+ * What this service needs of the Oxy SDK, and no more.
+ *
+ * A structural type rather than `OxyServices`: the real client satisfies it, a
+ * test can satisfy it in ten lines, and the compiler still checks every call.
+ */
+export interface OxyDirectoryClient {
+  getProfileByUsername(username: string, options?: { cache?: boolean }): Promise<User>;
+  getUserById(userId: string, options?: { cache?: boolean }): Promise<User>;
+  getUsersByIds(ids: string[]): Promise<User[]>;
+  searchProfiles(
+    query: string,
+    pagination?: { limit?: number; offset?: number },
+  ): Promise<SearchProfilesResponse>;
+  getFileDownloadUrl(fileId: string, variant?: string, expiresIn?: number): string;
+}
+
+/**
+ * The avatar size every Allo surface asks for.
+ *
+ * One constant because every one of the fifteen call sites in the app passes
+ * `'thumb'`, and a directory that resolved a different variant than the app
+ * asks for would silently double the bytes on every conversation row.
+ */
+export const AVATAR_VARIANT = "thumb";
+
+export interface OxyDirectoryService {
+  profileByUsername(username: string): Promise<DirectoryUser>;
+  userById(userId: string): Promise<DirectoryUser>;
+  usersByIds(ids: readonly string[]): Promise<DirectoryUser[]>;
+  searchProfiles(
+    query: string,
+    pagination: { limit: number; offset: number },
+  ): Promise<{ users: DirectoryUser[]; total: number; hasMore: boolean }>;
+  assetUrl(fileId: string, variant: string | undefined): string;
+}
+
+function trimToUndefined(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * One Oxy user, projected onto what Allo draws.
+ *
+ * `displayName` comes straight from Oxy's canonical `name.displayName` and is
+ * NOT recomposed from the parts when it is missing — `utils/oxyUserDisplay.ts`
+ * already settled that argument for the conversation participants, and a second
+ * answer here would mean the same person is named differently on the two
+ * screens they appear on. The handle is the fallback, then the literal
+ * "Unknown", which is what the participant enrichment does.
+ */
+export function toDirectoryUser(user: User, client: OxyDirectoryClient): DirectoryUser {
+  const avatar = trimToUndefined(user.avatar);
+  const displayName =
+    trimToUndefined(user.name?.displayName) ?? trimToUndefined(user.username) ?? "Unknown";
+
+  return {
+    id: user.id,
+    username: user.username,
+    displayName,
+    firstName: trimToUndefined(user.name?.first) ?? "",
+    lastName: trimToUndefined(user.name?.last) ?? "",
+    ...(avatar === undefined
+      ? {}
+      : { avatar, avatarUrl: client.getFileDownloadUrl(avatar, AVATAR_VARIANT) }),
+    ...(trimToUndefined(user.bio) === undefined ? {} : { bio: user.bio }),
+  };
+}
+
+export function createOxyDirectoryService(client: OxyDirectoryClient): OxyDirectoryService {
+  return {
+    async profileByUsername(username: string): Promise<DirectoryUser> {
+      return toDirectoryUser(await client.getProfileByUsername(username), client);
+    },
+
+    async userById(userId: string): Promise<DirectoryUser> {
+      return toDirectoryUser(await client.getUserById(userId), client);
+    },
+
+    async usersByIds(ids: readonly string[]): Promise<DirectoryUser[]> {
+      /**
+       * `getUsersByIds` deduplicates, chunks at 100 and drops a chunk that
+       * fails rather than the whole call, so the answer can legitimately be
+       * shorter than the request. The route says so; nothing here pads it back
+       * out with placeholders, because a placeholder is indistinguishable from
+       * a real answer at the point it is drawn.
+       */
+      const users = await client.getUsersByIds([...ids]);
+      return users.map((user) => toDirectoryUser(user, client));
+    },
+
+    async searchProfiles(
+      query: string,
+      pagination: { limit: number; offset: number },
+    ): Promise<{ users: DirectoryUser[]; total: number; hasMore: boolean }> {
+      const response = await client.searchProfiles(query, pagination);
+      return {
+        users: response.data.map((user) => toDirectoryUser(user, client)),
+        total: response.pagination.total,
+        hasMore: response.pagination.hasMore,
+      };
+    },
+
+    assetUrl(fileId: string, variant: string | undefined): string {
+      return client.getFileDownloadUrl(fileId, variant ?? AVATAR_VARIANT);
+    },
+  };
+}

--- a/packages/shared-types/src/directory.ts
+++ b/packages/shared-types/src/directory.ts
@@ -1,0 +1,71 @@
+/**
+ * The people directory: who somebody is, as Allo is willing to say it.
+ *
+ * ## Why these types exist rather than the Oxy `User`
+ *
+ * Today the app asks Oxy directly for a profile, and Oxy answers with its whole
+ * `User` document — which carries `email`, `phone`, `address` and `birthday`
+ * alongside the handle and the avatar. That is fine in a client holding the
+ * viewer's own session, because the API decides what that viewer may see. It is
+ * NOT fine coming back out of `api.allo.you`, which asks Oxy as itself: a
+ * backend that forwarded the whole document would hand every signed-in user
+ * every other user's contact details.
+ *
+ * So the directory endpoints project. {@link DirectoryUser} is everything Allo
+ * draws — a name, a handle, an avatar — and nothing else exists on the wire to
+ * be leaked by a future caller that forgets to pick fields.
+ *
+ * ## Why the avatar arrives twice
+ *
+ * `avatar` is the Oxy asset id and `avatarUrl` is that id already resolved
+ * against the Oxy CDN. Both, because the app has fifteen places that turn an id
+ * into a URL and every one of them is a call into the Oxy SDK; once the app no
+ * longer carries that SDK it will have no way to build the URL itself. Sending
+ * the resolved form alongside the id is what lets those fifteen call sites
+ * become a field read instead of a network round trip.
+ */
+
+/** One person, as Allo describes them. */
+export interface DirectoryUser {
+  /** The Oxy account id. A 24-character hexadecimal ObjectId. */
+  id: string;
+  /** The handle, without the `@`. */
+  username: string;
+  /** The canonical display string, resolved by Oxy. Never recomposed here. */
+  displayName: string;
+  /** The given name, or an empty string. Passed through, never recombined. */
+  firstName: string;
+  /** The family name, or an empty string. */
+  lastName: string;
+  /** The Oxy asset id of the avatar, when the account has one. */
+  avatar?: string;
+  /** {@link avatar} resolved against the Oxy CDN. Absent when `avatar` is. */
+  avatarUrl?: string;
+  /** The short public profile line, when the account has one. */
+  bio?: string;
+}
+
+/** `GET /api/directory/users` and `GET /api/directory/profiles/search`. */
+export interface DirectoryUserListResponse {
+  users: DirectoryUser[];
+}
+
+/** `GET /api/directory/profiles/search`, which is paginated. */
+export interface DirectorySearchResponse extends DirectoryUserListResponse {
+  /** How many matches exist in total, as Oxy reports it. */
+  total: number;
+  /** Whether another page follows the one returned. */
+  hasMore: boolean;
+}
+
+/**
+ * `GET /api/directory/assets/:fileId/url`.
+ *
+ * A URL and not a redirect. A redirect would make the endpoint unusable from
+ * the one place it is needed most — an `<Image source={{ uri }}>` that has to
+ * know the address before it starts loading — and would put an Allo hop in
+ * front of every avatar the app draws.
+ */
+export interface DirectoryAssetUrlResponse {
+  url: string;
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -18,3 +18,6 @@ export * from "./conversation";
 
 // Device / Signal Protocol key DTOs
 export * from "./device";
+
+// People directory DTOs (the Oxy lookups, projected)
+export * from "./directory";


### PR DESCRIPTION
## Summary

Allo signs a person in twice today: once to Oxy for `api.allo.you`, once through Matrix Authentication Service for chat. Two tokens for one person is two identities that have to be kept aligned, and #104 is what happens when they stop. The end state is one sign-in, through MAS. **This is the backend half.**

**Nothing changes for what is deployed.** The frontend is untouched and still sends an Oxy `Authorization: Bearer` token. The MAS path is off entirely unless `ALLO_MAS_ISSUER` is set, and a request that does not use the new scheme reaches `createOxyAuthMiddleware` exactly as before.

### Token-type discrimination

A request says which token it carries by the **HTTP authentication scheme**:

```
Authorization: Bearer <oxy access token>          unchanged, the shipped default
Authorization: MatrixBearer <MAS access token>    new
```

Not a side header, because a proxy that drops an unrecognised header would separate a credential from its issuer. Three things keep the two from being confused, and each alone would be enough:

1. `oxy.auth()` extracts a token only from a header beginning with the exact string `"Bearer "`, so a `MatrixBearer` credential is **structurally invisible** to it.
2. A refused `MatrixBearer` request is answered here and **never** offered to the Oxy validator, so the boundary is not the weaker of the two.
3. Neither validator can be fooled by the other's token: an Oxy JWT is unknown to MAS (`active: false`); a MAS token is opaque, so `jwtDecode` fails.

The scheme is client-controlled and that is fine — it selects a validator, it never grants. Mis-declaring can only produce a 401.

### Validation and cache

A MAS access token is opaque, so it is validated by RFC 7662 introspection on every request, cached for **at most 30 seconds**, with `exp` as an additional ceiling and never an extension. That window is the bound on how long a revoked token keeps working. Refusals are cached for 5s, upstream failures never.

MAS's introspection response carries no `iss` and no `aud`, so the issuer verification comes from **where the question is asked**: `ALLO_MAS_INTROSPECTION_URL` must be same-origin with `ALLO_MAS_ISSUER` or the process refuses to boot. `iss`/`aud` are still checked when present. The audience check for an opaque token is the MSC2967 client-API scope. A refresh token is refused — it introspects as active. The subject must be a well-formed Oxy account id; a bridge ghost is refused, not coerced.

**MAS unreachable is 503, never 401.** A chat app answers 401 by signing the user out, and an outage must not log everybody out.

### `/api/directory/*`

The five Oxy lookups the app makes, so an app holding no Oxy session can still draw a person. **The frontend keeps calling Oxy directly in this PR** — this is the surface it moves to. Every underlying Oxy route is public, so no service credential is required. Responses are a projection, not the Oxy `User`, which carries `email`, `phone`, `address` and `birthday`.

## Test plan

Run on arm64 Linux, where `mongodb-memory-server` cannot fetch a binary (`fastdl.mongodb.org` 403s for `linux-aarch64`), so the suite was driven with `MONGOMS_SYSTEM_BINARY=/usr/bin/mongod` — the escape hatch `vitest.globalSetup.ts` documents. CI runs on x86_64 and downloads its own.

| | Before | After |
| --- | --- | --- |
| Backend `vitest` files | 25 | 31 |
| Backend `vitest` tests | 421 passed | **585 passed** |
| Frontend `jest` | 89 suites / 1275 tests | 89 suites / **1275 passed** (untouched) |
| `bun run typecheck` | clean | clean |

Refusals are tested as hard as acceptances: inactive, inactive-with-everything-else-right, expired, expired-at-the-exact-second, not-yet-valid, refresh token, wrong issuer, wrong audience, absent audience, missing scope, scope matched by prefix, client outside the allowlist, no subject, blank subject, uppercase ObjectId, short/long ObjectId, every bridge ghost and bot in the catalogue, foreign-homeserver MXID, MAS unreachable, MAS rejecting our own credentials, MAS returning non-JSON, an Oxy token under `MatrixBearer`, and a MAS token under `Bearer`.

### Mutation testing

Every security property claimed above was mutated. Each mutation was applied, **the file on disk was asserted to have changed before the suite ran**, the suite was run, the file restored, and the restore asserted.

**26 mutations applied, 26 killed, 0 survived.** Among them: accept an inactive token (2 tests red), accept an expired token (2), accept a refresh token (1), skip the issuer check (1), skip the audience check (2), skip the scope check (3), match a scope by prefix (1), ignore the client allowlist (2), coerce a localpart instead of refusing it (10), widen the Oxy id grammar (5), cache for the token's whole lifetime (3), cache an upstream failure (1), remove the cache size ceiling (1), drop the same-origin rule (2), fall through to the Oxy validator after refusing (2), let a request through when MAS is unreachable (2), claim the `Bearer` scheme as well (7), claim a scheme that merely starts the same way (1), accept a MatrixBearer token with MAS turned off (1), forward the whole Oxy `User` instead of projecting (3).

## Not in this PR

- **The frontend.** It still signs in twice and still calls Oxy directly.
- **The Socket.IO handshake.** Still `oxy.authSocket()`; a MAS token cannot open a websocket. Deliberate — the realtime namespace belongs to the legacy transport.
- **Per-user rate limiting for MAS requests.** `createOxyRateLimit` resolves its own session and overwrites `req.userId` with `null` when it finds no `Bearer` header, so the Matrix middleware has to sit after it and a MatrixBearer request lands in the anonymous per-IP bucket. Nothing sends MatrixBearer today, so nothing is affected yet; it needs a fix in `@oxyhq/core` (making the limiter's session resolution idempotent, which its own doc comment already claims it is) before the frontend switches.

## Separately, and more urgent

While assembling the middleware test against the **real** `createOxyAuthMiddleware`, a forged, unsigned JWT authenticated as an arbitrary user — HTTP 200. That is a defect on the **Oxy** path, which this PR does not touch, and it is present in the current npm `latest` of `@oxyhq/core`. It is deliberately not worked around here; it is being handled at the source and reported separately. `__tests__/middleware/matrixAuth.test.ts` records it in a test that will go red the moment the dependency is bumped to a fixed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)