### PR TITLE
feat(backend): social repositories — blocks, restricts, user settings and behaviour

### DIFF
--- a/packages/backend/src/__tests__/db/social.realdb.test.ts
+++ b/packages/backend/src/__tests__/db/social.realdb.test.ts
@@ -1,0 +1,674 @@
+/**
+ * The social repositories — blocks, restricts, settings and behaviour — against
+ * a REAL Postgres server.
+ *
+ * Every property worth asserting in this domain is one only a server has: a
+ * unique index deciding a race, a column DEFAULT supplying a value the
+ * application deliberately does not, a CHECK refusing a value that type-checks.
+ * A mocked `insert` accepts all three, which is exactly why the foundation PR
+ * booted this harness rather than mocking drizzle.
+ *
+ * Nothing here imports a route or a Mongoose model. The repositories land
+ * unused; this file is the only thing that calls them.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, getTableColumns } from "drizzle-orm";
+import { createDatabase, constraintNameOf, isCheckViolation, isUniqueViolation } from "@oxyhq/db";
+import type postgres from "postgres";
+import { setUpTestDatabase, type TestDatabaseHandle } from "../../db/testDatabase";
+import * as schema from "../../db/schema";
+import { blockUser, listBlockedUserIds, unblockUser } from "../../db/social/blockRepository";
+import {
+  listRestrictedUserIds,
+  restrictUser,
+  unrestrictUser,
+} from "../../db/social/restrictRepository";
+import { deleteUserBehavior } from "../../db/social/userBehaviorRepository";
+import {
+  ensureUserSettings,
+  updateUserSettings,
+  UPDATABLE_USER_SETTINGS_COLUMNS,
+  type UserSettingsPatch,
+} from "../../db/social/userSettingsRepository";
+
+let handle: TestDatabaseHandle;
+let db: ReturnType<typeof createDatabase<typeof schema>>["db"];
+let client: postgres.Sql;
+
+/** Unique per call so cases cannot collide inside the one shared database. */
+let counter = 0;
+function id(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${String(counter).padStart(4, "0")}`;
+}
+
+/**
+ * Open eight pool connections before a case races on them.
+ *
+ * Not ceremony — measured. postgres.js opens connections on demand, so the FIRST
+ * concurrent burst after a run of sequential queries queues onto the single
+ * connection that happens to be open and executes strictly in order. A racing
+ * case in that position silently tests nothing: mutating `blockUser` to the
+ * read-then-write it replaced left every racing case here GREEN, while the same
+ * bursts preceded by this warm-up caught it 20 times out of 20.
+ */
+async function warmPool(userId: string): Promise<void> {
+  await Promise.all(Array.from({ length: 8 }, () => listBlockedUserIds(db, userId)));
+}
+
+beforeAll(async () => {
+  handle = await setUpTestDatabase();
+  const created = createDatabase({ databaseUrl: handle.databaseUrl, schema });
+  db = created.db;
+  client = created.client;
+}, 180_000);
+
+afterAll(async () => {
+  await client?.end();
+  await handle?.drop();
+});
+
+describe("blocks converge on the unique index instead of reading first", () => {
+  it("reports whether the call is what created the block", async () => {
+    const pair = { userId: id("blocker"), blockedId: id("blocked") };
+
+    expect(await blockUser(db, pair)).toBe(true);
+    expect(await blockUser(db, pair)).toBe(false);
+
+    const rows = await db.select().from(schema.blocks).where(eq(schema.blocks.userId, pair.userId));
+    // The second call is what `POST /blocks` answers 200 to rather than 201, and
+    // it must not have written a second row to do it.
+    expect(rows).toHaveLength(1);
+  });
+
+  it("blocks in ONE statement, so there is no window between a read and a write", async () => {
+    const statements: string[] = [];
+    const observed = createDatabase({
+      databaseUrl: handle.databaseUrl,
+      schema,
+      client: {
+        debug: (_connection: number, query: string) => {
+          statements.push(query.toLowerCase());
+        },
+      },
+    });
+
+    try {
+      const pair = { userId: id("blocker"), blockedId: id("blocked") };
+      // Open the socket first: postgres.js emits its own setup chatter on a new
+      // connection and none of it belongs to the measurement.
+      await listBlockedUserIds(observed.db, pair.userId);
+
+      statements.length = 0;
+      expect(await blockUser(observed.db, pair)).toBe(true);
+      const firstCall = [...statements];
+
+      statements.length = 0;
+      expect(await blockUser(observed.db, pair)).toBe(false);
+      const secondCall = [...statements];
+
+      // THE property, and the only deterministic way to observe it. Both a
+      // correct repository and a read-then-write one answer `false` for a block
+      // that already exists, so no assertion about the RESULT can tell them
+      // apart; what differs is that the second issues two statements with a gap
+      // between them, and the gap is the race. Measured: the mutation makes this
+      // read 2.
+      expect(firstCall).toHaveLength(1);
+      expect(secondCall).toHaveLength(1);
+      expect(firstCall[0]).toContain('insert into "blocks"');
+      expect(firstCall[0]).toContain("on conflict");
+      expect(firstCall[0]).not.toContain("select");
+
+      // Anti-vacuity: the hook really does count each statement, so `1` above is
+      // a measurement rather than a callback that never fired.
+      statements.length = 0;
+      await listBlockedUserIds(observed.db, pair.userId);
+      await listBlockedUserIds(observed.db, pair.userId);
+      expect(statements).toHaveLength(2);
+    } finally {
+      await observed.client.end();
+    }
+  });
+
+  it("survives eight concurrent blocks of the same person", async () => {
+    const pair = { userId: id("blocker"), blockedId: id("blocked") };
+    await warmPool(pair.userId);
+
+    // The race the Mongoose version lost: `findOne` then `create` let every one
+    // of these see nothing and insert, and seven of the eight then failed on the
+    // index. See `warmPool` — without it these serialise and prove nothing.
+    const outcomes = await Promise.all(
+      Array.from({ length: 8 }, () => blockUser(db, pair)),
+    );
+
+    // Not "at least one": exactly one, and none of the eight rejected. A
+    // repository that let the duplicate-key error escape fails here, not only
+    // one that wrote two rows.
+    expect(outcomes.filter(Boolean)).toHaveLength(1);
+    const rows = await db.select().from(schema.blocks).where(eq(schema.blocks.userId, pair.userId));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("scopes the unique index to the PAIR, so two people may block one person", async () => {
+    const target = id("blocked");
+    const first = id("blocker");
+    const second = id("blocker");
+
+    expect(await blockUser(db, { userId: first, blockedId: target })).toBe(true);
+    // A conflict target of `blockedId` alone would swallow this and report false.
+    expect(await blockUser(db, { userId: second, blockedId: target })).toBe(true);
+
+    const rows = await db
+      .select()
+      .from(schema.blocks)
+      .where(eq(schema.blocks.blockedId, target));
+    expect(rows).toHaveLength(2);
+  });
+
+  it("names the index the repository's conflict target relies on", async () => {
+    const pair = { userId: id("blocker"), blockedId: id("blocked") };
+    await blockUser(db, pair);
+
+    // Written raw, bypassing `ON CONFLICT`, so the constraint itself answers —
+    // this is what proves the index the repository infers actually exists under
+    // the name the schema declares.
+    const error = await db
+      .insert(schema.blocks)
+      .values({ id: id("blk"), userId: pair.userId, blockedId: pair.blockedId })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+    expect(error).not.toBeNull();
+    expect(isUniqueViolation(error)).toBe(true);
+    // Named, not matched on a message: drizzle wraps the driver error, so the
+    // constraint name lives on `cause` and a regex over the text would pass for
+    // the wrong index.
+    expect(constraintNameOf(error)).toBe("blocks_user_id_blocked_id_key");
+  });
+
+  it("lists only the owner's blocks, newest first", async () => {
+    const owner = id("blocker");
+    const other = id("blocker");
+    const first = id("blocked");
+    const second = id("blocked");
+    const third = id("blocked");
+
+    await blockUser(db, { userId: owner, blockedId: first });
+    await blockUser(db, { userId: owner, blockedId: second });
+    await blockUser(db, { userId: owner, blockedId: third });
+    // Anti-vacuity for the scoping half: a query missing its `where` would
+    // return this too, and an assertion on the owner's rows alone could not see it.
+    await blockUser(db, { userId: other, blockedId: first });
+
+    expect(await listBlockedUserIds(db, owner)).toEqual([third, second, first]);
+    expect(await listBlockedUserIds(db, other)).toEqual([first]);
+  });
+
+  it("returns an empty list for someone who has blocked nobody", async () => {
+    expect(await listBlockedUserIds(db, id("stranger"))).toEqual([]);
+  });
+
+  it("reports whether unblocking removed anything", async () => {
+    const pair = { userId: id("blocker"), blockedId: id("blocked") };
+    await blockUser(db, pair);
+
+    // `DELETE /blocks/:blockedId` answers 404 on the second call, so the two
+    // outcomes cannot collapse into "succeeded".
+    expect(await unblockUser(db, pair)).toBe(true);
+    expect(await unblockUser(db, pair)).toBe(false);
+    expect(await listBlockedUserIds(db, pair.userId)).toEqual([]);
+  });
+
+  it("unblocks only the named pair", async () => {
+    const owner = id("blocker");
+    const kept = id("blocked");
+    const removed = id("blocked");
+    await blockUser(db, { userId: owner, blockedId: kept });
+    await blockUser(db, { userId: owner, blockedId: removed });
+
+    await unblockUser(db, { userId: owner, blockedId: removed });
+    expect(await listBlockedUserIds(db, owner)).toEqual([kept]);
+  });
+});
+
+describe("restricts are the same shape and a separate table", () => {
+  it("converges, lists and removes exactly as blocks do", async () => {
+    const pair = { userId: id("restricter"), restrictedId: id("restricted") };
+
+    expect(await restrictUser(db, pair)).toBe(true);
+    expect(await restrictUser(db, pair)).toBe(false);
+    expect(await listRestrictedUserIds(db, pair.userId)).toEqual([pair.restrictedId]);
+    expect(await unrestrictUser(db, pair)).toBe(true);
+    expect(await unrestrictUser(db, pair)).toBe(false);
+  });
+
+  it("survives eight concurrent restrictions of the same person", async () => {
+    const pair = { userId: id("restricter"), restrictedId: id("restricted") };
+    await warmPool(pair.userId);
+    const outcomes = await Promise.all(
+      Array.from({ length: 8 }, () => restrictUser(db, pair)),
+    );
+    expect(outcomes.filter(Boolean)).toHaveLength(1);
+  });
+
+  it("does not touch blocks — the two tables are not one table with a kind", async () => {
+    const userId = id("blocker");
+    const target = id("target");
+
+    await blockUser(db, { userId, blockedId: target });
+
+    // If the port had "DRY'd" these into one table, this would read as restricted.
+    expect(await listRestrictedUserIds(db, userId)).toEqual([]);
+    expect(await listBlockedUserIds(db, userId)).toEqual([target]);
+
+    await restrictUser(db, { userId, restrictedId: target });
+    await unblockUser(db, { userId, blockedId: target });
+
+    // And removing one must not remove the other.
+    expect(await listRestrictedUserIds(db, userId)).toEqual([target]);
+    expect(await listBlockedUserIds(db, userId)).toEqual([]);
+  });
+});
+
+describe("user_settings defaults come from the schema, not from the repository", () => {
+  it("creates a row with every field ABSENT and lets the server fill it", async () => {
+    const oxyUserId = id("settings-user");
+    const row = await ensureUserSettings(db, oxyUserId);
+
+    // The fixture shape that matters: NOTHING was supplied but the id and the
+    // owner, so each value below is the column's own DEFAULT. A row written with
+    // these fields set explicitly could not tell a correct repository from one
+    // that hardcodes its own literals.
+    expect(row.appearanceThemeMode).toBe("system");
+    expect(row.appearancePrimaryColor).toBeNull();
+    expect(row.privacyProfileVisibility).toBe("public");
+    expect(row.privacyShowContactInfo).toBe(true);
+    expect(row.privacyHideLikeCounts).toBe(false);
+    expect(row.privacyHiddenWords).toEqual([]);
+    expect(row.privacyRestrictedUsers).toEqual([]);
+    expect(row.profileCoverPhotoEnabled).toBe(true);
+    expect(row.profileMinimalistMode).toBe(false);
+  });
+
+  it("keeps cloud sync opt-IN while encryption and P2P are opt-OUT", async () => {
+    const row = await ensureUserSettings(db, id("settings-user"));
+
+    // The asymmetry IS the product's device-first stance, so it is asserted as
+    // three separate facts rather than "the security defaults are correct".
+    expect(row.securityCloudSyncEnabled).toBe(false);
+    expect(row.securityEncryptionEnabled).toBe(true);
+    expect(row.securityPeerToPeerEnabled).toBe(true);
+  });
+
+  it("takes the security values from the column DEFAULT, not from a literal it writes", async () => {
+    // The case above cannot distinguish "the repository omitted the column" from
+    // "the repository wrote `false` itself" — both produce a `false`. Moving the
+    // DEFAULT out from under it can: only a repository that genuinely omits the
+    // column sees the new default. A repository that "helpfully normalises"
+    // missing settings would still report false here, and that is the mistake
+    // most likely to be made, because it looks like defensive coding.
+    await client`alter table user_settings alter column security_cloud_sync_enabled set default true`;
+    try {
+      const row = await ensureUserSettings(db, id("settings-user"));
+      expect(row.securityCloudSyncEnabled).toBe(true);
+    } finally {
+      await client`alter table user_settings alter column security_cloud_sync_enabled set default false`;
+    }
+
+    // And the restore worked, so no later case inherits a poisoned default.
+    const after = await ensureUserSettings(db, id("settings-user"));
+    expect(after.securityCloudSyncEnabled).toBe(false);
+  });
+});
+
+describe("ensuring settings is idempotent and does not rewrite the row", () => {
+  it("returns the same row twice without touching it", async () => {
+    const oxyUserId = id("settings-user");
+    const first = await ensureUserSettings(db, oxyUserId);
+
+    const probe = async () =>
+      client<{ xmin: string; updated_at: string }[]>`
+        select xmin::text, updated_at::text from user_settings where oxy_user_id = ${oxyUserId}
+      `;
+
+    const before = await probe();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = await ensureUserSettings(db, oxyUserId);
+    const after = await probe();
+
+    expect(second.id).toBe(first.id);
+    // `xmin` is the row's transaction id: an `ON CONFLICT DO UPDATE` careful
+    // enough to write identical values still moves it, so this catches what
+    // comparing columns cannot. Reading settings must not be a write.
+    expect(after[0].xmin).toBe(before[0].xmin);
+    expect(after[0].updated_at).toBe(before[0].updated_at);
+  });
+
+  it("gives every racer the same row on a user's first request", async () => {
+    const oxyUserId = id("settings-user");
+    await warmPool(oxyUserId);
+
+    // Eight concurrent first requests: seven lose the unique constraint and take
+    // the re-read path, and none may error or produce a second row.
+    const rows = await Promise.all(
+      Array.from({ length: 8 }, () => ensureUserSettings(db, oxyUserId)),
+    );
+
+    const ids = new Set(rows.map((row) => row.id));
+    expect(ids.size).toBe(1);
+    const stored = await db
+      .select()
+      .from(schema.userSettings)
+      .where(eq(schema.userSettings.oxyUserId, oxyUserId));
+    expect(stored).toHaveLength(1);
+  });
+});
+
+describe("a settings update is partial, and is an allow-list", () => {
+  it("upserts when there is no row yet, applying the patch over the defaults", async () => {
+    const oxyUserId = id("settings-user");
+    const row = await updateUserSettings(db, oxyUserId, {
+      appearanceThemeMode: "dark",
+      securityCloudSyncEnabled: true,
+    });
+
+    expect(row.appearanceThemeMode).toBe("dark");
+    expect(row.securityCloudSyncEnabled).toBe(true);
+    // Untouched columns still get their defaults — this is the `{ upsert: true }`
+    // half, and it must not produce a row of nulls.
+    expect(row.securityEncryptionEnabled).toBe(true);
+    expect(row.privacyProfileVisibility).toBe("public");
+  });
+
+  it("leaves every column the patch did not name alone", async () => {
+    const oxyUserId = id("settings-user");
+    await updateUserSettings(db, oxyUserId, {
+      appearanceThemeMode: "dark",
+      appearancePrimaryColor: "#ff0000",
+      privacyProfileVisibility: "private",
+      privacyShowContactInfo: false,
+      privacyHiddenWords: ["one", "two"],
+      profileDisplayName: "Ada",
+      securityCloudSyncEnabled: true,
+    });
+
+    const row = await updateUserSettings(db, oxyUserId, { privacyAllowTags: false });
+
+    expect(row.privacyAllowTags).toBe(false);
+    // A read-modify-write, or an update built from a reconstructed nested
+    // object, would reset these to their defaults here.
+    expect(row.appearanceThemeMode).toBe("dark");
+    expect(row.appearancePrimaryColor).toBe("#ff0000");
+    expect(row.privacyProfileVisibility).toBe("private");
+    expect(row.privacyShowContactInfo).toBe(false);
+    expect(row.privacyHiddenWords).toEqual(["one", "two"]);
+    expect(row.profileDisplayName).toBe("Ada");
+    expect(row.securityCloudSyncEnabled).toBe(true);
+  });
+
+  it("tells `null` (clear it) from absent (leave it)", async () => {
+    const oxyUserId = id("settings-user");
+    await updateUserSettings(db, oxyUserId, {
+      appearancePrimaryColor: "#00ff00",
+      profileDisplayName: "Grace",
+    });
+
+    // The distinction the `!== undefined` test exists to make. A fixture set
+    // carrying only non-null values sits entirely on one side of it and would
+    // pass against an implementation that treated both as "skip" — or both as
+    // "write null".
+    const row = await updateUserSettings(db, oxyUserId, { appearancePrimaryColor: null });
+
+    expect(row.appearancePrimaryColor).toBeNull();
+    expect(row.profileDisplayName).toBe("Grace");
+  });
+
+  it("treats an empty patch as Mongo's upsert-and-return, not an error", async () => {
+    const oxyUserId = id("settings-user");
+
+    // Reachable in production: the route builds its patch from whichever request
+    // fields validated, so a body with nothing recognisable lands here.
+    const created = await updateUserSettings(db, oxyUserId, {});
+    expect(created.oxyUserId).toBe(oxyUserId);
+
+    const again = await updateUserSettings(db, oxyUserId, {});
+    expect(again.id).toBe(created.id);
+
+    const stored = await db
+      .select()
+      .from(schema.userSettings)
+      .where(eq(schema.userSettings.oxyUserId, oxyUserId));
+    expect(stored).toHaveLength(1);
+  });
+
+  it("drops keys outside the allow-list instead of assigning them", async () => {
+    const oxyUserId = id("settings-user");
+    const victim = id("settings-user");
+    const created = await ensureUserSettings(db, oxyUserId);
+
+    // A subtype of the patch, which is how this reaches a repository in
+    // practice: nobody writes a cast, somebody widens a type or forwards a
+    // richer object. TypeScript's excess-property check only fires on object
+    // literals at the call site, so the type alone does not stop this — the
+    // allow-list loop does.
+    interface HostilePatch extends UserSettingsPatch {
+      id?: string;
+      oxyUserId?: string;
+      createdAt?: Date;
+    }
+    const hostile: HostilePatch = {
+      privacyAllowTags: false,
+      id: id("forged"),
+      oxyUserId: victim,
+      createdAt: new Date(0),
+    };
+
+    const row = await updateUserSettings(db, oxyUserId, hostile);
+
+    expect(row.privacyAllowTags).toBe(false);
+    expect(row.id).toBe(created.id);
+    expect(row.oxyUserId).toBe(oxyUserId);
+    expect(row.createdAt.getTime()).toBe(created.createdAt.getTime());
+
+    // And nothing was written under the victim's name.
+    const stolen = await db
+      .select()
+      .from(schema.userSettings)
+      .where(eq(schema.userSettings.oxyUserId, victim));
+    expect(stolen).toHaveLength(0);
+  });
+
+  it("moves updated_at when it changes something, and never created_at", async () => {
+    const oxyUserId = id("settings-user");
+    const created = await ensureUserSettings(db, oxyUserId);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const row = await updateUserSettings(db, oxyUserId, { profileMinimalistMode: true });
+
+    expect(row.updatedAt.getTime()).toBeGreaterThan(created.updatedAt.getTime());
+    expect(row.createdAt.getTime()).toBe(created.createdAt.getTime());
+  });
+});
+
+describe("the allow-list is checked against the real table", () => {
+  it("names every settings column except identity and timestamps", async () => {
+    const IDENTITY_AND_TIMESTAMPS = ["id", "oxyUserId", "createdAt", "updatedAt"];
+    const schemaColumns = Object.keys(getTableColumns(schema.userSettings))
+      .filter((name) => !IDENTITY_AND_TIMESTAMPS.includes(name))
+      .sort();
+
+    // A column added to the schema and forgotten in the tuple would be silently
+    // unsettable — an endpoint that appears to accept a field and never stores
+    // it. This is the gate that makes the tuple and the table one fact.
+    expect([...UPDATABLE_USER_SETTINGS_COLUMNS].sort()).toEqual(schemaColumns);
+    // Anti-vacuity: a traversal returning nothing would satisfy the equality above.
+    expect(UPDATABLE_USER_SETTINGS_COLUMNS).toHaveLength(21);
+  });
+
+  it("excludes identity and timestamp columns", async () => {
+    // Stated separately from the equality: that assertion is symmetric, so it
+    // would also be satisfied if `getTableColumns` and the tuple BOTH contained
+    // `oxyUserId`. These four are the ones whose presence would be a bug.
+    for (const forbidden of ["id", "oxyUserId", "createdAt", "updatedAt"]) {
+      expect(UPDATABLE_USER_SETTINGS_COLUMNS).not.toContain(forbidden);
+    }
+  });
+});
+
+describe("the closed value sets are enforced by the database", () => {
+  it("refuses a theme mode outside the tuple", async () => {
+    const oxyUserId = id("settings-user");
+    await ensureUserSettings(db, oxyUserId);
+
+    // `text({ enum })` emits no DDL, so the repository's type is a narrowing
+    // only. Written raw here because that is the shape a bad value arrives in —
+    // from somewhere the TypeScript type never covered.
+    const error = await client`
+      update user_settings set appearance_theme_mode = 'neon' where oxy_user_id = ${oxyUserId}
+    `.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).not.toBeNull();
+    expect(isCheckViolation(error)).toBe(true);
+    expect(constraintNameOf(error)).toBe("user_settings_appearance_theme_mode_check");
+  });
+
+  it("refuses a profile visibility outside the tuple", async () => {
+    // Positive control first: the same raw statement with a value the tuple
+    // allows must SUCCEED, so the refusal below is the CHECK answering and not a
+    // misspelled column or a missing default.
+    const accepted = await client`
+      insert into user_settings (id, oxy_user_id, privacy_profile_visibility)
+      values (${id("settings")}, ${id("settings-user")}, 'followers_only')
+    `.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(accepted).toBeNull();
+
+    const error = await client`
+      insert into user_settings (id, oxy_user_id, privacy_profile_visibility)
+      values (${id("settings")}, ${id("settings-user")}, 'everyone')
+    `.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).not.toBeNull();
+    expect(isCheckViolation(error)).toBe(true);
+    expect(constraintNameOf(error)).toBe("user_settings_privacy_profile_visibility_check");
+  });
+
+  it("refuses a second settings row for the same user", async () => {
+    const oxyUserId = id("settings-user");
+    await ensureUserSettings(db, oxyUserId);
+
+    const error = await db
+      .insert(schema.userSettings)
+      .values({ id: id("settings"), oxyUserId })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+    expect(error).not.toBeNull();
+    expect(isUniqueViolation(error)).toBe(true);
+    // The constraint `ensureUserSettings`'s conflict target infers.
+    expect(constraintNameOf(error)).toBe("user_settings_oxy_user_id_key");
+  });
+});
+
+describe("user_behaviors is deleted whole and never read into", () => {
+  it("reports whether a row existed to reset", async () => {
+    const oxyUserId = id("behavior-user");
+    await db.insert(schema.userBehaviors).values({ id: id("behavior"), oxyUserId });
+
+    // The route says "reset successfully" or "nothing to reset" from exactly
+    // this, so a `DELETE` that reported success either way would be wrong.
+    expect(await deleteUserBehavior(db, oxyUserId)).toBe(true);
+    expect(await deleteUserBehavior(db, oxyUserId)).toBe(false);
+  });
+
+  it("deletes only the named user's row", async () => {
+    const oxyUserId = id("behavior-user");
+    const other = id("behavior-user");
+    await db.insert(schema.userBehaviors).values([
+      { id: id("behavior"), oxyUserId },
+      { id: id("behavior"), oxyUserId: other },
+    ]);
+
+    await deleteUserBehavior(db, oxyUserId);
+
+    const survivors = await db
+      .select()
+      .from(schema.userBehaviors)
+      .where(eq(schema.userBehaviors.oxyUserId, other));
+    expect(survivors).toHaveLength(1);
+  });
+
+  it("does not care what shape `preferences` has", async () => {
+    const oxyUserId = id("behavior-user");
+    // `Schema.Types.Mixed` with no reader: an arbitrary, deeply nested value is
+    // exactly what a live row may hold, and nothing on the delete path may parse
+    // it. If this ever needs a fixture shaped a particular way, something
+    // started reading inside the column.
+    await db.insert(schema.userBehaviors).values({
+      id: id("behavior"),
+      oxyUserId,
+      preferences: { a: [1, { b: null }], "weird key": "…", nested: { deep: { deeper: true } } },
+    });
+
+    expect(await deleteUserBehavior(db, oxyUserId)).toBe(true);
+  });
+
+  it("defaults `preferences` to an empty object rather than null", async () => {
+    const oxyUserId = id("behavior-user");
+    await db.insert(schema.userBehaviors).values({ id: id("behavior"), oxyUserId });
+
+    const rows = await db
+      .select()
+      .from(schema.userBehaviors)
+      .where(eq(schema.userBehaviors.oxyUserId, oxyUserId));
+    // Mongo's `default: {}`, now the column's. A null here would make every
+    // future reader of this column need a guard the port could have avoided.
+    expect(rows[0].preferences).toEqual({});
+  });
+
+  it("refuses a second behaviour row for the same user", async () => {
+    const oxyUserId = id("behavior-user");
+    await db.insert(schema.userBehaviors).values({ id: id("behavior"), oxyUserId });
+
+    const error = await db
+      .insert(schema.userBehaviors)
+      .values({ id: id("behavior"), oxyUserId })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+    expect(error).not.toBeNull();
+    expect(isUniqueViolation(error)).toBe(true);
+    expect(constraintNameOf(error)).toBe("user_behaviors_oxy_user_id_key");
+  });
+});
+
+describe("the driver-error helpers tell the two failure kinds apart", () => {
+  it("does not read a CHECK violation as a unique violation", async () => {
+    const error = await client`
+      insert into user_settings (id, oxy_user_id, appearance_theme_mode)
+      values (${id("settings")}, ${id("settings-user")}, 'neon')
+    `.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    // Both predicates asserted on one error: a helper that answered `true` for
+    // any driver error at all would pass every other case in this file.
+    expect(isCheckViolation(error)).toBe(true);
+    expect(isUniqueViolation(error)).toBe(false);
+  });
+});

--- a/packages/backend/src/db/social/blockRepository.ts
+++ b/packages/backend/src/db/social/blockRepository.ts
@@ -1,0 +1,89 @@
+/**
+ * `blocks` — one direction of a block, `userId` blocks `blockedId`.
+ *
+ * Ported from the three `Block` call sites in `routes/profileSettings.ts`. This
+ * module is the whole surface those need and deliberately nothing more.
+ *
+ * ## Why this is not shared with `restrictRepository`
+ *
+ * `blocks` and `restricts` are separate tables with identical shape, on purpose
+ * (`schema/CONVENTIONS.md`). A generic helper parameterised over "the table and
+ * its target column" would express in TypeScript exactly the merge the schema
+ * declined to make, and would hide the one thing worth reading here — which
+ * unique index each statement converges on.
+ *
+ * ## Self-blocking
+ *
+ * `POST /blocks` refuses `userId === blockedId` with a 400. That rule is not
+ * repeated here: the schema carries no CHECK for it, so a guard in this module
+ * would be a SECOND application-level copy of a rule the database does not
+ * enforce, in a layer that cannot produce the 400 the caller needs.
+ */
+
+import { and, desc, eq } from "drizzle-orm";
+import { uuidv7 } from "@oxyhq/db";
+import type { AlloDatabase } from "../index";
+import { blocks } from "../schema/social";
+
+/** The pair naming one direction of a block. An object because both are `string`. */
+export interface BlockPair {
+  readonly userId: string;
+  readonly blockedId: string;
+}
+
+/**
+ * The ids `userId` has blocked, newest first.
+ *
+ * Only the id is selected because that is all `GET /blocks` returns — it maps
+ * the rows to `blockedId` and discards the rest.
+ *
+ * `id` is a tiebreaker, not decoration: `created_at` is truncated to
+ * milliseconds, so two rows written in the same millisecond have no order at
+ * all under `created_at` alone and Postgres is free to return them differently
+ * on each call. A uuid v7 is time-ordered, so descending `id` continues the
+ * intent of descending `created_at` rather than cutting across it.
+ */
+export async function listBlockedUserIds(db: AlloDatabase, userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ blockedId: blocks.blockedId })
+    .from(blocks)
+    .where(eq(blocks.userId, userId))
+    .orderBy(desc(blocks.createdAt), desc(blocks.id));
+  return rows.map((row) => row.blockedId);
+}
+
+/**
+ * Block `blockedId`. Returns whether this call is what created the block.
+ *
+ * ONE statement, converging on `blocks_user_id_blocked_id_key`. The Mongoose
+ * version read first and inserted second, with a duplicate-key `catch` behind
+ * it as a net; between that read and that write two concurrent requests could
+ * both see nothing and both insert. The unique index is what makes the
+ * duplicate impossible, and `ON CONFLICT DO NOTHING` is what turns losing that
+ * race into the correct answer instead of an error to classify.
+ *
+ * The empty vs. one-row `RETURNING` set IS the "already blocked" answer, which
+ * is why `POST /blocks` can keep telling 201 from 200 without a second query. A
+ * genuine failure — a dropped connection, an exhausted pool — still throws,
+ * rather than being read as a duplicate the way a `catch` on the insert would.
+ */
+export async function blockUser(db: AlloDatabase, pair: BlockPair): Promise<boolean> {
+  const inserted = await db
+    .insert(blocks)
+    .values({ id: uuidv7(), userId: pair.userId, blockedId: pair.blockedId })
+    .onConflictDoNothing({ target: [blocks.userId, blocks.blockedId] })
+    .returning({ id: blocks.id });
+  return inserted.length > 0;
+}
+
+/**
+ * Remove a block. Returns whether a row existed to remove — `DELETE /blocks/:id`
+ * answers 404 when it did not, so the caller needs to tell the two apart.
+ */
+export async function unblockUser(db: AlloDatabase, pair: BlockPair): Promise<boolean> {
+  const deleted = await db
+    .delete(blocks)
+    .where(and(eq(blocks.userId, pair.userId), eq(blocks.blockedId, pair.blockedId)))
+    .returning({ id: blocks.id });
+  return deleted.length > 0;
+}

--- a/packages/backend/src/db/social/restrictRepository.ts
+++ b/packages/backend/src/db/social/restrictRepository.ts
@@ -1,0 +1,62 @@
+/**
+ * `restricts` — one direction of a restriction, `userId` restricts
+ * `restrictedId`.
+ *
+ * Ported from the three `Restrict` call sites in `routes/profileSettings.ts`.
+ * The reasoning behind each statement is stated once, in `blockRepository.ts`:
+ * the two tables are deliberately separate and identical, so this module is
+ * deliberately its twin rather than a call into a shared generic.
+ *
+ * The one thing NOT to conclude from that: `restricts` is not the same fact as
+ * `user_settings.privacy_restricted_users`. That column is a `text[]` the PUT
+ * settings route overwrites wholesale; this table is the row-per-relation the
+ * `/restricts` endpoints maintain, with its own unique index and its own
+ * `created_at`. Mongo carried both too, and nothing reconciles them — porting
+ * them into one place would be a behaviour change, not a cleanup.
+ */
+
+import { and, desc, eq } from "drizzle-orm";
+import { uuidv7 } from "@oxyhq/db";
+import type { AlloDatabase } from "../index";
+import { restricts } from "../schema/social";
+
+/** The pair naming one direction of a restriction. An object because both are `string`. */
+export interface RestrictPair {
+  readonly userId: string;
+  readonly restrictedId: string;
+}
+
+/** The ids `userId` has restricted, newest first. See `listBlockedUserIds` for the ordering. */
+export async function listRestrictedUserIds(
+  db: AlloDatabase,
+  userId: string,
+): Promise<string[]> {
+  const rows = await db
+    .select({ restrictedId: restricts.restrictedId })
+    .from(restricts)
+    .where(eq(restricts.userId, userId))
+    .orderBy(desc(restricts.createdAt), desc(restricts.id));
+  return rows.map((row) => row.restrictedId);
+}
+
+/**
+ * Restrict `restrictedId`. Returns whether this call is what created the row,
+ * converging on `restricts_user_id_restricted_id_key` rather than reading first.
+ */
+export async function restrictUser(db: AlloDatabase, pair: RestrictPair): Promise<boolean> {
+  const inserted = await db
+    .insert(restricts)
+    .values({ id: uuidv7(), userId: pair.userId, restrictedId: pair.restrictedId })
+    .onConflictDoNothing({ target: [restricts.userId, restricts.restrictedId] })
+    .returning({ id: restricts.id });
+  return inserted.length > 0;
+}
+
+/** Remove a restriction. Returns whether a row existed to remove. */
+export async function unrestrictUser(db: AlloDatabase, pair: RestrictPair): Promise<boolean> {
+  const deleted = await db
+    .delete(restricts)
+    .where(and(eq(restricts.userId, pair.userId), eq(restricts.restrictedId, pair.restrictedId)))
+    .returning({ id: restricts.id });
+  return deleted.length > 0;
+}

--- a/packages/backend/src/db/social/userBehaviorRepository.ts
+++ b/packages/backend/src/db/social/userBehaviorRepository.ts
@@ -1,0 +1,39 @@
+/**
+ * `user_behaviors` — opaque personalization state, one row per user.
+ *
+ * `preferences` was `Schema.Types.Mixed` and is `jsonb` for the reason
+ * `schema/CONVENTIONS.md` gives: nothing projects a field out of it. So nothing
+ * here reads inside it, queries inside it, or declares a shape for it. A
+ * repository is where an invented shape would first look reasonable, and where
+ * it would then become the shape every later reader believes.
+ *
+ * ## Why this module has one function
+ *
+ * `DELETE /api/profile/settings/behavior` is the ONLY production call site of
+ * this model in the repository — `UserBehavior.findOneAndDelete({ oxyUserId })`.
+ * There is no writer and no reader anywhere in this service; whatever fills
+ * `preferences` does not live here. An `upsertUserBehavior` would therefore be
+ * surface nobody calls, written against a shape nobody has declared.
+ */
+
+import { eq } from "drizzle-orm";
+import type { AlloDatabase } from "../index";
+import { userBehaviors } from "../schema/social";
+
+/**
+ * Delete a user's personalization row. Returns whether one existed.
+ *
+ * The route reports "reset successfully" or "nothing to reset" from this, so
+ * the distinction is the caller's, not a detail: `DELETE` alone would report
+ * success for a user who never had a row.
+ */
+export async function deleteUserBehavior(
+  db: AlloDatabase,
+  oxyUserId: string,
+): Promise<boolean> {
+  const deleted = await db
+    .delete(userBehaviors)
+    .where(eq(userBehaviors.oxyUserId, oxyUserId))
+    .returning({ id: userBehaviors.id });
+  return deleted.length > 0;
+}

--- a/packages/backend/src/db/social/userSettingsRepository.ts
+++ b/packages/backend/src/db/social/userSettingsRepository.ts
@@ -1,0 +1,217 @@
+/**
+ * `user_settings` — the four Mongoose sub-documents, FLATTENED into columns.
+ *
+ * Ported from `utils/userSettings.ts`'s `ensureUserSettings` and the
+ * `PUT /api/profile/settings` handler. Both change shape here, and both change
+ * because the flattening moved work out of application code:
+ *
+ * - **`ensureUserSettings` loses a branch.** Mongoose's version had a second
+ *   repair path — "the row exists but has no `profileCustomization`, so write
+ *   the defaults into it" — because a sub-document with no value stored has no
+ *   defaults either. `profile_cover_photo_enabled` and
+ *   `profile_minimalist_mode` are `NOT NULL DEFAULT true/false` columns, so the
+ *   state that branch repaired is now unrepresentable. Deleting it is the port
+ *   working, not a behaviour the port dropped.
+ *
+ * - **An update is an explicit column list.** The Mongoose handler built a
+ *   `$set` of dot-paths from request fields; the equivalent here is
+ *   {@link UPDATABLE_USER_SETTINGS_COLUMNS}, an allow-list that omits `id`,
+ *   `oxyUserId` and `createdAt` — so no patch, however it was constructed, can
+ *   move a settings row to another user or rewrite when it was created.
+ *
+ * ## The defaults are the schema's, and they are asymmetric on purpose
+ *
+ * `security_cloud_sync_enabled` defaults FALSE while `security_encryption_...`
+ * and `security_peer_to_peer_...` default TRUE. That asymmetry is the product's
+ * device-first stance: cloud sync is opt-IN. Nothing in this module writes a
+ * security column unless a caller explicitly asked for it — in particular
+ * {@link ensureUserSettings} inserts `{id, oxyUserId}` and lets the server apply
+ * every default, rather than "normalising" a new row with a literal it could get
+ * wrong in exactly the direction that turns cloud sync on for somebody.
+ */
+
+import { eq } from "drizzle-orm";
+import { uuidv7 } from "@oxyhq/db";
+import type { AlloDatabase } from "../index";
+import { userSettings } from "../schema/social";
+
+/** A settings row as stored. No column is protected, so this is the whole row. */
+export type UserSettingsRow = typeof userSettings.$inferSelect;
+
+/**
+ * Every column a caller may set, named individually.
+ *
+ * This is the allow-list, and it is one tuple rather than a type beside a
+ * runtime list: {@link UserSettingsPatch} is derived from it and
+ * {@link pickUpdatableColumns} iterates it, so the compile-time and runtime
+ * halves cannot drift. `__tests__/db/social.realdb.test.ts` asserts it against
+ * the real drizzle table — a column added to the schema and forgotten here
+ * fails the suite rather than becoming quietly unsettable.
+ *
+ * `id`, `oxyUserId`, `createdAt` and `updatedAt` are absent deliberately. The
+ * first three are identity and history; `updatedAt` is maintained by
+ * {@link updateUserSettings} itself and must not be something a caller supplies.
+ */
+export const UPDATABLE_USER_SETTINGS_COLUMNS = [
+  "appearanceThemeMode",
+  "appearancePrimaryColor",
+  "profileHeaderImage",
+  "privacyProfileVisibility",
+  "privacyShowContactInfo",
+  "privacyAllowTags",
+  "privacyAllowAllos",
+  "privacyShowOnlineStatus",
+  "privacyHideLikeCounts",
+  "privacyHideShareCounts",
+  "privacyHideReplyCounts",
+  "privacyHideSaveCounts",
+  "privacyHiddenWords",
+  "privacyRestrictedUsers",
+  "profileCoverPhotoEnabled",
+  "profileMinimalistMode",
+  "profileDisplayName",
+  "profileCoverImage",
+  "securityCloudSyncEnabled",
+  "securityEncryptionEnabled",
+  "securityPeerToPeerEnabled",
+] as const;
+
+export type UpdatableUserSettingsColumn = (typeof UPDATABLE_USER_SETTINGS_COLUMNS)[number];
+
+/**
+ * A partial settings update.
+ *
+ * Absent (`undefined`) means "leave this column alone"; `null` on a nullable
+ * column means "clear it", which is how the route's
+ * `appearance.primaryColor === null` case survives the port. The two closed sets
+ * arrive already narrowed by the column's own `enum`, and the CHECK rendered
+ * from the same tuple catches anything that reaches the server anyway.
+ */
+export type UserSettingsPatch = Partial<
+  Pick<typeof userSettings.$inferInsert, UpdatableUserSettingsColumn>
+>;
+
+/**
+ * Copy one allow-listed key, if the caller supplied it.
+ *
+ * Generic in the key so `target[key] = value` is checked against that column's
+ * own type rather than the union of all of them — which is what makes the loop
+ * below type-safe without a cast.
+ */
+function copyIfPresent<K extends UpdatableUserSettingsColumn>(
+  target: UserSettingsPatch,
+  source: UserSettingsPatch,
+  key: K,
+): void {
+  const value = source[key];
+  if (value !== undefined) target[key] = value;
+}
+
+/**
+ * The allow-list applied: an object whose keys can only ever come from
+ * {@link UPDATABLE_USER_SETTINGS_COLUMNS}.
+ *
+ * This — not the type — is what makes an unexpected key harmless. TypeScript's
+ * excess-property check only fires on object literals, so a `UserSettingsPatch`
+ * that reached this function through a variable can carry anything at runtime;
+ * the loop never reads a key it was not told about, so nothing else can survive
+ * into the statement.
+ */
+function pickUpdatableColumns(patch: UserSettingsPatch): UserSettingsPatch {
+  const set: UserSettingsPatch = {};
+  for (const column of UPDATABLE_USER_SETTINGS_COLUMNS) copyIfPresent(set, patch, column);
+  return set;
+}
+
+async function readUserSettings(
+  db: AlloDatabase,
+  oxyUserId: string,
+): Promise<UserSettingsRow | null> {
+  const rows = await db
+    .select()
+    .from(userSettings)
+    .where(eq(userSettings.oxyUserId, oxyUserId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * The user's settings, creating a row of pure defaults if there is none.
+ *
+ * Read first, because a settings row usually already exists and the read is the
+ * cheap path. The insert converges on `user_settings_oxy_user_id_key` rather
+ * than trusting the read: two concurrent first requests from one user both see
+ * nothing, and the unique constraint decides which one inserts. The loser
+ * re-reads — `ON CONFLICT DO NOTHING` returns no row, and the winner's row is
+ * committed by then — so both callers get the same settings and neither errors.
+ *
+ * Deliberately NOT `ON CONFLICT DO UPDATE`. That would return the row in both
+ * branches and save a query, at the cost of writing a new tuple version on
+ * every read of an existing row — moving `updated_at` and `xmin` for a call
+ * that changed nothing.
+ */
+export async function ensureUserSettings(
+  db: AlloDatabase,
+  oxyUserId: string,
+): Promise<UserSettingsRow> {
+  const existing = await readUserSettings(db, oxyUserId);
+  if (existing) return existing;
+
+  const inserted = await db
+    .insert(userSettings)
+    .values({ id: uuidv7(), oxyUserId })
+    .onConflictDoNothing({ target: userSettings.oxyUserId })
+    .returning();
+  const created = inserted[0];
+  if (created) return created;
+
+  const raced = await readUserSettings(db, oxyUserId);
+  if (!raced) {
+    throw new Error(
+      "user_settings insert conflicted but no row was found — the unique constraint " +
+        "on oxy_user_id is missing or the row was deleted mid-call",
+    );
+  }
+  return raced;
+}
+
+/**
+ * Apply a partial update, creating the row if there is none, and return the
+ * result. The upsert is what preserves Mongoose's `{ upsert: true, new: true }`.
+ *
+ * An empty patch is not a degenerate case to reject: the route builds its patch
+ * from whichever request fields validated, so "nothing recognised" is reachable,
+ * and Mongo answered it by upserting and returning the current document.
+ * {@link ensureUserSettings} is that answer, and it is also the only correct
+ * one — `ON CONFLICT DO UPDATE SET` needs at least one assignment.
+ *
+ * `updatedAt` is set explicitly rather than left to the column's `$onUpdate`
+ * hook, because whether an ORM applies that hook inside a conflict branch is
+ * the ORM's decision to change; `schema/CONVENTIONS.md` makes maintaining this
+ * column the application's job, so the application does it where it can be read.
+ */
+export async function updateUserSettings(
+  db: AlloDatabase,
+  oxyUserId: string,
+  patch: UserSettingsPatch,
+): Promise<UserSettingsRow> {
+  const set = pickUpdatableColumns(patch);
+  if (Object.keys(set).length === 0) return ensureUserSettings(db, oxyUserId);
+
+  const rows = await db
+    .insert(userSettings)
+    // `set` is the allow-list's own output, so spreading it here can introduce
+    // no column `pickUpdatableColumns` did not name.
+    .values({ id: uuidv7(), oxyUserId, ...set })
+    .onConflictDoUpdate({
+      target: userSettings.oxyUserId,
+      set: { ...set, updatedAt: new Date() },
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) {
+    throw new Error("user_settings upsert returned no row");
+  }
+  return row;
+}


### PR DESCRIPTION
One domain of the repository layer for the Mongo → Postgres port, landing
**unused**: `blocks`, `restricts`, `user_settings`, `user_behaviors`. No route,
service or Mongoose model is touched, so the switch PR's diff can read as "call
sites move" rather than "call sites move and the repositories changed under
them".

The surface is derived from what the call sites actually do — the ten `Block` /
`Restrict` / `UserSettings` / `UserBehavior` sites in `routes/profileSettings.ts`
and `utils/userSettings.ts` — and deliberately stops there.

## The decisions

**A block is one statement, not a read and then a write.** Mongoose did
`findOne` → `create` with an `isDuplicateKeyError` catch behind it as a net. The
gap between those two is a race: two concurrent requests both see nothing and
both insert. `ON CONFLICT DO NOTHING` on `blocks_user_id_blocked_id_key` removes
the gap instead of recovering from it, and the empty-vs-one-row `RETURNING` set
IS the "already blocked" answer — so the route keeps telling 201 from 200 with
no second query, while a genuine failure (dropped connection, exhausted pool)
still throws rather than being misread as a duplicate.

**`blocks` and `restricts` are twin modules, not a shared generic.** The schema
made them separate tables with identical shape on purpose. A helper
parameterised over "the table and its target column" would express in TypeScript
exactly the merge the schema declined, and would hide the one thing worth
reading — which unique index each statement converges on.

**A settings update is an allow-list, and the allow-list is one tuple.**
`UPDATABLE_USER_SETTINGS_COLUMNS` names the 21 settable columns;
`UserSettingsPatch` is derived from it and the copy loop iterates it, so the
compile-time and runtime halves cannot drift. `id`, `oxyUserId` and `createdAt`
are absent, which is what makes them unsettable by construction rather than by a
check somebody has to remember. The loop — not the type — is what makes an
unexpected key harmless: TypeScript's excess-property check only fires on object
literals, so a patch that arrives through a variable can carry anything at
runtime.

**`ensureUserSettings` supplies only the id and the owner.** Every default is the
schema's, including the asymmetric one (`security_cloud_sync_enabled` FALSE while
encryption and P2P are TRUE — cloud sync is opt-IN). It also loses a branch:
Mongoose had a repair path for "the row exists but has no `profileCustomization`",
and once those became `NOT NULL DEFAULT` columns that state is unrepresentable.
It reads before it inserts (a settings row usually exists), and converges on the
unique constraint rather than trusting the read, so the loser of a first-request
race re-reads instead of erroring. Deliberately not `ON CONFLICT DO UPDATE` —
that would write a new tuple version on every *read* of an existing row.

**`user_behaviors` gets one function.** `DELETE /settings/behavior` is the only
production call site of that model in the whole repository; there is no writer
and no reader anywhere in this service. Nothing reads inside `preferences`, and
nothing here declares a shape for it — a repository is where an invented shape
would first look reasonable and then become the shape every later reader
believes.

## What the tests are worth

34 cases against a real Postgres server. Four mutations were run; two findings
are worth stating because they changed the tests rather than confirming them.

**The concurrency case was measuring nothing.** Mutating `blockUser` back to
read-then-write left the whole suite GREEN. The cause is real and general:
postgres.js opens connections on demand, so the first concurrent burst after a
run of sequential queries queues onto the single open connection and executes
strictly in order. Two fixes, both kept — a `warmPool()` before each racing
burst (which then caught the mutation 20/20), and a deterministic detector that
counts the statements the driver actually sent via postgres.js's `debug` hook.
The second is the one that matters: both a correct repository and a
read-then-write one answer `false` for a block that already exists, so no
assertion about the *result* can tell them apart — only the statement count can.

**Asserting the security defaults is not enough to protect them.** A repository
that "helpfully" writes `securityCloudSyncEnabled: false` itself produces
identical rows, and every naive assertion stays green. So one case moves the
column DEFAULT out from under the repository and asserts the new value comes
back — which only a repository that genuinely omits the column can satisfy.
Verified: that mutation fails exactly this case and no other. (Restored in a
`finally`, with a following assertion that the restore worked.)

The other two mutations: mass-assigning the patch (`{...patch}`) is caught by a
case that passes a *subtype* carrying `id`/`oxyUserId`/`createdAt` — no cast, no
`any`, which is how this reaches a repository in practice; and dropping a column
from the allow-list tuple is caught both by the coverage gate against
`getTableColumns` and by `tsc`, which proves the patch type really is derived
from the tuple.

## Notes on CONVENTIONS.md

Nothing contradicts it. One point of friction worth recording: the ledger says a
post-cutover row "gets a uuid v7 from `generatedId()`", but every table declares
`id: text().primaryKey()` with no runtime default, so the application must supply
one. These repositories call `uuidv7()` from `@oxyhq/db` — the same generator —
directly.

## Gates

- `src/__tests__/db/social.realdb.test.ts` — 34 passed, green on three
  consecutive runs (checked for flakiness after the pool finding).
- Full backend suite — 646 passed across 33 files.
- `bun run typecheck:backend` — clean.
- `bun install` left `bun.lock` byte-unchanged.
- Working tree touches only `src/db/social/` and the one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
