### PR TITLE
fix(chat): a launch held up by another tab explains itself, and the security settings stop 404ing

### DIFF
--- a/docs/encryption.mdx
+++ b/docs/encryption.mdx
@@ -138,12 +138,17 @@ Not implemented. `EncryptedMediaItem` exists as a type in `@allo/shared-types` a
 
 ## Device-first + cloud sync
 
-By default `UserSettings.security.cloudSyncEnabled` is `false`. That means:
+**The app runs with cloud sync ON, and the two ends of this setting do not agree.** `UserSettings.security.cloudSyncEnabled` defaults to `false` in the backend schema, and the default is written rather than notional: `ensureUserSettings` creates the document on the first `GET`, so every account has a stored `false` that nobody chose. The client has always run with `true` (`stores/messagesStore.ts`), and the disagreement stayed invisible because the boot-time read asked the Oxy API for an Allo document and got a 404 on every launch.
 
-- The client does not POST to `/api/messages` while cloud sync is off (`stores/messagesStore.ts` gates the network calls on `cloudSyncEnabled`); messages stay device-local.
-- When cloud sync is on, encrypted messages land on the server so other devices the same user owns can fetch them after a fresh install.
+The read now goes to Allo's backend (`lib/security/cloudSync.ts`), and the rule it applies is deliberately asymmetric: **the document is trusted to turn cloud sync on, not to turn it off, and an absent field leaves it on.** Acting on those stored falses would have switched cloud sync off for every account at boot, as a side effect of a URL fix. When the backend's schema default no longer writes a value nobody asked for, a `false` from the server becomes somebody's decision and the rule becomes a plain "a boolean wins".
+
+What the setting actually changes, which is narrower than "messages stay on the device":
+
+- With cloud sync **off**, `stores/messagesStore.ts` does not fetch from `/api/messages` and does not POST directly. It queues the send instead — and `lib/offlineQueue/queueManager.ts` drains that queue to `POST /api/messages` regardless of the setting, so the message still reaches the server. Incoming messages still arrive over Socket.IO while the app is open.
+- So off does not keep messages off the server. What it removes is the **backfill**: a message that arrived while the app was closed is never fetched, and a reinstalled device opens to empty conversations.
+- When cloud sync is **on**, encrypted messages land on the server so other devices the same user owns can fetch them after a fresh install.
 - The server holds only ciphertext (or, in the plaintext-fallback case below, plaintext) — see [Threats this does NOT defend against](#threats-this-does-not-defend-against).
-- The user can flip `cloudSyncEnabled` in `Settings -> Security & Encryption`.
+- The user can flip `cloudSyncEnabled` in `Settings -> Security & Encryption`. That switch wrote to the Oxy API until the same fix; turning it **off** still does not survive a relaunch, because of the asymmetry above.
 
 ## Peer-to-peer
 

--- a/docs/matrix/client-strategy.md
+++ b/docs/matrix/client-strategy.md
@@ -788,9 +788,27 @@ En orden de cuánto duele si sale mal:
 
    La implementación no lo resuelve ni lo disimula: el hueco está señalado en la
    cabecera de `packages/frontend/lib/matrix/client.web.ts` y en la llamada a
-   `initRustCrypto()`, que es donde el propio SDK cuelga el aviso **[V]**. Nada
-   en el puerto detecta una segunda pestaña. En una pestaña la web es segura; en
-   dos, no está probada.
+   `initRustCrypto()`, que es donde el propio SDK cuelga el aviso **[V]**. En una
+   pestaña la web es segura; en dos, no está probada.
+
+   Lo que sí hay, y no es lo mismo, es que **una segunda pestaña ya no puede
+   colgar el arranque en silencio**. El arranque borra el store antes de abrirlo,
+   IndexedDB deja el `deleteDatabase` pendiente mientras otra conexión lo tenga
+   abierto, y eso se quedaba dentro de la fase `starting`: la pantalla ponía
+   «Connecting…» indefinidamente y la única pista era una línea de consola. El
+   dueño se lo encontró en producción. Ahora `store.web.ts` lo anuncia
+   (`AlloStoreEraseObserver`), `matrixRuntime` lo publica como fase `blocked`, la
+   pantalla dice qué pestaña cerrar, la espera termina sola en cuanto se cierra —
+   sin recargar nada — y a los 30 s se rinde en `blocked-timed-out` **sin abrir el
+   store**, que es la regla de #104 intacta.
+
+   Eso detecta el síntoma, no la pestaña. No hay `navigator.locks` ni
+   `BroadcastChannel`: ambas exigen un participante vivo *en la otra pestaña*, que
+   es justamente la barandilla que sigue sin presupuestarse. La atribución
+   («otra pestaña») es una inferencia — IndexedDB es por origen y esos nombres de
+   base de datos son de Allo — y el único caso en que falla es un cliente que esta
+   misma pestaña acaba de cerrar, porque `stopClient()` no cierra su
+   `IndexedDBStore`. Está anotado en la cabecera de `store.web.ts`.
 
 ---
 

--- a/packages/frontend/__tests__/chat/matrixAutoSignIn.test.ts
+++ b/packages/frontend/__tests__/chat/matrixAutoSignIn.test.ts
@@ -29,12 +29,29 @@ describe('shouldAutoSignIn', () => {
     expect(shouldAutoSignIn({ ...base, phase: 'failed' })).toBe(false);
   });
 
-  it.each<AutoSignInPhase>(['idle', 'starting', 'authorizing', 'leaving', 'finishing', 'ready'])(
-    'does not start from %s',
-    (phase) => {
-      expect(shouldAutoSignIn({ ...base, phase })).toBe(false);
-    },
-  );
+  it.each<AutoSignInPhase>([
+    'idle',
+    'starting',
+    'blocked',
+    'blocked-timed-out',
+    'authorizing',
+    'leaving',
+    'finishing',
+    'ready',
+  ])('does not start from %s', (phase) => {
+    expect(shouldAutoSignIn({ ...base, phase })).toBe(false);
+  });
+
+  it('does not send a browser away from a screen that is asking for something', () => {
+    // Both halves of a launch held up by another window of Allo. `blocked` is
+    // waiting for that window to close and `blocked-timed-out` has stopped
+    // waiting and is asking the reader to close it — and in neither case is
+    // there a client for a sign-in to go through, because the store was never
+    // opened. An authorization started over either would put a browser hop on
+    // top of the request and come back to the same screen.
+    expect(shouldAutoSignIn({ ...base, phase: 'blocked' })).toBe(false);
+    expect(shouldAutoSignIn({ ...base, phase: 'blocked-timed-out' })).toBe(false);
+  });
 
   it('does not start one while the browser is being sent away', () => {
     // `leaving` is web's: the page has asked the browser to navigate and is about

--- a/packages/frontend/__tests__/chat/matrixRuntime.test.ts
+++ b/packages/frontend/__tests__/chat/matrixRuntime.test.ts
@@ -12,9 +12,11 @@ import {
   type MatrixStoreOwnerStorage,
 } from '@/lib/chat/matrixStoreOwner';
 import type { MatrixPushRegistration } from '@/lib/chat/pushRegistration';
+import { MatrixStoreEraseBlockedError } from '@/lib/matrix/errors';
 import type {
   AlloChatClient,
   AlloChatClientConfig,
+  AlloChatStoreEraser,
   AlloClientStore,
   AlloEncryptionState,
   AlloEphemeralPolicy,
@@ -25,6 +27,7 @@ import type {
   AlloRoomListHandle,
   AlloRoomTrust,
   AlloSession,
+  AlloStoreEraseObserver,
   AlloSyncState,
   AlloTimelineHandle,
   AlloUnsubscribe,
@@ -1508,6 +1511,205 @@ describe('MatrixRuntime store ownership', () => {
 
     expect(context.signInAttempt.forgets).toBe(0);
     expect(context.erased).toEqual([STORE]);
+  });
+});
+
+describe('MatrixRuntime store held open by another window', () => {
+  /**
+   * WHAT A BLOCKED ERASE LOOKS LIKE FROM WHERE THE PERSON IS SITTING.
+   *
+   * The launch has to empty the chat data on this device before it opens it. On
+   * web a second window of Allo holding that data open makes the deletion wait —
+   * correctly, and it completes on its own the moment that window closes. What
+   * was wrong was that the wait had nowhere to appear: the phase stayed
+   * `starting`, the gate drew "Connecting…", and there was no way to learn why
+   * and no way out but closing windows at random. The owner met exactly that.
+   *
+   * So the erase reports itself and this class turns the report into a phase.
+   * The rule that must survive all of it is the one #104 established: **a store
+   * that could not be erased is never opened.** Every case below that reaches
+   * the bound also asserts that no client was built.
+   */
+
+  /** The port's own error for a wait that was given up on. */
+  const blockedTooLong = (): Error =>
+    new MatrixStoreEraseBlockedError(['matrix-js-sdk:allo-matrix'], 30_000);
+
+  /**
+   * An erase that reports itself blocked and then waits for the test.
+   *
+   * Returns the ending, so a case can choose between the two the app has: the
+   * other window closes, or the wait is given up on.
+   */
+  function heldErase(): {
+    readonly eraseStore: AlloChatStoreEraser;
+    /** The other window closes. The pending deletion completes. */
+    otherWindowCloses(): void;
+    /** The bound is reached. The erase raises, and nothing opens the store. */
+    giveUp(): void;
+  } {
+    let report: AlloStoreEraseObserver | undefined;
+    let finish: ((error?: Error) => void) | undefined;
+    return {
+      eraseStore: async (_store, onBlocked) => {
+        report = onBlocked;
+        onBlocked?.(true);
+        await new Promise<void>((resolve, reject) => {
+          finish = (error) => (error === undefined ? resolve() : reject(error));
+        });
+      },
+      otherWindowCloses: () => {
+        report?.(false);
+        finish?.();
+      },
+      giveUp: () => {
+        // Deliberately without reporting the wait as over: the screen is about
+        // to say the launch has stopped, and a "carry on" one tick before that
+        // is a spinner it would never leave.
+        finish?.(blockedTooLong());
+      },
+    };
+  }
+
+  it('says another window has the data, instead of a spinner that means nothing', async () => {
+    const held = heldErase();
+    const context = harness({ eraseStore: held.eraseStore });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.runtime.getState().phase).toBe('blocked');
+    // Nothing has failed. It is a window that is open, and the screen for it
+    // asks rather than apologises.
+    expect(context.runtime.getState().error).toBeUndefined();
+
+    held.otherWindowCloses();
+    await settle();
+  });
+
+  it('does not open the store while it is still waiting for it', async () => {
+    const held = heldErase();
+    const context = harness({ eraseStore: held.eraseStore });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.createClientCalls).toBe(0);
+
+    held.otherWindowCloses();
+    await settle();
+  });
+
+  it('carries on by itself when the other window closes, with nothing reloaded', async () => {
+    // The common ending. The pending deletion completes, the erase resolves, and
+    // this same runtime finishes the launch it had started — no reload, nothing
+    // asked of anybody, and the phase goes back through `starting` on the way.
+    const held = heldErase();
+    const context = harness({ eraseStore: held.eraseStore });
+    const phases: string[] = [];
+    context.runtime.subscribe(() => {
+      phases.push(context.runtime.getState().phase);
+    });
+    await settle();
+
+    held.otherWindowCloses();
+    await settle();
+
+    expect(phases).toEqual(['starting', 'blocked', 'starting', 'signed-out']);
+    expect(context.createClientCalls).toBe(1);
+    expect(context.runtime.getState().phase).toBe('signed-out');
+  });
+
+  it('stops at its own phase when the wait is given up on, not at a failure', async () => {
+    // `failed` says something went wrong and offers an apology. Nothing went
+    // wrong: a window is open, and the reader is the only person who can close
+    // it. The screen has to be able to say so.
+    const held = heldErase();
+    const context = harness({ eraseStore: held.eraseStore });
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    held.giveUp();
+    await settle();
+
+    expect(context.runtime.getState().phase).toBe('blocked-timed-out');
+    expect(context.runtime.getState().error).toBeUndefined();
+  });
+
+  it('does not open the store it has just given up on erasing', async () => {
+    // THE ONE THE BOUND EXISTS UNDER. Waiting forever was safe and unusable;
+    // the danger in making it stop is that stopping falls through into the
+    // ordinary path, which opens the store — the last account's synced state
+    // and its decryption keys, handed to whoever is here now.
+    const held = heldErase();
+    const context = harness({ eraseStore: held.eraseStore });
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    held.giveUp();
+    await settle();
+
+    expect(context.createClientCalls).toBe(0);
+    expect(() => context.runtime.client('Observing the conversation list')).toThrow();
+  });
+
+  it('never passes through a phase that would draw the chat', async () => {
+    // Every phase, not only the last one. `ready` is what the room list and the
+    // timelines open against, and one notification of it is enough for them to
+    // ask a runtime that has no client.
+    const held = heldErase();
+    const context = harness({ eraseStore: held.eraseStore });
+    const phases: string[] = [];
+    context.runtime.subscribe(() => {
+      phases.push(context.runtime.getState().phase);
+    });
+    await settle();
+
+    held.giveUp();
+    await settle();
+
+    expect(phases).toEqual(['starting', 'blocked', 'blocked-timed-out']);
+  });
+
+  it('lets the reader try again once the other window is gone', async () => {
+    // What makes the bounded screen a way out rather than a dead end: the button
+    // rebuilds, the deletion is attempted again, and it works the moment nothing
+    // is holding the database.
+    const held = heldErase();
+    let blocking = true;
+    const context = harness({
+      eraseStore: async (store, onBlocked) => {
+        if (!blocking) {
+          return;
+        }
+        blocking = false;
+        await held.eraseStore(store, onBlocked);
+      },
+    });
+    context.runtime.subscribe(() => {});
+    await settle();
+    held.giveUp();
+    await settle();
+    expect(context.runtime.getState().phase).toBe('blocked-timed-out');
+
+    await context.runtime.signIn();
+    await settle();
+
+    expect(context.createClientCalls).toBe(1);
+    expect(context.runtime.getState().phase).toBe('ready');
+  });
+
+  it('reports a store it could not erase at all as a failure, as it always did', async () => {
+    // The neighbouring case, kept apart on purpose. A refused deletion — a
+    // private window whose IndexedDB takes no mutations — is not something
+    // closing a tab fixes, so it is still `failed` and still says so.
+    const context = harness({ eraseStoreFails: new Error('this window refuses IndexedDB') });
+
+    context.runtime.subscribe(() => {});
+    await settle();
+
+    expect(context.runtime.getState().phase).toBe('failed');
+    expect(context.createClientCalls).toBe(0);
   });
 });
 

--- a/packages/frontend/__tests__/chat/signInGateCopy.test.ts
+++ b/packages/frontend/__tests__/chat/signInGateCopy.test.ts
@@ -33,6 +33,14 @@ const LOCALES: readonly (readonly [string, Record<string, unknown>])[] = [
 /** Every string the gate can put on screen. */
 const REQUIRED_KEYS: readonly string[] = [
   'Connecting…',
+  // The two halves of a launch held up by a second window of Allo: the one that
+  // is still working and finishes by itself, and the one that has stopped and
+  // needs the reader. Both name the thing to close, because closing it is the
+  // only action there is.
+  'Allo is open in another tab',
+  'Close the other Allo tab and this one will carry on by itself.',
+  'Allo is still open in another tab',
+  'Close every other Allo tab or window, then try again.',
   'Finish signing in',
   'Allo is waiting for the sign-in page in your browser.',
   'Taking you to sign in…',
@@ -79,8 +87,22 @@ describe('the sign-in gate does not tell a signed-in person to sign in', () => {
     // above by never being a key at all, and would ship English to all three.
     const asked = Array.from(source.matchAll(/\bt\(\s*'([^']+)'/g), ([, key]) => key);
 
-    expect(asked.length).toBeGreaterThanOrEqual(REQUIRED_KEYS.length);
     expect(asked.filter((key) => !REQUIRED_KEYS.includes(key))).toEqual([]);
+  });
+
+  it('still asks for every string this list says it can show', () => {
+    // THE OTHER DIRECTION, and the one that was missing. The check above reads
+    // the source and asks whether each key is allowed; a screen that stopped
+    // saying something — a `t()` call replaced by a literal, a whole branch
+    // deleted — is invisible to it, and the bundles keep the string on file so
+    // the two checks above stay green as well. Measured: replacing the blocked
+    // screen's title with a bare "Connecting…" survived all three. It does not
+    // survive this one.
+    const asked = new Set(
+      Array.from(source.matchAll(/\bt\(\s*'([^']+)'/g), ([, key]) => key),
+    );
+
+    expect(REQUIRED_KEYS.filter((key) => !asked.has(key))).toEqual([]);
   });
 
   it('does not name the person as the thing that failed', () => {

--- a/packages/frontend/__tests__/matrix/web/store.test.ts
+++ b/packages/frontend/__tests__/matrix/web/store.test.ts
@@ -1,4 +1,8 @@
-import { MatrixPortError, MatrixStoreNotErasedError } from '@/lib/matrix/errors';
+import {
+  MatrixPortError,
+  MatrixStoreEraseBlockedError,
+  MatrixStoreNotErasedError,
+} from '@/lib/matrix/errors';
 import {
   cryptoDatabasePrefix,
   eraseWebStore,
@@ -29,20 +33,62 @@ class FakeIndexedDB {
   readonly present: string[] = [];
   /** Databases that answer with an error, as a private window's do. */
   refuse = new Set<string>();
+  /**
+   * Databases another connection still has open.
+   *
+   * The browser answers `onblocked` and then nothing at all: the request stays
+   * pending until that connection closes, which is what {@link release} is. A
+   * name left in here is a second window of Allo that nobody ever closes.
+   */
+  block = new Set<string>();
   /** Whether this browser offers `databases()` at all. */
   listable = true;
 
+  /** Every deletion this factory has handed out, by name. */
+  readonly #requests = new Map<string, Record<string, unknown>>();
+
   deleteDatabase(name: string): IDBOpenDBRequest {
     const request: Record<string, unknown> = { error: new Error('refused') };
+    this.#requests.set(name, request);
     queueMicrotask(() => {
       if (this.refuse.has(name)) {
         callHandler(request.onerror);
+        return;
+      }
+      if (this.block.has(name)) {
+        callHandler(request.onblocked);
         return;
       }
       this.deleted.push(name);
       callHandler(request.onsuccess);
     });
     return request as unknown as IDBOpenDBRequest;
+  }
+
+  /** The other connection closes: the pending deletion completes on its own. */
+  release(name: string): void {
+    this.block.delete(name);
+    this.deleted.push(name);
+    callHandler(this.#request(name).onsuccess);
+  }
+
+  /**
+   * The browser reports `onblocked` again on a request it has already answered.
+   *
+   * Allowed by the specification — "the implementation may fire it more than
+   * once" — and the reason the deletion keeps a `settled` of its own rather than
+   * relying on the promise's, which is idempotent and would swallow it silently.
+   */
+  blockAgain(name: string): void {
+    callHandler(this.#request(name).onblocked);
+  }
+
+  #request(name: string): Record<string, unknown> {
+    const request = this.#requests.get(name);
+    if (request === undefined) {
+      throw new Error(`${name} was never asked to be deleted`);
+    }
+    return request;
   }
 
   databases(): Promise<IDBDatabaseInfo[]> {
@@ -202,5 +248,242 @@ describe('eraseWebStore', () => {
     // Reporting success would let the client open a store this could not have
     // cleared.
     await expect(eraseWebStore(STORE, undefined)).rejects.toThrow(MatrixPortError);
+  });
+
+  it('says nothing about waiting when nothing is in the way', async () => {
+    // The ordinary launch. A report here would put "Allo is open in another tab"
+    // in front of somebody for whom it is not true.
+    const indexedDB = new FakeIndexedDB();
+    const reports: boolean[] = [];
+
+    await eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+    });
+
+    expect(reports).toEqual([]);
+  });
+});
+
+/**
+ * A DELETION ANOTHER WINDOW IS HOLDING UP.
+ *
+ * The state the owner met in production: the crypto database was open in a
+ * second tab, IndexedDB left the deletion pending, and the launch waited behind
+ * it with nothing on screen but "Connecting…". Waiting was right — it is the
+ * only answer that does not open somebody else's keys, and it ends by itself —
+ * but waiting in silence, with no bound, is a hang.
+ *
+ * So there are three things to keep true here, and each of them is a case: the
+ * wait is announced, it ends by itself when the other window goes, and it is
+ * bounded. What must never be true is the fourth: that giving up resolves. A
+ * resolution is read by `matrixRuntime` as "the store is empty" and is followed
+ * immediately by opening it.
+ */
+describe('eraseWebStore, blocked by another connection', () => {
+  /**
+   * Short enough that the bound is reached inside a test, not a coffee break.
+   *
+   * Every case that reaches it also waits {@link reachTheBlock} first, which
+   * costs a macrotask; the gap between the two is what keeps the ordering
+   * deterministic without fake timers.
+   */
+  const BOUND_MS = 60;
+
+  /** Lets the deletion start and the browser answer `onblocked`. */
+  const reachTheBlock = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 0));
+
+  it('reports the wait as soon as the browser reports it', async () => {
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+    const reports: boolean[] = [];
+
+    const erasing = eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    }).catch(() => undefined);
+    // Long enough for the browser to answer `onblocked`, far short of the bound.
+    // What is being asserted is that the report does not wait for the outcome —
+    // one that only arrived at the end would be a screen that only appeared once
+    // there was nothing left to say.
+    await reachTheBlock();
+
+    expect(reports).toEqual([true]);
+
+    await erasing;
+  });
+
+  it('finishes on its own when the other window closes, and says the wait is over', async () => {
+    // The common ending, and the one that must not need a reload: the pending
+    // request completes the moment the other connection goes, so the erase
+    // resolves and the launch carries on from where it was.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+    const reports: boolean[] = [];
+
+    const erasing = eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    });
+    await reachTheBlock();
+    indexedDB.release('matrix-js-sdk:allo-matrix');
+
+    await expect(erasing).resolves.toBeUndefined();
+    expect(reports).toEqual([true, false]);
+    expect(indexedDB.deleted).toEqual(['matrix-js-sdk:allo-matrix']);
+  });
+
+  it('gives up at the bound, and gives up by throwing', async () => {
+    // THE ONE THAT MATTERS. Resolving here would tell the runtime the store was
+    // empty and the runtime would open it — which is a client reading the last
+    // account's synced state, out of a database this could not delete.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+
+    const failure = await eraseWebStore(STORE, indexedDB.factory(), {
+      blockedTimeoutMs: BOUND_MS,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(MatrixStoreEraseBlockedError);
+    expect((failure as MatrixStoreEraseBlockedError).names).toEqual([
+      'matrix-js-sdk:allo-matrix',
+    ]);
+    expect((failure as MatrixStoreEraseBlockedError).waitedMs).toBe(BOUND_MS);
+    expect(indexedDB.deleted).toEqual([]);
+  });
+
+  it('is not a MatrixStoreNotErasedError, because the reader can fix one of them', async () => {
+    // A refused store cannot be deleted at all; a blocked one deletes itself the
+    // moment a window closes. The screens differ, so the types have to.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+
+    const failure = await eraseWebStore(STORE, indexedDB.factory(), {
+      blockedTimeoutMs: BOUND_MS,
+    }).catch((error: unknown) => error);
+
+    expect(failure).not.toBeInstanceOf(MatrixStoreNotErasedError);
+  });
+
+  it('does not report the wait as over when it is giving up', async () => {
+    // The screen would flick back to a spinner for one tick and then stop on a
+    // failure. Worse than either state on its own.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+    const reports: boolean[] = [];
+
+    await eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    }).catch(() => undefined);
+
+    expect(reports).toEqual([true]);
+  });
+
+  it('says nothing more once it has given up, however late the browser answers', async () => {
+    // IndexedDB has no way to cancel a deletion, so the request outlives the
+    // failure and may complete minutes later. It still deletes the database,
+    // which is what the next attempt wants — but it must not report to a caller
+    // that has already stopped.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+    const reports: boolean[] = [];
+
+    await eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    }).catch(() => undefined);
+    indexedDB.release('matrix-js-sdk:allo-matrix');
+    await reachTheBlock();
+
+    expect(reports).toEqual([true]);
+  });
+
+  it('does not announce a second wait after it has given up on the first', async () => {
+    // A browser is allowed to fire `onblocked` again, and one arriving after the
+    // bound would announce a wait nobody is waiting through — the screen would
+    // go back to "another window has your data" over a launch that has already
+    // stopped — and would arm a timer with nothing left to reject.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+    const reports: boolean[] = [];
+
+    await eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    }).catch(() => undefined);
+    indexedDB.blockAgain('matrix-js-sdk:allo-matrix');
+
+    expect(reports).toEqual([true]);
+  });
+
+  it('does not announce a wait on a deletion that has already finished', async () => {
+    // The same guard from the other side: the deletion succeeded, the erase
+    // resolved, and a stray report here would reach a runtime that has moved on
+    // to building a client.
+    const indexedDB = new FakeIndexedDB();
+    const reports: boolean[] = [];
+
+    await eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    });
+    indexedDB.blockAgain('matrix-js-sdk:allo-matrix');
+
+    expect(reports).toEqual([]);
+  });
+
+  it('announces the wait once when the browser reports it twice', async () => {
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+    const reports: boolean[] = [];
+
+    const erasing = eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    });
+    await reachTheBlock();
+    indexedDB.blockAgain('matrix-js-sdk:allo-matrix');
+    indexedDB.release('matrix-js-sdk:allo-matrix');
+
+    await expect(erasing).resolves.toBeUndefined();
+    expect(reports).toEqual([true, false]);
+  });
+
+  it('stops rather than waiting out every database in turn', async () => {
+    // Collecting blocks the way refusals are collected would multiply the bound
+    // by the number of databases, and the reader would be looking at a screen
+    // that cannot change for minutes. One window is holding all of them anyway.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.present.push('allo-matrix:DEVICE1::matrix-sdk-crypto');
+    indexedDB.block.add('matrix-js-sdk:allo-matrix');
+
+    await eraseWebStore(STORE, indexedDB.factory(), { blockedTimeoutMs: BOUND_MS }).catch(
+      () => undefined,
+    );
+
+    expect(indexedDB.deleted).toEqual([]);
+  });
+
+  it('waits out the crypto database too, which is the one the owner met', async () => {
+    // The name in his console was `allo-matrix:FNgFkAe4aZ::matrix-sdk-crypto`.
+    // The synced state went; this one was open in another tab.
+    const indexedDB = new FakeIndexedDB();
+    indexedDB.present.push('allo-matrix:DEVICE1::matrix-sdk-crypto');
+    indexedDB.block.add('allo-matrix:DEVICE1::matrix-sdk-crypto');
+    const reports: boolean[] = [];
+
+    const failure = await eraseWebStore(STORE, indexedDB.factory(), {
+      onBlocked: (blocked) => reports.push(blocked),
+      blockedTimeoutMs: BOUND_MS,
+    }).catch((error: unknown) => error);
+
+    expect(reports).toEqual([true]);
+    expect(failure).toBeInstanceOf(MatrixStoreEraseBlockedError);
+    expect((failure as MatrixStoreEraseBlockedError).names).toEqual([
+      'allo-matrix:DEVICE1::matrix-sdk-crypto',
+    ]);
+    // The one that did go, went.
+    expect(indexedDB.deleted).toEqual(['matrix-js-sdk:allo-matrix']);
   });
 });

--- a/packages/frontend/__tests__/security/cloudSync.test.ts
+++ b/packages/frontend/__tests__/security/cloudSync.test.ts
@@ -1,0 +1,216 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  CLOUD_SYNC_ENABLED_BY_DEFAULT,
+  fetchMyCloudSyncEnabled,
+  readCloudSyncEnabled,
+  updateMyCloudSyncEnabled,
+} from '@/lib/security/cloudSync';
+
+const mockGet = jest.fn();
+const mockPut = jest.fn();
+
+/**
+ * Allo's own backend client, and only it.
+ *
+ * The bug was which client, so the mock is of the client that must be used: a
+ * module that reached for the Oxy one instead would find nothing mocked and
+ * these cases would not pass by accident.
+ */
+jest.mock('@/utils/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+  },
+}));
+
+/**
+ * WHICH SERVER ANSWERS, AND WHAT ITS ANSWER MEANS.
+ *
+ * `lib/appInitializer.ts` asked the OXY client for `/profile/settings/me` and
+ * got a 404 on every launch the app has ever had — Oxy mounts `/profiles`, and
+ * this document is Allo's own. Repairing the URL is one line and it is the
+ * smaller half of the change; the larger half is that the line under it read
+ * `settings?.security?.cloudSyncEnabled || false`, so the repair on its own
+ * would have switched cloud sync off for every account at boot.
+ *
+ * That is not a cosmetic setting. With cloud sync off `fetchMessages` does not
+ * ask the server at all: a message that arrived while the app was closed is
+ * never backfilled, and a reinstalled device opens to empty conversations.
+ *
+ * The backend's `SecuritySchema` writes `cloudSyncEnabled: false` into every
+ * document it creates — asserted below against the model itself, because that
+ * fact is the reason this rule is asymmetric and a reader who does not know it
+ * would delete the asymmetry as a mistake. Nobody chose those falses: the only
+ * screen that could set the field wrote to the Oxy client too. So the document
+ * is trusted to turn cloud sync on and not to turn it off, and an absent field
+ * leaves it on.
+ */
+
+describe('what a settings document says about cloud sync', () => {
+  it('turns cloud sync on when the account has chosen it', () => {
+    expect(readCloudSyncEnabled({ data: { security: { cloudSyncEnabled: true } } })).toBe(true);
+  });
+
+  it('leaves cloud sync on when the field is absent', () => {
+    // Documents written before `security` existed in the schema. `.lean()`
+    // applies no defaults, so they come back without it. Absent is nobody's
+    // decision and must not be read as one.
+    expect(readCloudSyncEnabled({ data: { privacy: { profileVisibility: 'public' } } })).toBe(
+      true,
+    );
+    expect(readCloudSyncEnabled({ data: { security: {} } })).toBe(true);
+    expect(readCloudSyncEnabled({ data: {} })).toBe(true);
+  });
+
+  it('leaves cloud sync on when the document says false, because nobody said it', () => {
+    // THE CASE THE WHOLE MODULE IS FOR. Every account has this value, written by
+    // the schema at document creation; not one person put it there. Acting on it
+    // is the silent switch-off a URL fix must not cause.
+    expect(readCloudSyncEnabled({ data: { security: { cloudSyncEnabled: false } } })).toBe(true);
+  });
+
+  it('agrees with the value the messages store starts with', () => {
+    // They are two statements of one fact. When they disagreed — a `true` in the
+    // store and a `|| false` in the loader — only a 404 kept the disagreement
+    // off the screen.
+    expect(CLOUD_SYNC_ENABLED_BY_DEFAULT).toBe(true);
+  });
+
+  it('is the only place that value is written down', () => {
+    // Asserting the two are equal cannot catch them being written twice, because
+    // two literals that happen to agree today pass it. The store has to name the
+    // constant, so that changing it is one edit and not two — the second of
+    // which nobody would remember.
+    const source = readFileSync(
+      join(__dirname, '..', '..', 'stores', 'messagesStore.ts'),
+      'utf8',
+    );
+
+    expect(source).toContain('cloudSyncEnabled: CLOUD_SYNC_ENABLED_BY_DEFAULT');
+    expect(source).not.toMatch(/cloudSyncEnabled:\s*(true|false)/);
+  });
+
+  it('does not read a string or a number as an answer', () => {
+    // This document is written by more than one caller. A value of the wrong
+    // type is not a decision either.
+    expect(readCloudSyncEnabled({ data: { security: { cloudSyncEnabled: 'true' } } })).toBe(true);
+    expect(readCloudSyncEnabled({ data: { security: { cloudSyncEnabled: 1 } } })).toBe(true);
+  });
+
+  it('survives a body that is not a document at all', () => {
+    expect(readCloudSyncEnabled(undefined)).toBe(true);
+    expect(readCloudSyncEnabled(null)).toBe(true);
+    expect(readCloudSyncEnabled('not found')).toBe(true);
+  });
+
+  it('reads a document that arrives without the envelope', () => {
+    // `sendSuccessResponse` wraps its answer in `data`, and `api.get` unwraps a
+    // layer of its own. Both shapes have been seen by the neighbouring readers
+    // of this document, so both are handled.
+    expect(readCloudSyncEnabled({ security: { cloudSyncEnabled: true } })).toBe(true);
+  });
+});
+
+describe('which server is asked', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPut.mockReset();
+  });
+
+  it('reads the document from Allo, at the path Allo mounts', () => {
+    // `/profile`, not `/profiles`. The Oxy API mounts the plural and does not
+    // serve this document at all, which is the 404 the owner saw on every boot.
+    mockGet.mockResolvedValue({ data: { data: { security: { cloudSyncEnabled: true } } } });
+
+    return fetchMyCloudSyncEnabled().then((enabled) => {
+      expect(mockGet).toHaveBeenCalledWith('profile/settings/me');
+      expect(enabled).toBe(true);
+    });
+  });
+
+  it('writes the choice to the same document it reads', () => {
+    // A read that persists and a write that does not is worse than neither: the
+    // switch would appear to work and undo itself on the next launch.
+    mockPut.mockResolvedValue({ data: {} });
+
+    return updateMyCloudSyncEnabled(false).then(() => {
+      expect(mockPut).toHaveBeenCalledWith('profile/settings', {
+        security: { cloudSyncEnabled: false },
+      });
+    });
+  });
+
+  it('sends nothing but the one field, so the rest of the document survives', () => {
+    // The backend builds a `$set` from the keys it recognises. A body carrying
+    // more would overwrite settings this screen has no business touching.
+    mockPut.mockResolvedValue({ data: {} });
+
+    return updateMyCloudSyncEnabled(true).then(() => {
+      const [, body] = mockPut.mock.calls[0] as [string, Record<string, unknown>];
+      expect(Object.keys(body)).toEqual(['security']);
+      expect(body.security).toEqual({ cloudSyncEnabled: true });
+    });
+  });
+});
+
+describe('the boot path no longer asks Oxy for an Allo document', () => {
+  const INITIALIZER = join(__dirname, '..', '..', 'lib', 'appInitializer.ts');
+  const SETTINGS_SCREEN = join(
+    __dirname,
+    '..',
+    '..',
+    'app',
+    '(chat)',
+    'settings',
+    'index.tsx',
+  );
+
+  it('loads the setting through the module that knows which client to use', () => {
+    const source = readFileSync(INITIALIZER, 'utf8');
+
+    expect(source).toContain('fetchMyCloudSyncEnabled');
+    expect(source).not.toContain('/profile/settings/me');
+  });
+
+  it('saves the setting through it too', () => {
+    const source = readFileSync(SETTINGS_SCREEN, 'utf8');
+
+    expect(source).toContain('updateMyCloudSyncEnabled');
+    expect(source).not.toContain("authenticatedClient.put('/profile/settings'");
+  });
+
+  it('does not shout the failure through a banned console call', () => {
+    // `console.warn` and `console.error` are banned by the project's standards
+    // and this module already imports `logger`.
+    const source = readFileSync(INITIALIZER, 'utf8');
+    const initializing = source.slice(source.indexOf('async function initializeSignalProtocol'));
+
+    expect(initializing).not.toContain('console.');
+  });
+});
+
+describe('the backend fact this rule rests on', () => {
+  const MODEL = join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'backend',
+    'src',
+    'models',
+    'UserSettings.ts',
+  );
+
+  it('still defaults cloudSyncEnabled to false in the stored schema', () => {
+    // If this fails, the backend has been changed and the asymmetry above has
+    // served its purpose: a `false` from the server has become somebody's
+    // decision, and `readCloudSyncEnabled` should become a plain "a boolean
+    // wins, absent means on". The test is here so that change is noticed by the
+    // rule that depends on it rather than by a user losing messages.
+    const source = readFileSync(MODEL, 'utf8');
+
+    expect(source).toMatch(/cloudSyncEnabled:\s*\{\s*type:\s*Boolean,\s*default:\s*false\s*\}/);
+  });
+});

--- a/packages/frontend/app/(chat)/settings/index.tsx
+++ b/packages/frontend/app/(chat)/settings/index.tsx
@@ -21,6 +21,8 @@ import { getData, storeData } from "@/utils/storage";
 import { hasNotificationPermission, requestNotificationPermissions } from "@/utils/notifications";
 import { isPushEnabled, NOTIFICATION_PREFERENCE_KEY } from "@/lib/chat/pushRegistration";
 import { matrixRuntime } from "@/lib/chat/matrixRuntime";
+import { updateMyCloudSyncEnabled } from "@/lib/security/cloudSync";
+import { logger } from "@/utils/logger";
 import { signOutOfMatrix } from "@/hooks/useMatrixRuntime";
 import { useTheme } from "@/hooks/useTheme";
 import { getThemedBorder, getThemedShadow } from "@/utils/theme";
@@ -89,16 +91,16 @@ export default function SettingsScreen() {
             : 'Not initialized'
     );
 
+    // The switch moves the store first so the row answers immediately, and then
+    // writes to Allo's own backend — which is where this document lives, and
+    // which the write used to miss for the same reason the boot-time read did.
+    // See `lib/security/cloudSync.ts`.
     const onToggleCloudSync = useCallback(async (enabled: boolean) => {
         useMessagesStore.getState().setCloudSyncEnabled(enabled);
         try {
-            await authenticatedClient.put('/profile/settings', {
-                security: {
-                    cloudSyncEnabled: enabled,
-                },
-            });
+            await updateMyCloudSyncEnabled(enabled);
         } catch (error) {
-            console.error('Error updating cloud sync setting:', error);
+            logger.error('[Settings] the cloud sync setting could not be saved', error);
         }
     }, []);
 

--- a/packages/frontend/components/matrix/MatrixSignInGate.tsx
+++ b/packages/frontend/components/matrix/MatrixSignInGate.tsx
@@ -121,6 +121,57 @@ export function MatrixSignInGate({ children }: { children: React.ReactNode }) {
     );
   }
 
+  // ANOTHER WINDOW OF ALLO IS IN THE WAY, AND ONLY THE READER CAN MOVE IT.
+  //
+  // Before this screen existed the app drew "Connecting…" and kept drawing it:
+  // the launch has to empty the chat data on this device before it opens it, a
+  // second window holding that data open makes the deletion wait, and the wait
+  // had nowhere to appear. What it looked like from the outside was an app that
+  // had stopped, with the reason in a console line nobody was reading.
+  //
+  // A spinner is still right here, because this really is still working and it
+  // really does finish by itself — closing the other window completes the
+  // deletion and the phase moves on with nothing else asked of anybody. What
+  // was missing was the sentence next to it.
+  if (runtime.phase === 'blocked') {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator style={styles.spinner} color={theme.colors.primary} />
+        <ThemedText style={styles.title}>{t('Allo is open in another tab')}</ThemedText>
+        <ThemedText style={styles.detail}>
+          {t('Close the other Allo tab and this one will carry on by itself.')}
+        </ThemedText>
+      </View>
+    );
+  }
+
+  // The same request, after the app has stopped waiting for it.
+  //
+  // No spinner: nothing is running any more, and a spinner over a stopped launch
+  // is the lie this whole screen was written to stop telling. The button is the
+  // way out, and it is honest — pressing it starts the launch again, which tries
+  // the deletion again, which works the moment the other window is gone.
+  //
+  // What is deliberately NOT here is a way to continue anyway. The data that
+  // could not be deleted is the last account's synced state and keys.
+  if (runtime.phase === 'blocked-timed-out') {
+    return (
+      <View style={styles.container}>
+        <ThemedText style={styles.title}>{t('Allo is still open in another tab')}</ThemedText>
+        <ThemedText style={styles.detail}>
+          {t('Close every other Allo tab or window, then try again.')}
+        </ThemedText>
+        <TouchableOpacity
+          accessibilityRole="button"
+          style={styles.button}
+          onPress={signInToMatrix}
+        >
+          <ThemedText style={styles.buttonLabel}>{t('Try again')}</ThemedText>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
   if (runtime.phase === 'authorizing') {
     return (
       <View style={styles.container}>

--- a/packages/frontend/lib/appInitializer.ts
+++ b/packages/frontend/lib/appInitializer.ts
@@ -17,6 +17,7 @@ import {
 } from '@/utils/notifications';
 import { initializeI18n } from './i18n';
 import { INITIALIZATION_TIMEOUT } from './constants';
+import { fetchMyCloudSyncEnabled } from '@/lib/security/cloudSync';
 import { useDeviceKeysStore } from '@/stores/deviceKeysStore';
 import { useMessagesStore } from '@/stores/messagesStore';
 import { p2pManager } from './p2pMessaging';
@@ -192,14 +193,17 @@ async function initializeSignalProtocol(): Promise<void> {
       await deviceKeysStore.initialize();
     }
 
-    // Load cloud sync setting from backend
+    // What this account's document says about cloud sync, from Allo's backend
+    // and not Oxy's — see `lib/security/cloudSync.ts`, which also holds the rule
+    // for reading the field and why an absent one leaves cloud sync on.
+    //
+    // A launch is not blocked on the answer. The store already holds the value
+    // this settles on in every case but one, so a settings endpoint having a bad
+    // day costs nothing here.
     try {
-      const response = await oxyClient.getClient().get<{ data?: { security?: { cloudSyncEnabled?: boolean } } }>('/profile/settings/me');
-      const settings = response.data;
-      const cloudSyncEnabled = settings?.security?.cloudSyncEnabled || false;
-      useMessagesStore.getState().setCloudSyncEnabled(cloudSyncEnabled);
+      useMessagesStore.getState().setCloudSyncEnabled(await fetchMyCloudSyncEnabled());
     } catch (error) {
-      console.warn('[AppInitializer] Failed to load security settings:', error);
+      logger.warn('[AppInitializer] the cloud sync setting could not be loaded', error);
     }
 
     // Initialize P2P manager. It re-mints its own access token on each
@@ -208,7 +212,7 @@ async function initializeSignalProtocol(): Promise<void> {
       await p2pManager.initialize(user.id);
     }
   } catch (error) {
-    console.error('[AppInitializer] Error initializing Signal Protocol:', error);
+    logger.error('[AppInitializer] Error initializing Signal Protocol', error);
     // Don't throw - encryption initialization shouldn't block app startup
   }
 }

--- a/packages/frontend/lib/chat/matrixAutoSignIn.ts
+++ b/packages/frontend/lib/chat/matrixAutoSignIn.ts
@@ -33,6 +33,8 @@
 export type AutoSignInPhase =
   | 'idle'
   | 'starting'
+  | 'blocked'
+  | 'blocked-timed-out'
   | 'authorizing'
   | 'leaving'
   | 'finishing'
@@ -69,7 +71,10 @@ export function shouldAutoSignIn({
   if (alreadyAttempted) {
     return false;
   }
-  // `idle` and `starting` have not finished deciding; `authorizing` is already
+  // `idle` and `starting` have not finished deciding; `blocked` is waiting on
+  // another window of Allo to close and `blocked-timed-out` has stopped waiting,
+  // and starting a sign-in in front of either would put a browser hop on top of
+  // a screen that is asking the reader for something; `authorizing` is already
   // in the browser, `leaving` is on its way there and `finishing` is on its way
   // back; `ready` needs nothing; `failed` owes an explanation.
   return phase === 'signed-out';

--- a/packages/frontend/lib/chat/matrixRuntime.ts
+++ b/packages/frontend/lib/chat/matrixRuntime.ts
@@ -1,3 +1,4 @@
+import { MatrixStoreEraseBlockedError } from '@/lib/matrix/errors';
 import { eraseAlloChatStore } from '@/lib/matrix/store';
 import type {
   AlloChatClient,
@@ -95,6 +96,23 @@ import {
  * MatrixPhase.failed} with no client. A store that could not be emptied must not
  * be opened by the identity that comes next; that is the whole point of emptying
  * it.
+ *
+ * ## An erase that is waiting says so
+ *
+ * The one case where stopping the launch was right and saying nothing was not.
+ * On web a second window of Allo holding the database open makes the deletion
+ * wait, and waiting is correct — it completes the moment that window closes. But
+ * the wait used to happen inside a phase called `starting`, so the screen drew
+ * "Connecting…" and kept drawing it, for as long as a tab nobody remembered
+ * opening stayed open. There was no way to learn that from inside the app and no
+ * way out but closing windows at random.
+ *
+ * So the erase reports itself (`AlloStoreEraseObserver`) and the two states it
+ * can be in are two phases here: `blocked` while it waits, which leaves by
+ * itself in either direction, and `blocked-timed-out` when the wait has been
+ * given up on. Neither builds a client. The second one especially: a bound that
+ * fell through into `createClient` would be this class opening a store it has
+ * just admitted it could not empty.
  */
 
 /** How far along the runtime is. */
@@ -106,6 +124,29 @@ export type MatrixPhase =
    * the session of a previous launch if there is one.
    */
   | 'starting'
+  /**
+   * The data this launch has to erase is open somewhere else, and the erase is
+   * waiting for it to be let go of.
+   *
+   * Web only, and always somebody else's browsing context: it is what IndexedDB
+   * reports when a second window of Allo still has the database open. Nothing is
+   * wrong and nothing has failed — the deletion completes on its own the moment
+   * that window closes, and this phase goes back to `starting` by itself when it
+   * does. It exists so the screen can say which window to close, which is the
+   * only thing anybody can do about it and the one thing the app used to keep to
+   * itself.
+   */
+  | 'blocked'
+  /**
+   * The wait above was given up on.
+   *
+   * Terminal, and distinct from `failed` in what it can honestly ask for: this
+   * is not something that went wrong, it is a window that is still open, so the
+   * screen asks again and offers to retry rather than apologising. **No client
+   * is built and no store is opened** — the store this launch could not empty is
+   * exactly the store the next identity must not inherit.
+   */
+  | 'blocked-timed-out'
   /** There is a client, and nobody has signed in. */
   | 'signed-out'
   /** An authorization is in flight in the browser. */
@@ -740,6 +781,19 @@ export class MatrixRuntime implements MatrixRuntimeLike {
       // Cleared so that the next attempt — a user pressing sign in again —
       // rebuilds instead of handing back this failure forever.
       this.#starting = undefined;
+      if (error instanceof MatrixStoreEraseBlockedError) {
+        // Not a defect and not the app's fault, so it is neither logged as an
+        // error nor drawn as one. The store was not erased, which is why this
+        // returns without a client like every other failure here: the phase is
+        // different, the guarantee is the same.
+        logger.warn(
+          '[chat] the chat data on this device is still open in another window, so ' +
+            'this one stopped rather than open it',
+          error,
+        );
+        this.#publish({ phase: 'blocked-timed-out', error: undefined });
+        return undefined;
+      }
       this.#fail('Allo could not start its Matrix client', error);
       return undefined;
     }
@@ -766,6 +820,15 @@ export class MatrixRuntime implements MatrixRuntimeLike {
    * cannot be trusted, a store that cannot be emptied must not be reopened, and a
    * session that cannot be forgotten would be reinstated by the next launch
    * against the store this one just erased.
+   *
+   * The erase is watched rather than only awaited, and what comes out of it is a
+   * phase. A deletion another window of Allo is holding up completes when that
+   * window closes, so the wait is kept — but it is announced, and it is announced
+   * from here because this is where the app is between two states and can say
+   * which. Coming back from `blocked` is the same publish in reverse: the store
+   * modules report the end of the wait as well as its start, so a person who
+   * closes the other window sees the app carry on rather than a screen that has
+   * to be reloaded.
    */
   async #reinstatable(
     stored: AlloSession | undefined,
@@ -777,7 +840,9 @@ export class MatrixRuntime implements MatrixRuntimeLike {
     }
 
     await this.#dependencies.storeOwner.clear();
-    await this.#dependencies.eraseStore(config.store);
+    await this.#dependencies.eraseStore(config.store, (blocked) => {
+      this.#publish({ phase: blocked ? 'blocked' : 'starting', error: undefined });
+    });
 
     if (stored === undefined) {
       // The ordinary signed-out launch, and the tail of a sign-out. Nothing was

--- a/packages/frontend/lib/matrix/errors.ts
+++ b/packages/frontend/lib/matrix/errors.ts
@@ -189,6 +189,43 @@ export class MatrixStoreNotErasedError extends MatrixPortError {
 }
 
 /**
+ * The client's data was still open somewhere else after the erase had waited as
+ * long as it is willing to.
+ *
+ * Its own type rather than a {@link MatrixStoreNotErasedError}, because the two
+ * are different situations wearing the same outcome. A store that was *refused*
+ * cannot be deleted at all and nothing the reader does will change that; a store
+ * that is *blocked* is one another window of Allo still has open, it deletes
+ * itself the moment that window goes, and the reader is the only person who can
+ * make that happen. The screen for the second one is a request, not an
+ * apology — which it can only be if the runtime can tell them apart.
+ *
+ * What it shares with its neighbour is the part that matters: it is raised, so
+ * the launch stops. A blocked erase is an erase that did not happen, and the
+ * store must not be opened by whoever comes next. Waiting longer instead is not
+ * the safer option it looks like — a wait with no end is the hang this type
+ * exists to replace.
+ *
+ * {@link names} is what was still open, so the failure says which database
+ * rather than only that there was one.
+ */
+export class MatrixStoreEraseBlockedError extends MatrixPortError {
+  readonly names: readonly string[];
+  /** How long the erase waited before it gave up, in milliseconds. */
+  readonly waitedMs: number;
+
+  constructor(names: readonly string[], waitedMs: number) {
+    super(
+      `The Matrix client's data is still open somewhere else after ${waitedMs}ms, ` +
+        'so it could not be erased and must not be reopened by a different ' +
+        `account: ${names.join(', ')}`,
+    );
+    this.names = names;
+    this.waitedMs = waitedMs;
+  }
+}
+
+/**
  * A recovery phrase that is not a BIP-39 mnemonic.
  *
  * The message names no words and quotes nothing back: the phrase is the whole

--- a/packages/frontend/lib/matrix/store.native.ts
+++ b/packages/frontend/lib/matrix/store.native.ts
@@ -57,6 +57,14 @@ export function resolveAlloChatStore(): AlloClientStore {
  * next account opening the last account's keys. Both directories are attempted
  * before anything is raised, so a state store that cannot go does not also leave
  * the event cache behind.
+ *
+ * It takes no `onBlocked` and would have nothing to say through one. The web
+ * half can be made to wait indefinitely by a second browsing context holding a
+ * database open; a directory has no such state. `delete()` here either removes
+ * the files or throws, and it does so before it returns — there is no third
+ * outcome to report and no wait for anybody to be told about. An app is one
+ * process on a phone, and the second copy of Allo that would hold these paths
+ * open does not exist.
  */
 export const eraseAlloChatStore: AlloChatStoreEraser = async (store) => {
   if (store.kind === 'in-memory') {

--- a/packages/frontend/lib/matrix/store.web.ts
+++ b/packages/frontend/lib/matrix/store.web.ts
@@ -1,5 +1,13 @@
-import { MatrixStoreNotErasedError, MatrixStoreUnavailableError } from '@/lib/matrix/errors';
-import type { AlloChatStoreEraser, AlloClientStore } from '@/lib/matrix/types';
+import {
+  MatrixStoreEraseBlockedError,
+  MatrixStoreNotErasedError,
+  MatrixStoreUnavailableError,
+} from '@/lib/matrix/errors';
+import type {
+  AlloChatStoreEraser,
+  AlloClientStore,
+  AlloStoreEraseObserver,
+} from '@/lib/matrix/types';
 import { logger } from '@/utils/logger';
 
 /**
@@ -31,9 +39,59 @@ import { logger } from '@/utils/logger';
  * still attempted before the failure is raised — stopping at the first refusal
  * would leave behind databases that could have gone — and what is raised names
  * the ones that did not.
+ *
+ * **A deletion that is BLOCKED is a different thing, and it is the one a person
+ * meets.** IndexedDB refuses to delete a database another connection still has
+ * open and leaves the request pending; the request completes on its own the
+ * moment that connection closes. So the erase waits, because waiting is both the
+ * behaviour that recovers and the only safe one — the caller is holding off a
+ * client that would otherwise open this database. What it does NOT do any more
+ * is wait in silence and wait forever. It says so through
+ * {@link AlloStoreEraseObserver} as soon as it starts waiting, so the launch can
+ * put a sentence on screen instead of a spinner, says so again if the wait ends
+ * by itself, and gives up after {@link BLOCKED_DELETION_TIMEOUT_MS} by raising
+ * {@link MatrixStoreEraseBlockedError}. Giving up is a REFUSAL TO CONTINUE and
+ * never a fall-through: the store that could not be emptied is not opened.
+ *
+ * ## Why "another window", inferred rather than proven
+ *
+ * `onblocked` says a connection exists; it does not say whose. The Web Locks API
+ * and `BroadcastChannel` were both considered for saying it with certainty, and
+ * neither can here: each needs a live participant *in the other window* — a lock
+ * held or a listener answering — which means every tab holding a client would
+ * have to register one, and that is the two-tab guard `client.web.ts` documents
+ * as absent and out of scope. A probe nobody answers proves nothing.
+ *
+ * What makes the inference safe enough to put on screen instead: IndexedDB is
+ * scoped to an origin, and these database names are Allo's own, built by this
+ * module. Nothing but Allo opens them, and the only place Allo runs on this
+ * origin is one of its own browsing contexts. The one case that is NOT another
+ * window is a client this tab closed a moment ago —
+ * `MatrixClient.stopClient()` does not close its `IndexedDBStore` — which the
+ * runtime can reach through `#startOver`. The copy is a request to close other
+ * windows, so the worst that case costs is a suggestion that does not help,
+ * ending at the bound in a screen with a button; before this it ended nowhere.
  */
 
 const LOG_TAG = '[matrix]';
+
+/**
+ * How long a deletion is allowed to wait for another connection to let go.
+ *
+ * Long enough for somebody who has just been told to go and close another window
+ * to find it and close it, and to have the launch carry on the moment they do —
+ * this bound is not the common ending, the other window closing is. Short enough
+ * that a window they cannot find, or one the browser is holding in a state they
+ * cannot see, does not leave them in front of a screen that never changes.
+ *
+ * A deletion that is not blocked has no timer at all: it either succeeds or
+ * errors, promptly and on its own. Blocked is the one outcome IndexedDB never
+ * settles by itself, which is why it is the one outcome that is bounded.
+ */
+export const BLOCKED_DELETION_TIMEOUT_MS = 30_000;
+
+/** Reports nothing, for the callers that have no screen to draw. */
+const IGNORE_BLOCKED: AlloStoreEraseObserver = () => {};
 
 /** The IndexedDB database name. Also the crypto databases' first component. */
 const STORE_NAME = 'allo-matrix';
@@ -73,19 +131,34 @@ export function cryptoDatabasePrefix(dataPath: string, deviceId: string): string
   return `${dataPath}:${deviceId}`;
 }
 
-export const eraseAlloChatStore: AlloChatStoreEraser = (store) =>
-  eraseWebStore(store, globalThis.indexedDB);
+export const eraseAlloChatStore: AlloChatStoreEraser = (store, onBlocked) =>
+  eraseWebStore(store, globalThis.indexedDB, { onBlocked });
+
+/** What an erase can be told beyond which store to empty. */
+export interface WebStoreEraseOptions {
+  /** Told when a deletion starts and stops waiting on another connection. */
+  readonly onBlocked?: AlloStoreEraseObserver;
+  /**
+   * How long one blocked deletion is waited out.
+   *
+   * Overridable for the same reason `indexedDB` is injected: a case about what
+   * happens at the bound should not take {@link BLOCKED_DELETION_TIMEOUT_MS}
+   * of wall clock to make its point. The app never passes it.
+   */
+  readonly blockedTimeoutMs?: number;
+}
 
 /**
  * The eraser, with the browser's IndexedDB handed in.
  *
  * Injected rather than read from `globalThis` so that the deletion — which
- * databases, in what order, and what a refusal does — can be exercised without a
- * browser.
+ * databases, in what order, what a refusal does and what a block does — can be
+ * exercised without a browser.
  */
 export async function eraseWebStore(
   store: AlloClientStore,
   indexedDB: IDBFactory | undefined,
+  options: WebStoreEraseOptions = {},
 ): Promise<void> {
   if (store.kind === 'in-memory') {
     return;
@@ -102,9 +175,16 @@ export async function eraseWebStore(
     names.add(name);
   }
 
+  const onBlocked = options.onBlocked ?? IGNORE_BLOCKED;
+  const blockedTimeoutMs = options.blockedTimeoutMs ?? BLOCKED_DELETION_TIMEOUT_MS;
+
   const remaining: string[] = [];
   for (const name of names) {
-    if (!(await deleteDatabase(name, indexedDB))) {
+    // A block, unlike a refusal, stops the loop rather than being collected:
+    // every database left would have to be waited out for the same bound, and
+    // several minutes of a screen that cannot change is not a better answer than
+    // one. It throws from here, so nothing below runs and nothing opens a store.
+    if (!(await deleteDatabase(name, indexedDB, onBlocked, blockedTimeoutMs))) {
       remaining.push(name);
     }
   }
@@ -154,30 +234,89 @@ async function cryptoDatabaseNames(
  * failure naming all of them.
  *
  * A deletion can be *blocked* rather than refused, which is a connection
- * somewhere else still holding the database open — another tab. It is reported
- * and waited out rather than treated as an error, because the request stays
- * pending and completes when the other connection closes. Waiting is the right
- * answer and it is also the safe one: the caller is holding off a client that
- * would otherwise open this database, and a launch that hangs with a line in the
- * log beats one that proceeds into somebody else's keys.
+ * somewhere else still holding the database open. The request stays pending and
+ * completes on its own when that connection closes, so this waits — the caller
+ * is holding off a client that would otherwise open this database, and a launch
+ * that waits beats one that proceeds into somebody else's keys.
+ *
+ * Three things make that wait something a person can live through rather than a
+ * hang:
+ *
+ * - it is **announced**, through `onBlocked`, the moment the browser says so;
+ * - it **ends by itself** when the other connection closes, which is the common
+ *   ending: `onsuccess` arrives, `onBlocked(false)` is reported, and the launch
+ *   carries on with nothing reloaded and nothing asked of anybody;
+ * - it is **bounded**, and at the bound it THROWS. Never resolves. A resolution
+ *   would be read by the caller as "the store is empty", which is the one thing
+ *   it is not.
+ *
+ * `onBlocked(false)` is deliberately not reported on the timeout path: the
+ * caller is about to be handed a failure and told to draw it, and a "carry on"
+ * a tick before that is a screen that flickers back to a spinner it will never
+ * leave.
+ *
+ * The pending request is not cancelled at the bound — IndexedDB has no way to —
+ * so it outlives the failure and may complete a minute later. That is fine and
+ * even useful: it still deletes the database, which is the state the next
+ * attempt wants. What must not happen is anything about it reaching a caller
+ * whose launch has moved on, which is what {@link settled} is for. It guards the
+ * one handler that can *say* something on its own — a browser is allowed to
+ * report `onblocked` more than once, and one arriving after this deletion is
+ * over would put "another window has your data" in front of somebody who is past
+ * it, and start a timer that outlives the page.
  */
-function deleteDatabase(name: string, indexedDB: IDBFactory): Promise<boolean> {
-  return new Promise((resolve) => {
+function deleteDatabase(
+  name: string,
+  indexedDB: IDBFactory,
+  onBlocked: AlloStoreEraseObserver,
+  blockedTimeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    /** Whether this deletion has an answer. A promise's own settling is not enough: see below. */
+    let settled = false;
+    let waiting: ReturnType<typeof setTimeout> | undefined;
+
+    /** Ends the wait, if there was one, and says so unless we are giving up. */
+    const stopWaiting = (announce: boolean): void => {
+      if (waiting === undefined) {
+        return;
+      }
+      clearTimeout(waiting);
+      waiting = undefined;
+      if (announce) {
+        onBlocked(false);
+      }
+    };
+
     const request = indexedDB.deleteDatabase(name);
     request.onsuccess = () => {
+      settled = true;
+      stopWaiting(true);
       resolve(true);
     };
     request.onerror = () => {
+      settled = true;
+      stopWaiting(true);
       // A browser whose `indexedDB` refuses mutations — some private windows do
       // — cannot have its store erased, and cannot be allowed to reopen one.
       logger.warn(`${LOG_TAG} the database ${name} could not be deleted`, request.error);
       resolve(false);
     };
     request.onblocked = () => {
+      // Once, and only while this deletion is still the live question.
+      if (settled || waiting !== undefined) {
+        return;
+      }
       logger.warn(
         `${LOG_TAG} the database ${name} is still open somewhere else; it will ` +
           'be deleted when that connection closes',
       );
+      onBlocked(true);
+      waiting = setTimeout(() => {
+        settled = true;
+        waiting = undefined;
+        reject(new MatrixStoreEraseBlockedError([name], blockedTimeoutMs));
+      }, blockedTimeoutMs);
     };
   });
 }

--- a/packages/frontend/lib/matrix/types.ts
+++ b/packages/frontend/lib/matrix/types.ts
@@ -766,6 +766,27 @@ export type AlloClientStore =
   | { readonly kind: 'filesystem'; readonly dataPath: string; readonly cachePath: string };
 
 /**
+ * Told when an erase starts waiting on something else that has the store open,
+ * and told again when it stops.
+ *
+ * The one thing an erase has to say while it is still running, and it is here
+ * rather than in a platform's own module because the caller is the runtime and
+ * the runtime is what draws a screen. An erase that waits is indistinguishable
+ * from one that is slow, and the difference is the difference between a launch
+ * that is working and a launch that is waiting on a person to close a window.
+ *
+ * Deliberately a boolean and not a reason: *why* a store cannot be deleted yet
+ * is the platform's business — an IndexedDB deletion refused by a second
+ * browsing context on web, and nothing at all on a phone — and the port would
+ * have to invent a vocabulary that only one implementation could ever speak.
+ * What crosses the boundary is the only part the caller can act on.
+ *
+ * It may be called more than once in each direction: an erase deletes several
+ * databases in turn and any of them can wait.
+ */
+export type AlloStoreEraseObserver = (blocked: boolean) => void;
+
+/**
  * Deletes what a client built on a store would otherwise inherit.
  *
  * Separate from {@link AlloChatClient.logout} because it has to be callable when
@@ -775,9 +796,16 @@ export type AlloClientStore =
  * session". Handing a new session a store that belongs to an older one is the
  * failure that does not look like its cause.
  *
- * Erasing a store nothing has written is not an error.
+ * Erasing a store nothing has written is not an error. Failing to erase one that
+ * is there IS: it is raised, and the caller must not open the store afterwards.
+ *
+ * {@link AlloStoreEraseObserver} is optional because a caller with no screen to
+ * draw — the native client's own sign-out — has nothing to do with the answer.
  */
-export type AlloChatStoreEraser = (store: AlloClientStore) => Promise<void>;
+export type AlloChatStoreEraser = (
+  store: AlloClientStore,
+  onBlocked?: AlloStoreEraseObserver,
+) => Promise<void>;
 
 export interface AlloChatClientConfig {
   readonly homeserverUrl: string;

--- a/packages/frontend/lib/security/cloudSync.ts
+++ b/packages/frontend/lib/security/cloudSync.ts
@@ -1,0 +1,120 @@
+/**
+ * WHETHER THIS ACCOUNT'S MESSAGES GO THROUGH ALLO'S SERVER.
+ *
+ * One field of the settings document — `security.cloudSyncEnabled` — and the
+ * rule for reading it, which is not the obvious one and is the whole reason this
+ * module exists rather than a line at each call site.
+ *
+ * ## Which client
+ *
+ * `api`, the linked client pointed at Allo's own backend. NOT the Oxy client:
+ * Oxy mounts `/profiles`, Allo mounts `/profile`
+ * (`packages/backend/src/server.ts`), and this document is Allo's
+ * (`routes/profileSettings.ts`). `lib/appInitializer.ts` asked the Oxy client for
+ * it and had been getting a 404 on every launch since the line was written —
+ * the same mistake #102 fixed for the privacy screens, in the one file it did
+ * not reach. `lib/privacy/api.ts` and `stores/appearanceStore.ts` already read
+ * neighbouring fields of this very document through `api`.
+ *
+ * ## What the document says, and what it means
+ *
+ * The backend's schema gives the field a default of `false`, and the default is
+ * not notional: `new UserSettings({ oxyUserId })` persists
+ * `security: { cloudSyncEnabled: false, … }`, and `ensureUserSettings` creates
+ * exactly that document on the first `GET`. Every account that has ever opened
+ * Allo has one, because the appearance store fetches this endpoint at boot.
+ *
+ * The field is therefore `false` on the server for very nearly everybody, and
+ * for **nobody** is that `false` a decision: the only screen that can set it
+ * wrote to the Oxy client too, so no value a person chose has ever reached the
+ * server. It is absent only in documents written before `security` was added to
+ * the schema, because `.lean()` applies no defaults.
+ *
+ * ## The rule
+ *
+ * > The document is trusted to turn cloud sync **on**. It is not trusted to turn
+ * > it **off**, and an absent field leaves it on.
+ *
+ * So {@link CLOUD_SYNC_ENABLED_BY_DEFAULT} — `true`, the value
+ * `stores/messagesStore.ts` starts with and the value the app has actually run
+ * with for its whole life — wins for both `false` and absent.
+ *
+ * `settings?.security?.cloudSyncEnabled || false` did the opposite, and repairing
+ * only the URL under it would have turned cloud sync off for every account at
+ * boot. That is not a small thing: with it off, `fetchMessages` does not ask the
+ * server at all, so a message that arrived while the app was closed is never
+ * backfilled and a reinstalled device opens to empty conversations. A bug fix
+ * that loses messages is not a fix.
+ *
+ * **The exit condition, stated so nobody has to guess it.** This rule is
+ * asymmetric because the server's `false` is undecidable, not because off is a
+ * worse answer than on. When `SecuritySchema.cloudSyncEnabled` in
+ * `packages/backend/src/models/UserSettings.ts` no longer writes a value nobody
+ * asked for, a `false` from the server becomes a decision and this becomes a
+ * plain "a boolean wins, absent means on".
+ */
+
+import { api } from '@/utils/api';
+
+/**
+ * What cloud sync is when the account's document does not decide it.
+ *
+ * The same value `stores/messagesStore.ts` initialises the store with. They are
+ * two statements of one fact and they must not drift: this is what a launch
+ * settles on, that is what the app runs with until a launch settles anything.
+ */
+export const CLOUD_SYNC_ENABLED_BY_DEFAULT = true;
+
+/** The part of the settings document this module reads. */
+interface SecurityDocument {
+  security?: {
+    cloudSyncEnabled?: unknown;
+  };
+}
+
+/**
+ * The `{ data: … }` envelope Allo's endpoints wrap their answers in.
+ *
+ * `api.get` unwraps its own layer, so what arrives here is the parsed body —
+ * which has a `data` of its own from `sendSuccessResponse`. Unwrapped
+ * defensively rather than assumed, the same way `lib/privacy/api.ts` and
+ * `stores/appearanceStore.ts` do it for neighbouring fields of the same
+ * document.
+ */
+function unwrapEnvelope(body: unknown): SecurityDocument | null {
+  if (typeof body !== 'object' || body === null) {
+    return null;
+  }
+  const record: Record<string, unknown> = { ...body };
+  const inner = 'data' in record ? record.data : record;
+  return typeof inner === 'object' && inner !== null ? (inner as SecurityDocument) : null;
+}
+
+/**
+ * Reads the setting out of whatever the endpoint returned.
+ *
+ * Exported because the rule at the top of this file is the interesting part and
+ * it should be assertable without a network. See there for why `false` and
+ * absent are the same answer here and `true` is not.
+ */
+export function readCloudSyncEnabled(body: unknown): boolean {
+  const stored = unwrapEnvelope(body)?.security?.cloudSyncEnabled;
+  return stored === true ? true : CLOUD_SYNC_ENABLED_BY_DEFAULT;
+}
+
+/** What this account's document says cloud sync should be on this launch. */
+export async function fetchMyCloudSyncEnabled(): Promise<boolean> {
+  const response = await api.get<unknown>('profile/settings/me');
+  return readCloudSyncEnabled(response.data);
+}
+
+/**
+ * Writes the choice to the account's document.
+ *
+ * A PATCH in everything but name: the backend builds a `$set` of only the keys
+ * it recognises, so sending this one leaves `encryptionEnabled`,
+ * `peerToPeerEnabled` and every other part of the document exactly as they were.
+ */
+export async function updateMyCloudSyncEnabled(enabled: boolean): Promise<void> {
+  await api.put('profile/settings', { security: { cloudSyncEnabled: enabled } });
+}

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -612,6 +612,10 @@
     }
   },
   "Connecting…": "Connecting…",
+  "Allo is open in another tab": "Allo is open in another tab",
+  "Close the other Allo tab and this one will carry on by itself.": "Close the other Allo tab and this one will carry on by itself.",
+  "Allo is still open in another tab": "Allo is still open in another tab",
+  "Close every other Allo tab or window, then try again.": "Close every other Allo tab or window, then try again.",
   "Finish signing in": "Finish signing in",
   "Allo is waiting for the sign-in page in your browser.": "Allo is waiting for the sign-in page in your browser.",
   "Allo could not connect your chat": "Allo could not connect your chat",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -581,6 +581,10 @@
     }
   },
   "Connecting…": "Conectando…",
+  "Allo is open in another tab": "Allo está abierto en otra pestaña",
+  "Close the other Allo tab and this one will carry on by itself.": "Cierra la otra pestaña de Allo y esta seguirá sola.",
+  "Allo is still open in another tab": "Allo sigue abierto en otra pestaña",
+  "Close every other Allo tab or window, then try again.": "Cierra las demás pestañas y ventanas de Allo y vuelve a intentarlo.",
   "Finish signing in": "Termina de iniciar sesión",
   "Allo is waiting for the sign-in page in your browser.": "Allo está esperando a la página de inicio de sesión de tu navegador.",
   "Allo could not connect your chat": "Allo no ha podido conectar tu chat",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -575,6 +575,10 @@
     }
   },
   "Connecting…": "Connessione…",
+  "Allo is open in another tab": "Allo è aperto in un’altra scheda",
+  "Close the other Allo tab and this one will carry on by itself.": "Chiudi l’altra scheda di Allo e questa proseguirà da sola.",
+  "Allo is still open in another tab": "Allo è ancora aperto in un’altra scheda",
+  "Close every other Allo tab or window, then try again.": "Chiudi tutte le altre schede e finestre di Allo, poi riprova.",
   "Finish signing in": "Completa l'accesso",
   "Allo is waiting for the sign-in page in your browser.": "Allo sta aspettando la pagina di accesso nel tuo browser.",
   "Allo could not connect your chat": "Allo non è riuscito a collegare la tua chat",

--- a/packages/frontend/stores/messagesStore.ts
+++ b/packages/frontend/stores/messagesStore.ts
@@ -12,6 +12,7 @@ import {
   addToSyncQueue,
 } from '@/lib/offlineStorage';
 import { p2pManager } from '@/lib/p2pMessaging';
+import { CLOUD_SYNC_ENABLED_BY_DEFAULT } from '@/lib/security/cloudSync';
 import { logger } from '@/utils/logger';
 import NetInfo from '@react-native-community/netinfo';
 
@@ -179,7 +180,13 @@ export const useMessagesStore = create<MessagesState>()(
     loadingByConversation: {},
     errorByConversation: {},
     lastUpdatedByConversation: {},
-    cloudSyncEnabled: true, // Enable cloud sync by default for reliable messaging
+    // What the app runs with until a launch reads the account's document, and
+    // what that read settles on when the document does not decide it. Imported
+    // rather than written twice: the two used to be a `true` here and a
+    // `|| false` there, and only a 404 kept them from disagreeing out loud. See
+    // `lib/security/cloudSync.ts` for the rule and for why `false` on the server
+    // is not yet anybody's decision.
+    cloudSyncEnabled: CLOUD_SYNC_ENABLED_BY_DEFAULT,
 
     // Actions
     setMessages: async (conversationId, messages) => {


### PR DESCRIPTION
Two boot-path failures the owner hit in production.

## 1. A blocked store deletion hung the launch in silence

A launch erases the store before it opens it. A second window of Allo holding those databases open makes IndexedDB leave the `deleteDatabase` pending, and `store.web.ts` waited it out — correct, because it completes when that window closes, and because the alternative is opening a store that could not be emptied (#104). But the wait happened inside the phase called `starting`, so the gate drew "Connecting…" forever with the reason only in the console.

The erase now reports itself across the port (`AlloStoreEraseObserver`, one boolean — the platform keeps *why* to itself), and the runtime turns it into two phases:

- **`blocked`** — spinner plus "Allo is open in another tab" and what to do about it. Leaves by itself in both directions, so closing the other window resumes the launch with nothing reloaded.
- **`blocked-timed-out`** — after 30s. No spinner, the same request, and a Try again that rebuilds and retries the deletion.

Neither builds a client, and the bound **raises** rather than resolving: a resolution is read as "the store is empty" and is followed immediately by opening it.

Web Locks and BroadcastChannel were considered for proving "another tab" rather than inferring it; both need a live participant in the other window, which is the two-tab guard that stays out of scope. The one case the inference gets wrong is written down in the file header. This does not make two tabs safe.

## 2. Security settings 404ed on every boot

`lib/appInitializer.ts` asked the Oxy client for `/profile/settings/me`; Oxy mounts `/profiles` and the document is Allo's. Repairing only the URL would have been worse than the 404: the line under it was `… || false`, and the backend persists `security.cloudSyncEnabled: false` into every document `ensureUserSettings` creates. Nobody chose those falses — the settings switch wrote to the Oxy client too.

So `lib/security/cloudSync.ts` owns the endpoint and one deliberate rule: **the document is trusted to turn cloud sync on, not to turn it off, and an absent field leaves it on.** With cloud sync off, `fetchMessages` never asks the server, so a message that arrived while the app was closed is never backfilled. The asymmetry is because the server's `false` is undecidable today; the exit condition is in the module and guarded by a test that reads the backend model. The write is fixed too, and `console.warn`/`console.error` become `logger`.

## Test plan

| | before | after |
|---|---|---|
| `bunx tsc --noEmit` | 0 errors | **0 errors** |
| `bunx jest --watchAll=false` | 93 suites / 1356 tests | **94 suites / 1395 tests**, green |
| `bun run --cwd packages/frontend build` | — | **`Exported: dist`** |

39 new tests. `bunx expo lint` is red on `main` (156 pre-existing problems); no new one comes from these files.

**Mutation-tested: 22 mutations, 0 survived, 0 never matched.** Each applied to disk, verified changed by hash before the run, restored and verified restored after. The first pass had 3 survivors and all three were real gaps, now closed:

- a redundant `settled` guard on `onsuccess` (removed; the guard that matters is on `onblocked`, and a stray or repeated report is now covered);
- `signInGateCopy.test.ts` read one direction only — replacing the blocked screen's title with a bare literal survived 1355 tests. It now asserts every required key is actually asked for;
- `messagesStore`'s default was a literal that happened to agree with the constant. It imports it now, and a test says so.

Mutations that must fail and do: the bound resolving instead of raising; the bound removed; the wait never announced; the end of the wait never announced; the bounded state falling through into `createClient`; the bounded state drawn as `failed`; auto sign-in firing over either screen; absent → false; stored false honoured; the default flipped; either request pointed back at Oxy.

Not merging.
