### PR TITLE
feat(backend): the moderation repositories, and the guard that makes a 201 mean stored

### DIFF
--- a/packages/backend/src/__tests__/db/moderation.realdb.test.ts
+++ b/packages/backend/src/__tests__/db/moderation.realdb.test.ts
@@ -1,0 +1,970 @@
+/**
+ * The moderation repositories, against a REAL Postgres server.
+ *
+ * Every claim in `db/moderation/` is a property only a server has: a transaction
+ * that rolls both writes back, a primary key that answers "already seen" as a
+ * value, `for update skip locked` handing two dispatchers different rows, and an
+ * `on conflict do nothing` that leaves the tuple untouched. A mocked `insert`
+ * accepts any statement — including one the server rejects outright — which is
+ * exactly why this backend already boots a real Mongo replica set for the
+ * moderation suite it is replacing rather than mocking the model.
+ *
+ * ## The concurrency cases hold a real lock
+ *
+ * `SKIP LOCKED` cannot be observed sequentially: one claim after another passes
+ * whether or not it is there. So both concurrency cases below run claims that
+ * OVERLAP in time — one with N claims in flight at once, one with the contended
+ * row's lock held open inside a transaction.
+ *
+ * Only the SECOND of those discriminates, which is worth stating because the first
+ * is the one that looks like the concurrency test. Mutation-tested by deleting
+ * `skip locked` from the claim: the N-way race still PASSES, because under READ
+ * COMMITTED a plain `for update` merely serialises the claimers and each one
+ * re-reads and lands on a different row; the held-lock case deadlocks until the
+ * test times out, because the claim it is waiting on cannot commit until it
+ * returns. Do not delete that case as redundant with the race — it is the only one
+ * that fails.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { createDatabase, constraintNameOf, isUniqueViolation } from "@oxyhq/db";
+import type postgres from "postgres";
+import { setUpTestDatabase, type TestDatabaseHandle } from "../../db/testDatabase";
+import * as schema from "../../db/schema";
+import {
+  MissingTransactionError,
+  requireTransaction,
+} from "../../db/moderation/transactionGuard";
+import {
+  claimModerationOutboxEvent,
+  completeModerationOutboxEvent,
+  enqueueModerationOutboxEvent,
+  MODERATION_OUTBOX_RETENTION_SECONDS,
+  releaseModerationOutboxEvent,
+  renewModerationOutboxEvent,
+} from "../../db/moderation/moderationOutboxRepository";
+import {
+  claimModerationEvent,
+  markModerationEventIgnored,
+  markModerationEventQueued,
+  releaseModerationEvent,
+} from "../../db/moderation/moderationEventRepository";
+import {
+  applyReportDecision,
+  closeUndeliverableReport,
+  findReportByCaseId,
+  findReportById,
+  findReportBySubject,
+  insertReport,
+  listReportsByReporter,
+  markReportDeliveryFailed,
+  markReportSubmitted,
+} from "../../db/moderation/reportRepository";
+
+let handle: TestDatabaseHandle;
+let db: ReturnType<typeof createDatabase<typeof schema>>["db"];
+let client: postgres.Sql;
+
+/** Unique per call so cases cannot collide inside the one shared database. */
+let counter = 0;
+function id(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${String(counter).padStart(4, "0")}`;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+
+function future(): Date {
+  return new Date(Date.now() + HOUR_MS);
+}
+
+/** The row's transaction id and its application-maintained timestamp, as TEXT. */
+async function outboxTuple(eventId: string): Promise<{ xmin: string; updated_at: string }> {
+  const rows = await client<{ xmin: string; updated_at: string }[]>`
+    select xmin::text, updated_at::text from moderation_outbox where id = ${eventId}
+  `;
+  return rows[0];
+}
+
+async function insertDueOutboxEvent(eventId: string): Promise<void> {
+  await db.transaction(async (tx) => {
+    await enqueueModerationOutboxEvent(
+      { eventId, kind: "report.submit", payload: { reportId: id("report") } },
+      tx,
+    );
+  });
+}
+
+/**
+ * Push every row that is currently due out of reach.
+ *
+ * An untargeted claim takes the OLDEST due work in the table, whatever it is —
+ * that is the dispatcher's whole job — so a case asserting WHICH row was claimed
+ * has to own the entire due set, and this suite shares one database with every
+ * case that ran before it. Moving `available_at` rather than deleting keeps those
+ * rows, and their history, exactly as their own cases left them.
+ */
+async function parkPendingOutboxWork(): Promise<void> {
+  await db
+    .update(schema.moderationOutbox)
+    .set({ availableAt: future() })
+    .where(eq(schema.moderationOutbox.status, "pending"));
+}
+
+beforeAll(async () => {
+  handle = await setUpTestDatabase();
+  const created = createDatabase({ databaseUrl: handle.databaseUrl, schema });
+  db = created.db;
+  client = created.client;
+}, 180_000);
+
+afterAll(async () => {
+  await client?.end();
+  await handle?.drop();
+});
+
+describe("the transaction guard", () => {
+  it("refuses the ROOT connection, naming the call that was misrouted", async () => {
+    const eventId = id("outbox");
+
+    const error = await enqueueModerationOutboxEvent(
+      { eventId, kind: "report.submit", payload: { reportId: id("report") } },
+      db,
+    ).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(MissingTransactionError);
+    // The event id rides in the message: "some enqueue was misrouted" sends
+    // whoever hits it hunting through every caller.
+    expect(String(error)).toContain(`enqueueModerationOutboxEvent(${eventId})`);
+
+    // And it refused BEFORE writing. A guard that throws after the insert would
+    // leave exactly the row it exists to prevent.
+    const rows = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("refuses the root connection for the inbound event's audit write too", async () => {
+    const eventId = id("evt");
+    await claimModerationEvent(eventId, db);
+
+    const error = await markModerationEventQueued(
+      { eventId, type: "case.decided", caseId: id("case"), payload: { decision: {} } },
+      db,
+    ).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(MissingTransactionError);
+    expect(String(error)).toContain(`markModerationEventQueued(${eventId})`);
+
+    // Guarding only the outbox half would leave this reachable: the audit row
+    // completed outside the transaction, the work queued inside it, and a crash
+    // between them losing a decision that reads as already handled.
+    const [row] = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    expect(row.state).toBe("claimed");
+  });
+
+  it("accepts a transaction handle, and a SAVEPOINT inside one", async () => {
+    // A nested transaction is a savepoint and has `rollback` for the same reason
+    // the outer one does, which is what makes the discriminator safe inside a
+    // caller that already opened a transaction.
+    await db.transaction(async (tx) => {
+      expect(requireTransaction(tx, "outer")).toBe(tx);
+      await tx.transaction(async (nested) => {
+        expect(requireTransaction(nested, "nested")).toBe(nested);
+      });
+    });
+  });
+});
+
+describe("intake: the report and its delivery event commit together, or neither", () => {
+  it("commits both", async () => {
+    const eventIds = await db.transaction(async (tx) => {
+      const report = await insertReport(
+        {
+          reporter: id("reporter"),
+          reportedType: "user",
+          reportedId: id("subject"),
+          categories: ["harassment", "spam"],
+          localStatus: "queued",
+        },
+        tx,
+      );
+      const eventId = await enqueueModerationOutboxEvent(
+        {
+          eventId: `moderation:report.submit:${report.id}`,
+          kind: "report.submit",
+          payload: { reportId: report.id },
+        },
+        tx,
+      );
+      return { reportId: report.id, eventId };
+    });
+
+    const stored = await findReportById(eventIds.reportId, db);
+    expect(stored?.localStatus).toBe("queued");
+    // The id is generated by the repository — `reports.id` has no database
+    // default, so a row inserted without one would not exist at all.
+    expect(stored?.id).toBe(eventIds.reportId);
+
+    const [event] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventIds.eventId));
+    expect(event.payloadReportId).toBe(eventIds.reportId);
+    expect(event.status).toBe("pending");
+
+    // The writer owns the deadline the expiry sweep reaps against.
+    const expectedExpiry = event.createdAt.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000;
+    expect(Math.abs(event.expiresAt.getTime() - expectedExpiry)).toBeLessThan(60_000);
+  });
+
+  it("commits NEITHER when the transaction fails after both writes", async () => {
+    const reporter = id("reporter");
+    const reportedId = id("subject");
+    let eventId = "";
+
+    const error = await db
+      .transaction(async (tx) => {
+        const report = await insertReport(
+          {
+            reporter,
+            reportedType: "user",
+            reportedId,
+            categories: ["spam"],
+            localStatus: "queued",
+          },
+          tx,
+        );
+        eventId = await enqueueModerationOutboxEvent(
+          {
+            eventId: `moderation:report.submit:${report.id}`,
+            kind: "report.submit",
+            payload: { reportId: report.id },
+          },
+          tx,
+        );
+        throw new Error("deliberate rollback");
+      })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+    expect(error).not.toBeNull();
+    // This is the property `POST /reports`'s 201 rests on: never a report with no
+    // delivery event, and never a delivery event naming a report that rolled back.
+    expect(await findReportBySubject({ reporter, reportedId, reportedType: "user" }, db)).toBeUndefined();
+    const events = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(events).toHaveLength(0);
+  });
+
+  it("refuses a second report of the same subject by the same reporter", async () => {
+    const reporter = id("reporter");
+    const reportedId = id("subject");
+    const insert = () =>
+      db.transaction(async (tx) =>
+        insertReport(
+          { reporter, reportedType: "user", reportedId, categories: ["spam"], localStatus: "queued" },
+          tx,
+        ),
+      );
+
+    await insert();
+    const error = await insert().then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).not.toBeNull();
+    // Named, not matched on a message: drizzle wraps the driver error, so the
+    // constraint name lives on `cause` and a regex over the text would pass for
+    // the wrong index.
+    expect(isUniqueViolation(error)).toBe(true);
+    expect(constraintNameOf(error)).toBe("reports_reporter_reported_id_reported_type_key");
+  });
+
+  it("stores a locally-recorded report with its reason and no delivery event", async () => {
+    // The common case in Allo: a reported message never leaves, because the
+    // server cannot read one.
+    const report = await db.transaction(async (tx) =>
+      insertReport(
+        {
+          reporter: id("reporter"),
+          reportedType: "message",
+          reportedId: id("msg"),
+          categories: ["explicit_content"],
+          localStatus: "received",
+          localStatusReason: "Allo has no moderation subject provider for 'message'.",
+        },
+        tx,
+      ),
+    );
+
+    expect(report.localStatus).toBe("received");
+    expect(report.localStatusReason).toContain("no moderation subject provider");
+    expect(report.status).toBe("pending");
+  });
+});
+
+describe("the enqueue is idempotent, structurally", () => {
+  it("treats a repeated enqueue of the same id as a genuine no-op", async () => {
+    const eventId = id("outbox");
+    const payload = { reportId: id("report") };
+    await db.transaction(async (tx) =>
+      enqueueModerationOutboxEvent({ eventId, kind: "report.submit", payload }, tx),
+    );
+
+    const before = await outboxTuple(eventId);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await db.transaction(async (tx) =>
+      enqueueModerationOutboxEvent({ eventId, kind: "report.submit", payload }, tx),
+    );
+    const after = await outboxTuple(eventId);
+
+    // `xmin` is the row's transaction id: a `DO UPDATE` careful enough to write
+    // identical values still moves it, so this catches what comparing columns
+    // cannot. `updated_at` catches the ordinary version, where drizzle applies
+    // the column's `$onUpdate` inside the conflict branch's `set`.
+    expect(after.xmin).toBe(before.xmin);
+    expect(after.updated_at).toBe(before.updated_at);
+  });
+
+  it("does not let a repeat rewrite the payload of the row already queued", async () => {
+    const eventId = id("outbox");
+    const original = id("report");
+    await db.transaction(async (tx) =>
+      enqueueModerationOutboxEvent(
+        { eventId, kind: "report.submit", payload: { reportId: original } },
+        tx,
+      ),
+    );
+    await db.transaction(async (tx) =>
+      enqueueModerationOutboxEvent(
+        { eventId, kind: "report.submit", payload: { reportId: id("other") } },
+        tx,
+      ),
+    );
+
+    const [row] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(row.payloadReportId).toBe(original);
+  });
+});
+
+describe("the claim is a lease, and leases are held under concurrency", () => {
+  it("hands N concurrent dispatchers N DIFFERENT rows", async () => {
+    await parkPendingOutboxWork();
+    const owners = ["a", "b", "c", "d", "e", "f"].map((suffix) => id(`owner-${suffix}`));
+    const eventIds: string[] = [];
+    for (let index = 0; index < owners.length; index += 1) {
+      const eventId = id("outbox-race");
+      await insertDueOutboxEvent(eventId);
+      eventIds.push(eventId);
+    }
+
+    // In flight at once, on separate pooled connections. Sequential claims pass
+    // whether or not `skip locked` is there; overlapping ones do not.
+    const claimed = await Promise.all(
+      owners.map((leaseOwner) => claimModerationOutboxEvent({ leaseOwner }, db)),
+    );
+
+    const ids = claimed.map((event) => event?.id);
+    expect(ids.filter((value) => value === undefined)).toHaveLength(0);
+    expect(new Set(ids).size).toBe(owners.length);
+    // Anti-vacuity: the rows claimed must be the ones this case created, not
+    // leftovers from another describe block that happened to be due.
+    expect(ids.every((value) => eventIds.includes(String(value)))).toBe(true);
+  });
+
+  it("SKIPS a row another transaction is holding, rather than waiting for it", async () => {
+    await parkPendingOutboxWork();
+    const held = id("outbox-held");
+    const free = id("outbox-free");
+    await insertDueOutboxEvent(held);
+    await insertDueOutboxEvent(free);
+
+    let concurrent: Awaited<ReturnType<typeof claimModerationOutboxEvent>> = null;
+    await db.transaction(async (tx) => {
+      // Claimed and still uncommitted, so its row lock is live for the whole body.
+      const first = await claimModerationOutboxEvent({ leaseOwner: id("owner"), eventId: held }, tx);
+      expect(first?.id).toBe(held);
+
+      // Without `skip locked` this second claim blocks on that lock until the
+      // outer transaction commits — which it cannot, because it is awaiting this.
+      concurrent = await claimModerationOutboxEvent({ leaseOwner: id("owner") }, db);
+    });
+
+    expect(concurrent).not.toBeNull();
+    expect(concurrent?.id).toBe(free);
+  });
+
+  it("counts attempts and clears the previous error on every claim", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    const owner = id("owner");
+
+    const first = await claimModerationOutboxEvent({ leaseOwner: owner, eventId }, db);
+    expect(first?.attempts).toBe(1);
+    expect(first?.leaseOwner).toBe(owner);
+    // Absent optionals are normalized to `undefined`, because every reader of
+    // `ModerationOutboxEvent` tests `=== undefined` and a `null` passes that.
+    expect(first?.payload.eventId).toBeUndefined();
+
+    await releaseModerationOutboxEvent(
+      {
+        eventId,
+        leaseOwner: owner,
+        deadLettered: false,
+        availableAt: new Date(Date.now() - 1_000),
+        error: "a transient failure",
+      },
+      db,
+    );
+
+    const second = await claimModerationOutboxEvent({ leaseOwner: owner, eventId }, db);
+    expect(second?.attempts).toBe(2);
+    const [row] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(row.lastError).toBeNull();
+  });
+
+  it("reclaims an EXPIRED lease and leaves a live one alone", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+
+    const claimed = await claimModerationOutboxEvent(
+      { leaseOwner: id("owner-dead"), eventId, leaseMs: MINUTE_MS },
+      db,
+    );
+    expect(claimed?.id).toBe(eventId);
+
+    // Nobody else may take it while the lease is live.
+    expect(await claimModerationOutboxEvent({ leaseOwner: id("owner-early"), eventId }, db)).toBeNull();
+
+    // The clock moves rather than the lease shortening, because that is the real
+    // failure: a task that died holding this row, and a survivor that has to be
+    // able to pick the work back up.
+    const afterLapse = new Date(Date.now() + 2 * MINUTE_MS);
+    const reclaimed = await claimModerationOutboxEvent(
+      { leaseOwner: id("owner-live"), eventId, now: afterLapse },
+      db,
+    );
+    expect(reclaimed?.id).toBe(eventId);
+    expect(reclaimed?.attempts).toBe(2);
+  });
+
+  it("never claims a row that has never been leased through the reclaim branch", async () => {
+    // `lease_until` is NULL for a fresh row and `NULL <= now` is NULL, so the
+    // reclaim branch excludes it by the comparison itself — as `{$lte: now}` did
+    // for a missing field in Mongo.
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    await db
+      .update(schema.moderationOutbox)
+      .set({ status: "processing" })
+      .where(eq(schema.moderationOutbox.id, eventId));
+
+    expect(await claimModerationOutboxEvent({ leaseOwner: id("owner"), eventId }, db)).toBeNull();
+  });
+
+  it("does not claim work that is not due yet", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    await db
+      .update(schema.moderationOutbox)
+      .set({ availableAt: future() })
+      .where(eq(schema.moderationOutbox.id, eventId));
+
+    expect(await claimModerationOutboxEvent({ leaseOwner: id("owner"), eventId }, db)).toBeNull();
+  });
+});
+
+describe("only the owner of a live lease may finish the work", () => {
+  it("completes for the owner and refuses everyone else", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    const owner = id("owner");
+    await claimModerationOutboxEvent({ leaseOwner: owner, eventId }, db);
+
+    expect(await completeModerationOutboxEvent(eventId, id("stranger"), new Date(), db)).toBe(false);
+    expect(await completeModerationOutboxEvent(eventId, owner, new Date(), db)).toBe(true);
+
+    const [row] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(row.status).toBe("processed");
+    expect(row.leaseOwner).toBeNull();
+    expect(row.processedAt).not.toBeNull();
+
+    // Completing twice is not a second completion: the lease is gone.
+    expect(await completeModerationOutboxEvent(eventId, owner, new Date(), db)).toBe(false);
+  });
+
+  it("refuses to complete or renew an EXPIRED lease", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    const owner = id("owner");
+    const claimed = await claimModerationOutboxEvent(
+      { leaseOwner: owner, eventId, leaseMs: MINUTE_MS },
+      db,
+    );
+    // Not decoration: without it, a claim that silently matched nothing would
+    // make the two refusals below pass for the wrong reason entirely.
+    expect(claimed?.id).toBe(eventId);
+
+    // A dispatcher whose lease lapsed must not write an outcome for work another
+    // task may already have reclaimed.
+    const afterLapse = new Date(Date.now() + 2 * MINUTE_MS);
+    expect(await renewModerationOutboxEvent(eventId, owner, MINUTE_MS, afterLapse, db)).toBe(false);
+    expect(await completeModerationOutboxEvent(eventId, owner, afterLapse, db)).toBe(false);
+    // And it really is the lapse that refuses them, not the owner or the status.
+    expect(await completeModerationOutboxEvent(eventId, owner, new Date(), db)).toBe(true);
+  });
+
+  it("extends a live lease for its owner", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    const owner = id("owner");
+    const claimed = await claimModerationOutboxEvent({ leaseOwner: owner, eventId, leaseMs: 5_000 }, db);
+    expect(claimed?.id).toBe(eventId);
+
+    expect(await renewModerationOutboxEvent(eventId, owner, 2 * MINUTE_MS, new Date(), db)).toBe(true);
+    const [row] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(row.leaseUntil.getTime()).toBeGreaterThan(claimed.leaseUntil.getTime());
+  });
+
+  it("dead-letters with its error, and bounds it", async () => {
+    const eventId = id("outbox");
+    await insertDueOutboxEvent(eventId);
+    const owner = id("owner");
+    await claimModerationOutboxEvent({ leaseOwner: owner, eventId }, db);
+
+    const released = await releaseModerationOutboxEvent(
+      {
+        eventId,
+        leaseOwner: owner,
+        deadLettered: true,
+        availableAt: new Date(),
+        error: "x".repeat(5_000),
+      },
+      db,
+    );
+
+    expect(released).toBe(true);
+    const [row] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, eventId));
+    expect(row.status).toBe("dead_letter");
+    // The Mongoose schema bounded nothing and the service sliced at 2 000 before
+    // every write; the bound lives at the repository now so it holds for callers
+    // that do not.
+    expect(row.lastError).toHaveLength(2_000);
+    expect(row.leaseOwner).toBeNull();
+  });
+});
+
+describe("the inbound webhook dedupe claim", () => {
+  it("answers 'already seen' as a VALUE, not as a thrown duplicate key", async () => {
+    const eventId = id("evt");
+    expect(await claimModerationEvent(eventId, db)).toBe(true);
+    // A second delivery, on another ECS task, gets `false` — not an exception a
+    // `catch` has to classify apart from a lost connection.
+    expect(await claimModerationEvent(eventId, db)).toBe(false);
+
+    const [row] = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    expect(row.state).toBe("claimed");
+  });
+
+  it("releases a claim by deleting it, so a redelivery can be processed", async () => {
+    const eventId = id("evt");
+    await claimModerationEvent(eventId, db);
+    await releaseModerationEvent(eventId, db);
+
+    const rows = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    expect(rows).toHaveLength(0);
+    expect(await claimModerationEvent(eventId, db)).toBe(true);
+  });
+
+  it("records a decision event and queues its work in ONE transaction", async () => {
+    const eventId = id("evt");
+    const caseId = id("case");
+    await claimModerationEvent(eventId, db);
+
+    await db.transaction(async (tx) => {
+      await markModerationEventQueued(
+        { eventId, type: "case.decided", caseId, payload: { caseId, decision: { revision: 1 } } },
+        tx,
+      );
+      await enqueueModerationOutboxEvent(
+        {
+          eventId: `moderation:decision.apply:${eventId}`,
+          kind: "decision.apply",
+          payload: { eventId, caseId, decision: { revision: 1 } },
+        },
+        tx,
+      );
+    });
+
+    const [event] = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    expect(event.state).toBe("queued");
+    expect(event.caseId).toBe(caseId);
+    expect(event.queuedAt).not.toBeNull();
+
+    const [work] = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, `moderation:decision.apply:${eventId}`));
+    expect(work.kind).toBe("decision.apply");
+    expect(work.payloadCaseId).toBe(caseId);
+    // The decision rides whole in `jsonb`: §10.11 makes it loose, and projecting
+    // it into columns would drop whatever a newer CrowdSource added.
+    expect(work.payloadDecision).toEqual({ revision: 1 });
+  });
+
+  it("leaves the claim held and nothing queued when that transaction fails", async () => {
+    const eventId = id("evt");
+    const caseId = id("case");
+    await claimModerationEvent(eventId, db);
+
+    const error = await db
+      .transaction(async (tx) => {
+        await markModerationEventQueued(
+          { eventId, type: "case.decided", caseId, payload: { caseId } },
+          tx,
+        );
+        await enqueueModerationOutboxEvent(
+          { eventId: `moderation:decision.apply:${eventId}`, kind: "decision.apply", payload: { eventId, caseId } },
+          tx,
+        );
+        throw new Error("deliberate rollback");
+      })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+    expect(error).not.toBeNull();
+    const [event] = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    // Still `claimed`: the only two outcomes are "recorded and queued" or
+    // "neither", and "neither" is what the middleware releases and CrowdSource
+    // redelivers.
+    expect(event.state).toBe("claimed");
+    const work = await db
+      .select()
+      .from(schema.moderationOutbox)
+      .where(eq(schema.moderationOutbox.id, `moderation:decision.apply:${eventId}`));
+    expect(work).toHaveLength(0);
+  });
+
+  it("never manufactures an audit row for an event nothing claimed", async () => {
+    const eventId = id("evt-unclaimed");
+    const queued = await db.transaction(async (tx) =>
+      markModerationEventQueued({ eventId, type: "case.decided", caseId: id("case"), payload: {} }, tx),
+    );
+
+    expect(queued).toBe(false);
+    const rows = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("records an ignored event without erasing a case id it already had", async () => {
+    const eventId = id("evt");
+    const caseId = id("case");
+    await claimModerationEvent(eventId, db);
+    await markModerationEventIgnored({ eventId, type: "case.created", caseId }, db);
+    await markModerationEventIgnored({ eventId, type: "case.escalated" }, db);
+
+    const [row] = await db
+      .select()
+      .from(schema.moderationEvents)
+      .where(eq(schema.moderationEvents.id, eventId));
+    expect(row.state).toBe("ignored");
+    expect(row.type).toBe("case.escalated");
+    expect(row.caseId).toBe(caseId);
+  });
+});
+
+describe("recording a decision on the report it belongs to", () => {
+  async function queuedReport(): Promise<string> {
+    const report = await db.transaction(async (tx) =>
+      insertReport(
+        {
+          reporter: id("reporter"),
+          reportedType: "user",
+          reportedId: id("subject"),
+          categories: ["hate_speech"],
+          localStatus: "queued",
+        },
+        tx,
+      ),
+    );
+    return report.id;
+  }
+
+  it("applies the FIRST decision, whose expected revision is NULL", async () => {
+    const reportId = await queuedReport();
+
+    const applied = await applyReportDecision(
+      {
+        reportId,
+        expectedRevision: null,
+        status: "resolved",
+        localStatus: "submitted",
+        decisionId: id("decision"),
+        decisionRevision: 1,
+        decisionOutcome: "violation",
+        decisionStatus: "final",
+        decidedAt: new Date(),
+        enforcedAction: "restrict",
+      },
+      db,
+    );
+
+    // `decision_revision = NULL` is NULL, so an `eq` here would match no row and
+    // the first decision about EVERY report would be dropped in silence. This is
+    // the case that tells `is not distinct from` from `=`.
+    expect(applied).toBe(true);
+    const stored = await findReportById(reportId, db);
+    expect(stored?.decisionRevision).toBe(1);
+    expect(stored?.enforcedAction).toBe("restrict");
+    // Nothing acted, so nothing claims it did.
+    expect(stored?.enforcedAt).toBeNull();
+  });
+
+  it("refuses a write whose expected revision is stale", async () => {
+    const reportId = await queuedReport();
+    const decision = (revision: number, expectedRevision: number | null) =>
+      applyReportDecision(
+        {
+          reportId,
+          expectedRevision,
+          status: "resolved",
+          localStatus: "submitted",
+          decisionId: id("decision"),
+          decisionRevision: revision,
+          decisionOutcome: "no_violation",
+          decisionStatus: "final",
+          decidedAt: new Date(),
+          enforcedAction: "restore",
+        },
+        db,
+      );
+
+    expect(await decision(2, null)).toBe(true);
+    // A concurrent worker that read revision 2 before this one wrote it loses.
+    expect(await decision(3, null)).toBe(false);
+    expect(await decision(3, 2)).toBe(true);
+    expect((await findReportById(reportId, db))?.decisionRevision).toBe(3);
+  });
+
+  it("finds the report a decision names by its case id", async () => {
+    const reportId = await queuedReport();
+    const caseId = id("case");
+    await markReportSubmitted(
+      {
+        reportId,
+        crowdSourceReportId: id("cs-report"),
+        crowdSourceCaseId: caseId,
+        crowdSourceMerged: false,
+        contentSnapshotHash: "sha256:deadbeef",
+      },
+      db,
+    );
+
+    const found = await findReportByCaseId(caseId, db);
+    expect(found?.id).toBe(reportId);
+    expect(found?.localStatus).toBe("submitted");
+    expect(found?.submittedAt).not.toBeNull();
+  });
+});
+
+describe("what delivery writes back onto the report", () => {
+  async function deliverableReport(): Promise<string> {
+    const report = await db.transaction(async (tx) =>
+      insertReport(
+        {
+          reporter: id("reporter"),
+          reportedType: "user",
+          reportedId: id("subject"),
+          categories: ["misinformation"],
+          localStatus: "queued",
+          localStatusReason: "a reason from an earlier attempt",
+        },
+        tx,
+      ),
+    );
+    return report.id;
+  }
+
+  it("clears the previous failure and reason when the report is submitted", async () => {
+    const reportId = await deliverableReport();
+    await markReportDeliveryFailed(reportId, "the gateway timed out", db);
+    expect((await findReportById(reportId, db))?.localStatus).toBe("delivery_failed");
+
+    await markReportSubmitted(
+      {
+        reportId,
+        crowdSourceReportId: id("cs-report"),
+        crowdSourceCaseId: id("case"),
+        crowdSourceMerged: true,
+        contentSnapshotHash: "sha256:cafe",
+      },
+      db,
+    );
+
+    const stored = await findReportById(reportId, db);
+    expect(stored?.localStatus).toBe("submitted");
+    // A stale reason is worse than none: both describe a state the row has left.
+    expect(stored?.lastDeliveryError).toBeNull();
+    expect(stored?.localStatusReason).toBeNull();
+    expect(stored?.crowdSourceMerged).toBe(true);
+  });
+
+  it("bounds a delivery error at the length the Mongoose schema declared", async () => {
+    const reportId = await deliverableReport();
+    await markReportDeliveryFailed(reportId, "y".repeat(9_000), db);
+    expect((await findReportById(reportId, db))?.lastDeliveryError).toHaveLength(2_000);
+  });
+
+  it("closes a report whose subject no longer exists, with the reason stored", async () => {
+    const reportId = await deliverableReport();
+    await closeUndeliverableReport(
+      reportId,
+      "The reported account no longer exists, so there is nothing to review.",
+      db,
+    );
+
+    const stored = await findReportById(reportId, db);
+    expect(stored?.localStatus).toBe("closed");
+    expect(stored?.localStatusReason).toContain("no longer exists");
+  });
+
+  it("reports `false` rather than throwing when the report is already gone", async () => {
+    // The delivery event can outlive its report; a worker looking for one that
+    // was deleted has nothing to do and nothing to retry.
+    expect(await markReportDeliveryFailed(id("missing"), "anything", db)).toBe(false);
+    expect(await closeUndeliverableReport(id("missing"), "anything", db)).toBe(false);
+  });
+});
+
+describe("the reporter's own list", () => {
+  it("returns only this reporter's reports, newest first, and no operational state", async () => {
+    const reporter = id("reporter");
+    for (let index = 0; index < 3; index += 1) {
+      await db.transaction(async (tx) =>
+        insertReport(
+          {
+            reporter,
+            reportedType: "user",
+            reportedId: id("subject"),
+            categories: ["spam"],
+            localStatus: "queued",
+            localStatusReason: "operational state that must not be returned",
+          },
+          tx,
+        ),
+      );
+    }
+    await db.transaction(async (tx) =>
+      insertReport(
+        {
+          reporter: id("someone-else"),
+          reportedType: "user",
+          reportedId: id("subject"),
+          categories: ["spam"],
+          localStatus: "queued",
+        },
+        tx,
+      ),
+    );
+
+    const rows = await listReportsByReporter(reporter, db);
+    expect(rows).toHaveLength(3);
+    // The projection is the security boundary: a reporter learning which of their
+    // reports left the deployment learns which can be made to disappear.
+    expect(Object.keys(rows[0]).sort()).toEqual([
+      "categories",
+      "createdAt",
+      "details",
+      "id",
+      "reportedId",
+      "reportedType",
+      "status",
+    ]);
+    for (let index = 1; index < rows.length; index += 1) {
+      expect(rows[index - 1].createdAt.getTime()).toBeGreaterThanOrEqual(
+        rows[index].createdAt.getTime(),
+      );
+    }
+  });
+
+  it("truncates a reporter's details at the length the Mongoose schema declared", async () => {
+    const report = await db.transaction(async (tx) =>
+      insertReport(
+        {
+          reporter: id("reporter"),
+          reportedType: "user",
+          reportedId: id("subject"),
+          categories: ["other"],
+          details: "z".repeat(900),
+          localStatus: "queued",
+        },
+        tx,
+      ),
+    );
+    expect(report.details).toHaveLength(500);
+  });
+});
+
+describe("sanity", () => {
+  it("wrote through the schema helpers, so the casing matches the migration", async () => {
+    const [row] = await client<{ total: number }[]>`
+      select count(*)::int as total from moderation_outbox
+    `;
+    // Anti-vacuity: every case above would also pass against a database where
+    // nothing was ever written, if the reads were as broken as the writes.
+    expect(row.total).toBeGreaterThan(0);
+    const rows = await db.select({ total: sql<number>`count(*)::int` }).from(schema.reports);
+    expect(rows[0].total).toBeGreaterThan(0);
+  });
+});

--- a/packages/backend/src/db/moderation/moderationEventRepository.ts
+++ b/packages/backend/src/db/moderation/moderationEventRepository.ts
@@ -1,0 +1,169 @@
+/**
+ * `moderation_events` — the inbound webhook dedupe claim, shared across tasks, and
+ * the audit trail of what CrowdSource told this deployment to do.
+ *
+ * `@oxyhq/crowdsource-express` defaults to an IN-PROCESS store and says exactly
+ * when that is not enough: two instances behind a load balancer each keep their
+ * own, so a redelivery landing on the OTHER instance is not deduplicated. Allo runs
+ * on ECS Fargate behind one ALB, so this is that case.
+ *
+ * ## The INSERT is the claim, and that is now a VALUE rather than a throw
+ *
+ * `id` is the CrowdSource event id and it is the primary key, so a conflict is not
+ * an error condition to work around — it is the answer "somebody else has this
+ * event". Under Mongo that answer arrived as a duplicate-key ERROR (`code 11000`)
+ * which `moderationEventStore.ts` had to recognise by inspecting an exception and
+ * separate from every other failure. `on conflict (id) do nothing … returning`
+ * gives it as a value instead.
+ *
+ * That is the load-bearing difference, not a tidier spelling. A lost connection, a
+ * failover or pool exhaustion is NOT "already processed": it has to propagate so
+ * the middleware answers non-2xx and the event stays on CrowdSource's retry
+ * schedule (§10.9). Swallowing it would answer 200 and retire a decision nobody
+ * ever handled — and the Mongo shape made that one mis-widened `catch` away. Here
+ * there is no catch to widen: the duplicate never throws, and everything that does
+ * throw reaches the caller.
+ *
+ * A claim is released by DELETING the row, not by marking it failed — see
+ * {@link releaseModerationEvent}.
+ */
+
+import { eq } from "drizzle-orm";
+import { getDb } from "../index";
+import { moderationEvents } from "../schema/moderation";
+import { requireTransaction, type AlloDatabaseOrTransaction } from "./transactionGuard";
+
+/**
+ * Retention.
+ *
+ * §10.9's retry schedule ends at 24 hours, so a dedupe row only has to outlive
+ * that. It is kept far longer because the row is also the audit trail of what a
+ * third party told this deployment to do, and an enforcement question asked weeks
+ * later is answered from here. This is the deadline `db/expiry.ts` reaps against.
+ */
+export const MODERATION_EVENT_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * Take the claim on an event id.
+ *
+ * Deliberately NOT transactional, and deliberately not paired with anything: the
+ * middleware claims BEFORE running the handler, so that a concurrent redelivery
+ * cannot also run it. A claim that only became visible when the handler's own
+ * transaction committed would deduplicate nothing during the window it exists for.
+ *
+ * @returns `true` when THIS call took the claim, `false` when it was already held.
+ *   A thrown error is neither: it means the store could not answer, and the caller
+ *   must let it propagate rather than read it as "already processed".
+ */
+export async function claimModerationEvent(
+  eventId: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const now = new Date();
+  const claimed = await db
+    .insert(moderationEvents)
+    .values({
+      id: eventId,
+      state: "claimed",
+      receivedAt: now,
+      expiresAt: new Date(now.getTime() + MODERATION_EVENT_RETENTION_SECONDS * 1_000),
+    })
+    .onConflictDoNothing({ target: moderationEvents.id })
+    .returning({ id: moderationEvents.id });
+
+  return claimed.length === 1;
+}
+
+/**
+ * Give the claim back so a redelivery can be processed.
+ *
+ * Called when the handler THROWS. Recording an id and never releasing it would make
+ * a transient failure permanent and lose a decision silently — which is why this
+ * DELETES rather than marking the row failed, and why there is no state value for
+ * it to write instead.
+ */
+export async function releaseModerationEvent(
+  eventId: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<void> {
+  await db.delete(moderationEvents).where(eq(moderationEvents.id, eventId));
+}
+
+/**
+ * Complete the audit row for a decision-bearing event, with the CALLER's
+ * transaction.
+ *
+ * The transaction is required for the reason `ModerationInboundService` opens one
+ * at all, and it is a sharper reason than the intake path's. The middleware has
+ * ALREADY claimed this event id, so the dedupe is in force; if completing the row
+ * and queueing the work were two operations, a crash between them would leave an
+ * event permanently deduplicated with no work queued — a decision silently lost,
+ * with a row that says it arrived. Committing both together means the only outcomes
+ * are "recorded and queued" or "neither", and "neither" leaves the claim to be
+ * released and the event redelivered.
+ *
+ * Guarding only the outbox half would leave that reachable: a caller that queued
+ * inside a transaction and completed this row outside it gets the same lost
+ * decision, and nothing would refuse it.
+ *
+ * An update, never an upsert: an event id with no claimed row is one nothing
+ * claimed, and inserting one here would manufacture an audit trail for a webhook
+ * this deployment never accepted.
+ *
+ * @returns `true` when the claimed row was found and completed.
+ */
+export async function markModerationEventQueued(
+  input: {
+    eventId: string;
+    type: string;
+    caseId: string;
+    payload: unknown;
+    queuedAt?: Date;
+  },
+  db: AlloDatabaseOrTransaction,
+): Promise<boolean> {
+  const tx = requireTransaction(db, `markModerationEventQueued(${input.eventId})`);
+  const updated = await tx
+    .update(moderationEvents)
+    .set({
+      type: input.type,
+      caseId: input.caseId,
+      payload: input.payload,
+      state: "queued",
+      queuedAt: input.queuedAt ?? new Date(),
+    })
+    .where(eq(moderationEvents.id, input.eventId))
+    .returning({ id: moderationEvents.id });
+
+  return updated.length === 1;
+}
+
+/**
+ * Record an event there is nothing to do about.
+ *
+ * `case.created`, `case.escalated`, `case.closed` and any type a newer CrowdSource
+ * introduces. No outbox row, because no work — and therefore no transaction, this
+ * being the one write of the pair that has no partner. The row is kept because "did
+ * CrowdSource tell us about this case, and when" is the first question asked when a
+ * report looks stuck.
+ *
+ * `caseId` is left ALONE when the caller has none, rather than written as NULL: an
+ * ignored event that carries no case must not erase a case id an earlier write
+ * recorded for the same row.
+ */
+export async function markModerationEventIgnored(
+  input: { eventId: string; type: string; caseId?: string },
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const updated = await db
+    .update(moderationEvents)
+    .set({
+      type: input.type,
+      ...(input.caseId === undefined ? {} : { caseId: input.caseId }),
+      state: "ignored",
+    })
+    .where(eq(moderationEvents.id, input.eventId))
+    .returning({ id: moderationEvents.id });
+
+  return updated.length === 1;
+}

--- a/packages/backend/src/db/moderation/moderationOutboxRepository.ts
+++ b/packages/backend/src/db/moderation/moderationOutboxRepository.ts
@@ -1,0 +1,351 @@
+/**
+ * `moderation_outbox` — the durable promise that moderation work will happen.
+ *
+ * The at-least-once contract is unchanged from Mongo: an expired lease is
+ * reclaimable and a worker can die mid-delivery, so every handler MUST make its
+ * downstream effect idempotent using the event id.
+ *
+ * ## The claim is `FOR UPDATE SKIP LOCKED`, not a `findOneAndUpdate`
+ *
+ * Mongo claimed with an atomic `findOneAndUpdate` over a disjunctive filter.
+ * Postgres has a better primitive for exactly this shape: the `select … order by
+ * created_at limit 1 for update skip locked` lives INSIDE the `update`, so N
+ * dispatchers draining the queue never hand each other the same row and never block
+ * on one another either — `skip locked` steps over a row another task is already
+ * claiming instead of waiting for it. Allo runs on ECS Fargate behind one ALB and
+ * every task starts a dispatcher, so that is the normal case rather than an edge
+ * one.
+ *
+ * `lease_until` is nullable and `NULL <= now` is NULL, so a row that has never been
+ * leased is excluded from the reclaim branch by the comparison itself — matching
+ * Mongo, where a missing field did not match `{$lte: now}` either.
+ *
+ * ## The Mongo `timestamps: false` hazard has no counterpart here, and that is the point
+ *
+ * The Mongo enqueue carried a long comment about writing `createdAt`/`updatedAt`
+ * explicitly under `timestamps: false`, because Mongoose otherwise named
+ * `updatedAt` in two operators of one update document and the server rejected the
+ * WHOLE write — which, inside the intake transaction, took the `Report` with it.
+ * The fix it settled on was not interchangeable with the obvious one: letting
+ * Mongoose own the timestamps also cleared the server error but left a
+ * `$set: { updatedAt }` on the update, turning a repeated enqueue into a real write
+ * that contends with the dispatcher's live lease on that same row.
+ *
+ * `on conflict (id) do nothing` writes nothing at all — no tuple version, no
+ * timestamp, no lock — so a repeat is a genuine no-op for a STRUCTURAL reason
+ * rather than by matching a spelling. `onConflictDoUpdate` reintroduces exactly the
+ * bug the Mongo flag existed to fix, and measurably so: drizzle applies the
+ * column's `$onUpdate` to a conflict branch's `set`, so "write the same data back"
+ * is not even a quiet write — it moves `updated_at` AND the row's `xmin`. Both are
+ * asserted in `__tests__/db/moderation.realdb.test.ts`.
+ *
+ * ## The payload was one embedded document and is now four columns
+ *
+ * `db/schema/moderation.ts` flattened `ModerationOutboxPayload` into
+ * `payload_report_id`, `payload_event_id`, `payload_case_id` and a `payload_decision`
+ * that stays `jsonb` because the decision document is a loose third-party contract.
+ * This module is the only place that translation happens, in {@link toEvent} and in
+ * the enqueue, so the workers keep consuming the one object shape they always did.
+ */
+
+import { and, asc, eq, gt, lte, or, sql } from "drizzle-orm";
+import { getDb } from "../index";
+import {
+  moderationOutbox,
+  type ModerationOutboxKind,
+  type ModerationOutboxStatus,
+} from "../schema/moderation";
+import { requireTransaction, type AlloDatabaseOrTransaction } from "./transactionGuard";
+
+/**
+ * Retention ceiling, so a stalled dispatcher cannot turn the outbox into an
+ * unbounded table. Ninety days because a moderation case can legitimately sit open
+ * for weeks and a `dead_letter` event is evidence somebody still has to look at.
+ *
+ * This is the deadline `db/expiry.ts` reaps against, and that registry states
+ * outright what reaping this table costs: a `pending` row destroyed here is
+ * moderation work nobody will ever deliver. Operational alerting on outbox age has
+ * to fire long before this, and is not the sweep's job.
+ */
+export const MODERATION_OUTBOX_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * Bound on a stored dispatch error.
+ *
+ * The Mongoose schema declared none and `ModerationOutboxService` sliced at this
+ * length before every write, which is a guard that holds for exactly one caller.
+ * It lives here now so it holds for all of them — the message comes from a third
+ * party and nothing else bounds it. It can carry no reported material because Allo
+ * never puts any into a request.
+ */
+const MAX_LAST_ERROR_LENGTH = 2_000;
+
+/** The lease a dispatcher takes when it claims, and the floor any caller can ask for. */
+const DEFAULT_LEASE_MS = 60_000;
+const MIN_LEASE_MS = 1_000;
+
+/**
+ * The job payload, keyed by `kind`.
+ *
+ * A flat optional shape rather than a discriminated union, matching what the
+ * workers read: each already knows its own `kind` from the row it claimed, and a
+ * union would force a narrowing step at every call site that adds nothing.
+ */
+export interface ModerationOutboxPayload {
+  /** `report.submit` — the local `reports` id. */
+  reportId?: string;
+  /** `decision.apply` — the inbound webhook event id. */
+  eventId?: string;
+  /** The CrowdSource case a decision belongs to. */
+  caseId?: string;
+  /**
+   * The decision exactly as CrowdSource published it, whole and opaque.
+   *
+   * Validated against the contract when it is READ, never when it is stored, so an
+   * event is never lost to a schema this deployment has not caught up with.
+   */
+  decision?: unknown;
+}
+
+/** One claimed event, in the shape the dispatcher and both workers consume. */
+export interface ModerationOutboxEvent {
+  id: string;
+  kind: ModerationOutboxKind;
+  payload: ModerationOutboxPayload;
+  attempts: number;
+  availableAt: Date;
+  leaseOwner?: string;
+  leaseUntil?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+type OutboxRow = typeof moderationOutbox.$inferSelect;
+
+/**
+ * Absent values come back as `undefined`, never `null`.
+ *
+ * A field Mongo left ABSENT is `NULL` in Postgres, and every consumer of
+ * `ModerationOutboxEvent` was written against `undefined` — including
+ * `applyDecisionOutboxEvent`, whose first statement is `if (caseId === undefined)`.
+ * A `null` reaching that check passes it and the event proceeds with no case.
+ * The normalization therefore happens once, here, rather than at each reader.
+ *
+ * A decision stored as JSON `null` is indistinguishable from an absent one. Mongo's
+ * `Mixed` had the same ambiguity and no caller depends on the difference: a
+ * `decision.apply` event with no decision fails contract parsing either way.
+ */
+function toEvent(row: OutboxRow): ModerationOutboxEvent {
+  return {
+    id: row.id,
+    kind: row.kind,
+    payload: {
+      ...(row.payloadReportId === null ? {} : { reportId: row.payloadReportId }),
+      ...(row.payloadEventId === null ? {} : { eventId: row.payloadEventId }),
+      ...(row.payloadCaseId === null ? {} : { caseId: row.payloadCaseId }),
+      ...(row.payloadDecision === null ? {} : { decision: row.payloadDecision }),
+    },
+    attempts: row.attempts,
+    availableAt: row.availableAt,
+    ...(row.leaseOwner === null ? {} : { leaseOwner: row.leaseOwner }),
+    ...(row.leaseUntil === null ? {} : { leaseUntil: row.leaseUntil }),
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Write the event with the CALLER's transaction.
+ *
+ * The transaction is required, not optional — this is the whole point of the table:
+ * the domain write and this row commit together or not at all. See
+ * `transactionGuard.ts` for why the TYPE alone cannot express that, and what a
+ * caller passing `getDb()` would otherwise get away with. This function
+ * deliberately does NOT default its `db` parameter, because the default is the
+ * mistake.
+ *
+ * It is also the ONLY writer of this table — every other function here claims or
+ * releases an EXISTING row and none of them inserts — so no second queue can drift
+ * out of sync with the outbox: the row IS the job.
+ *
+ * @returns The event id, so a caller can record what it queued.
+ */
+export async function enqueueModerationOutboxEvent(
+  input: {
+    eventId: string;
+    kind: ModerationOutboxKind;
+    payload: ModerationOutboxPayload;
+  },
+  db: AlloDatabaseOrTransaction,
+): Promise<string> {
+  const tx = requireTransaction(db, `enqueueModerationOutboxEvent(${input.eventId})`);
+  const now = new Date();
+
+  await tx
+    .insert(moderationOutbox)
+    .values({
+      id: input.eventId,
+      kind: input.kind,
+      payloadReportId: input.payload.reportId,
+      payloadEventId: input.payload.eventId,
+      payloadCaseId: input.payload.caseId,
+      payloadDecision: input.payload.decision,
+      status: "pending",
+      attempts: 0,
+      availableAt: now,
+      expiresAt: new Date(now.getTime() + MODERATION_OUTBOX_RETENTION_SECONDS * 1_000),
+    })
+    /**
+     * NEVER `onConflictDoUpdate`. A repeat has to be a genuine no-op, and a repeat
+     * is ordinary — a transaction retry, two concurrent duplicate submissions, a
+     * reconciliation re-deriving this deterministic id — running while a dispatcher
+     * holds a lease on this very row.
+     */
+    .onConflictDoNothing({ target: moderationOutbox.id });
+
+  return input.eventId;
+}
+
+/**
+ * Atomically claim one due event.
+ *
+ * An expired `processing` lease is reclaimable, so a dead task cannot strand
+ * moderation work forever. `skip locked` is what lets several dispatchers drain the
+ * queue concurrently without handing each other the same row.
+ */
+export async function claimModerationOutboxEvent(
+  options: {
+    leaseOwner: string;
+    eventId?: string;
+    now?: Date;
+    leaseMs?: number;
+  },
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<ModerationOutboxEvent | null> {
+  const now = options.now ?? new Date();
+  const leaseMs = Math.max(MIN_LEASE_MS, options.leaseMs ?? DEFAULT_LEASE_MS);
+
+  const due = and(
+    options.eventId ? eq(moderationOutbox.id, options.eventId) : undefined,
+    or(
+      and(eq(moderationOutbox.status, "pending"), lte(moderationOutbox.availableAt, now)),
+      and(eq(moderationOutbox.status, "processing"), lte(moderationOutbox.leaseUntil, now)),
+    ),
+  );
+
+  const claimed = await db
+    .update(moderationOutbox)
+    .set({
+      status: "processing",
+      leaseOwner: options.leaseOwner,
+      leaseUntil: new Date(now.getTime() + leaseMs),
+      attempts: sql`${moderationOutbox.attempts} + 1`,
+      lastError: null,
+    })
+    /**
+     * Both references name the SAME table, so the subquery's own range entry
+     * shadows the outer one inside it — which is exactly what is wanted here, and
+     * is why the row the subquery locks is the row the update writes.
+     */
+    .where(
+      sql`${moderationOutbox.id} = (
+        select ${moderationOutbox.id} from ${moderationOutbox}
+        where ${due}
+        order by ${asc(moderationOutbox.createdAt)}
+        limit 1
+        for update skip locked
+      )`,
+    )
+    .returning();
+
+  return claimed[0] ? toEvent(claimed[0]) : null;
+}
+
+/**
+ * Only the lease this dispatcher currently owns matches.
+ *
+ * Every terminal transition carries it, so a dispatcher whose lease expired and was
+ * reclaimed by another task cannot complete, renew or release work that is no
+ * longer its own — which is what stops two tasks writing contradictory outcomes for
+ * one row.
+ */
+function ownedLease(eventId: string, leaseOwner: string, now: Date) {
+  return and(
+    eq(moderationOutbox.id, eventId),
+    eq(moderationOutbox.status, "processing"),
+    eq(moderationOutbox.leaseOwner, leaseOwner),
+    gt(moderationOutbox.leaseUntil, now),
+  );
+}
+
+/** Complete only the lease this dispatcher currently owns. */
+export async function completeModerationOutboxEvent(
+  eventId: string,
+  leaseOwner: string,
+  now: Date = new Date(),
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const completed = await db
+    .update(moderationOutbox)
+    .set({
+      status: "processed",
+      processedAt: now,
+      leaseOwner: null,
+      leaseUntil: null,
+      lastError: null,
+    })
+    .where(ownedLease(eventId, leaseOwner, now))
+    .returning({ id: moderationOutbox.id });
+  return completed.length === 1;
+}
+
+/** Extend only a live lease still owned by this dispatcher. */
+export async function renewModerationOutboxEvent(
+  eventId: string,
+  leaseOwner: string,
+  leaseMs: number,
+  now: Date = new Date(),
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const renewed = await db
+    .update(moderationOutbox)
+    .set({ leaseUntil: new Date(now.getTime() + Math.max(MIN_LEASE_MS, leaseMs)) })
+    .where(ownedLease(eventId, leaseOwner, now))
+    .returning({ id: moderationOutbox.id });
+  return renewed.length === 1;
+}
+
+/**
+ * Release a failed claim, with backoff — or stop.
+ *
+ * `deadLettered` and `availableAt` are the CALLER's decisions: only the service
+ * knows whether the error was retryable, how many attempts have been spent and what
+ * its backoff curve is. This writes them, and matches the owned lease so a
+ * dispatcher that already lost the row cannot overwrite the outcome its successor
+ * wrote.
+ */
+export async function releaseModerationOutboxEvent(
+  options: {
+    eventId: string;
+    leaseOwner: string;
+    deadLettered: boolean;
+    availableAt: Date;
+    error: string;
+    now?: Date;
+  },
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const now = options.now ?? new Date();
+  const released = await db
+    .update(moderationOutbox)
+    .set({
+      status: options.deadLettered ? "dead_letter" : "pending",
+      availableAt: options.availableAt,
+      lastError: options.error.slice(0, MAX_LAST_ERROR_LENGTH),
+      leaseOwner: null,
+      leaseUntil: null,
+    })
+    .where(ownedLease(options.eventId, options.leaseOwner, now))
+    .returning({ id: moderationOutbox.id });
+  return released.length === 1;
+}

--- a/packages/backend/src/db/moderation/reportRepository.ts
+++ b/packages/backend/src/db/moderation/reportRepository.ts
@@ -1,0 +1,337 @@
+/**
+ * `reports` — one person's report of one thing, and the state of Allo's own
+ * attempt to get it reviewed.
+ *
+ * A report is a receipt and an integration state, never a verdict. CrowdSource owns
+ * cases, reviews and decisions; the decision columns here are a CACHE of a
+ * published revision, overwritten by a later revision and never edited in place.
+ *
+ * ## Absent optionals come back as `null`, not `undefined`
+ *
+ * Deliberately, and this is the one place in this domain where the Mongo shape is
+ * NOT restored. `ModerationOutboxEvent` is a defined interface whose readers test
+ * `=== undefined`, so `moderationOutboxRepository` normalizes it; a report row has
+ * no such interface — it is fifteen optional columns, and fifteen lines of
+ * `x === null ? {} : { … }` whose only job would be to restore a distinction
+ * Postgres does not make. Readers use `??`, which is what `decisionRevision ?? 0`
+ * in `ModerationDecisionWorker` already does, and the one place a `string | null`
+ * must become a `string | undefined` (`details`, handed to the SDK's `ReportInput`)
+ * says so at that call site.
+ *
+ * ## Three Mongoose `maxlength` bounds land here
+ *
+ * `details` (500), `localStatusReason` (300) and `lastDeliveryError` (2 000) were
+ * bounded by the Mongoose schema; `db/schema/moderation.ts` carries no CHECK for
+ * any of them, so the bound has nowhere else to live and is applied at every write
+ * below. It TRUNCATES where Mongoose REJECTED, which is what every existing caller
+ * already does to the same values before handing them over — the route slices
+ * `details`, the delivery worker slices its error — so this makes the bound hold
+ * for callers that do not, rather than turning a 201 into a 500 for a report whose
+ * details ran one character long.
+ */
+
+import { and, desc, eq, sql } from "drizzle-orm";
+import { uuidv7 } from "@oxyhq/db";
+import { getDb } from "../index";
+import {
+  reports,
+  type ModerationEnforcementAction,
+  type ModerationLocalStatus,
+  type ReportCategory,
+  type ReportStatus,
+  type ReportedType,
+} from "../schema/moderation";
+import type { AlloDatabaseOrTransaction } from "./transactionGuard";
+
+/** A stored report, exactly as the table holds it. */
+export type ModerationReport = typeof reports.$inferSelect;
+
+const MAX_DETAILS_LENGTH = 500;
+const MAX_LOCAL_STATUS_REASON_LENGTH = 300;
+const MAX_DELIVERY_ERROR_LENGTH = 2_000;
+
+/**
+ * The ceiling on a reporter's own list.
+ *
+ * A cap rather than a caller's choice: the projection this bounds is served
+ * straight to a user, and an unbounded page size would be a parameter that decides
+ * how much work an authenticated request can ask for.
+ */
+const MAX_REPORTS_PER_READ = 100;
+
+function bounded(value: string | undefined, limit: number): string | undefined {
+  return value === undefined ? undefined : value.slice(0, limit);
+}
+
+/**
+ * The one report a reporter can have about one object.
+ *
+ * Read inside intake's transaction so the duplicate answer and the insert that
+ * follows it see the same snapshot. It is not the only defence — the unique index
+ * `reports_reporter_reported_id_reported_type_key` is, and a concurrent duplicate
+ * still surfaces there as a `23505` a caller must recognise with
+ * `isUniqueViolation` rather than a message regex.
+ */
+export async function findReportBySubject(
+  query: { reporter: string; reportedId: string; reportedType: ReportedType },
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<ModerationReport | undefined> {
+  const [row] = await db
+    .select()
+    .from(reports)
+    .where(
+      and(
+        eq(reports.reporter, query.reporter),
+        eq(reports.reportedId, query.reportedId),
+        eq(reports.reportedType, query.reportedType),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+/** One report by its own id. */
+export async function findReportById(
+  reportId: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<ModerationReport | undefined> {
+  const [row] = await db.select().from(reports).where(eq(reports.id, reportId)).limit(1);
+  return row;
+}
+
+/**
+ * The report a decision names, found by the case CrowdSource opened for it.
+ *
+ * `crowd_source_case_id` is not unique — §7.3 lets CrowdSource MERGE reports into
+ * one case, so several local reports can legitimately name it. This returns the
+ * first, matching the Mongo `findOne` it replaces; nothing downstream is defined
+ * for the merged case yet, and inventing an ordering here would be a policy this
+ * repository is not the place to decide.
+ */
+export async function findReportByCaseId(
+  caseId: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<ModerationReport | undefined> {
+  const [row] = await db
+    .select()
+    .from(reports)
+    .where(eq(reports.crowdSourceCaseId, caseId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Store a report.
+ *
+ * The `db` parameter has NO default, unlike every read above. Intake's two writes —
+ * this row and its delivery event — are a pair that must commit together, and a
+ * default would make passing nothing, which is the root connection, the easiest
+ * thing to write. The outbox enqueue REFUSES the root outright; a report has no
+ * second write of its own to be refused for, so what this can do instead is make
+ * the handle a decision the caller states rather than one it omits.
+ *
+ * The id is generated here. `reports.id` is a bare `text().primaryKey()` with no
+ * database default, so a row inserted without one fails — this is where Mongo's
+ * `_id` generation went, and the value is the uuid v7 CONVENTIONS.md specifies for
+ * a row created after the cutover.
+ */
+export async function insertReport(
+  input: {
+    reporter: string;
+    reportedType: ReportedType;
+    reportedId: string;
+    categories: readonly ReportCategory[];
+    details?: string;
+    status?: ReportStatus;
+    localStatus: ModerationLocalStatus;
+    localStatusReason?: string;
+  },
+  db: AlloDatabaseOrTransaction,
+): Promise<ModerationReport> {
+  const [row] = await db
+    .insert(reports)
+    .values({
+      id: uuidv7(),
+      reporter: input.reporter,
+      reportedType: input.reportedType,
+      reportedId: input.reportedId,
+      categories: [...input.categories],
+      details: bounded(input.details, MAX_DETAILS_LENGTH),
+      status: input.status ?? "pending",
+      localStatus: input.localStatus,
+      localStatusReason: bounded(
+        input.localStatusReason,
+        MAX_LOCAL_STATUS_REASON_LENGTH,
+      ),
+    })
+    .returning();
+  return row;
+}
+
+/**
+ * The reports one person filed, newest first.
+ *
+ * The projection is the route's: `localStatus`, `localStatusReason` and every
+ * CrowdSource identifier are operational state, and returning them would tell a
+ * reporter which of their reports left the deployment.
+ */
+export async function listReportsByReporter(
+  reporter: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<
+  Pick<
+    ModerationReport,
+    "id" | "reportedType" | "reportedId" | "categories" | "details" | "status" | "createdAt"
+  >[]
+> {
+  return await db
+    .select({
+      id: reports.id,
+      reportedType: reports.reportedType,
+      reportedId: reports.reportedId,
+      categories: reports.categories,
+      details: reports.details,
+      status: reports.status,
+      createdAt: reports.createdAt,
+    })
+    .from(reports)
+    .where(eq(reports.reporter, reporter))
+    .orderBy(desc(reports.createdAt))
+    .limit(MAX_REPORTS_PER_READ);
+}
+
+/**
+ * Record what CrowdSource decided, if this is still the newest revision.
+ *
+ * A compare-and-set on `decision_revision`, and the comparison is
+ * `is not distinct from` rather than `=`. That is not a stylistic choice: the
+ * expected value is NULL for every report that has never been decided, which is
+ * most of them, and `decision_revision = NULL` is NULL — so an `eq` here would
+ * match no row at all and the FIRST decision about every report would be silently
+ * dropped. §10.6 allows redelivery and reordering, so the guard has to hold against
+ * what is stored rather than against arrival order.
+ *
+ * `enforcedAction` is the action Allo WOULD take. `enforced_at` is deliberately not
+ * written: nothing acts yet, and a timestamp claiming otherwise would be the record
+ * of an enforcement that never happened.
+ *
+ * @returns `false` when a concurrent writer already moved the revision.
+ */
+export async function applyReportDecision(
+  input: {
+    reportId: string;
+    expectedRevision: number | null;
+    status: ReportStatus;
+    localStatus: ModerationLocalStatus;
+    decisionId: string;
+    decisionRevision: number;
+    decisionOutcome: string;
+    decisionStatus: string;
+    decidedAt: Date;
+    enforcedAction: ModerationEnforcementAction;
+  },
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const applied = await db
+    .update(reports)
+    .set({
+      status: input.status,
+      localStatus: input.localStatus,
+      decisionId: input.decisionId,
+      decisionRevision: input.decisionRevision,
+      decisionOutcome: input.decisionOutcome,
+      decisionStatus: input.decisionStatus,
+      decidedAt: input.decidedAt,
+      enforcedAction: input.enforcedAction,
+    })
+    .where(
+      and(
+        eq(reports.id, input.reportId),
+        sql`${reports.decisionRevision} is not distinct from ${input.expectedRevision}`,
+      ),
+    )
+    .returning({ id: reports.id });
+  return applied.length === 1;
+}
+
+/**
+ * The report left for review.
+ *
+ * `localStatusReason` and `lastDeliveryError` are cleared, because both describe a
+ * state this row has just left and a stale reason is worse than none.
+ */
+export async function markReportSubmitted(
+  input: {
+    reportId: string;
+    crowdSourceReportId: string;
+    crowdSourceCaseId: string;
+    crowdSourceMerged: boolean;
+    contentSnapshotHash: string;
+    submittedAt?: Date;
+  },
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const updated = await db
+    .update(reports)
+    .set({
+      localStatus: "submitted",
+      crowdSourceReportId: input.crowdSourceReportId,
+      crowdSourceCaseId: input.crowdSourceCaseId,
+      crowdSourceMerged: input.crowdSourceMerged,
+      contentSnapshotHash: input.contentSnapshotHash,
+      submittedAt: input.submittedAt ?? new Date(),
+      lastDeliveryError: null,
+      localStatusReason: null,
+    })
+    .where(eq(reports.id, input.reportId))
+    .returning({ id: reports.id });
+  return updated.length === 1;
+}
+
+/**
+ * A delivery attempt failed, and it is visible on the REPORT rather than only in
+ * the outbox row.
+ *
+ * `delivery_failed` is the state the reconciliation sweep reads; leaving the report
+ * at `queued` while the outbox quietly backed off would hide the problem in a table
+ * nobody looks at.
+ */
+export async function markReportDeliveryFailed(
+  reportId: string,
+  error: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const updated = await db
+    .update(reports)
+    .set({
+      localStatus: "delivery_failed",
+      lastDeliveryError: error.slice(0, MAX_DELIVERY_ERROR_LENGTH),
+    })
+    .where(eq(reports.id, reportId))
+    .returning({ id: reports.id });
+  return updated.length === 1;
+}
+
+/**
+ * Close a report there is genuinely nothing left to do about — the reported account
+ * was deleted between the report and its delivery.
+ *
+ * The reason is stored rather than left to be inferred, because a report closed for
+ * this and a report never delivered because its TYPE has no route out are different
+ * claims that end up in adjacent states, and in Allo the second is the common case.
+ */
+export async function closeUndeliverableReport(
+  reportId: string,
+  reason: string,
+  db: AlloDatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const updated = await db
+    .update(reports)
+    .set({
+      localStatus: "closed",
+      localStatusReason: reason.slice(0, MAX_LOCAL_STATUS_REASON_LENGTH),
+    })
+    .where(eq(reports.id, reportId))
+    .returning({ id: reports.id });
+  return updated.length === 1;
+}

--- a/packages/backend/src/db/moderation/transactionGuard.ts
+++ b/packages/backend/src/db/moderation/transactionGuard.ts
@@ -1,0 +1,92 @@
+/**
+ * Refusing the root connection where a TRANSACTION was required.
+ *
+ * ## What this replaces, and why a type is not enough
+ *
+ * Under Mongo the invariant was `session.inTransaction()`, and
+ * `ModerationOutboxService` explains at length why the TYPE alone could not carry
+ * it: a required `ClientSession` parameter is satisfied by any session, including
+ * a bare `startSession()` nobody opened a transaction on, which type-checks
+ * perfectly and commits the row on its own.
+ *
+ * Drizzle has the same hole and a wider one. The root handle and a transaction
+ * handle are both accepted wherever `AlloDatabaseOrTransaction` is asked for — so
+ * `enqueueModerationOutboxEvent(input, getDb())` compiles, runs, commits the row
+ * alone, and passes any test that only asserts the row exists. It is also what
+ * FORGETTING an argument gets you, everywhere a repository defaults its `db`
+ * parameter to `getDb()`, which is the shape of the mistake worth catching: it
+ * looks exactly like correct code and fails as lost moderation work on the day
+ * something restarts between the two writes.
+ *
+ * ## The discriminator
+ *
+ * The root database has no `rollback`; a transaction handle's `rollback` IS a
+ * function — for a nested (savepoint) transaction too, which is what makes this
+ * safe inside a caller that already opened one. `rollback` is the method a
+ * transaction has BECAUSE it is one, so this tests what the handle can DO rather
+ * than a name that happens to differ.
+ *
+ * `instanceof PgTransaction` was the alternative and is worse here: it holds only
+ * while exactly one copy of drizzle is installed, which is a property of the
+ * installer's hoisting rather than of this code — and bun's linker modes put
+ * packages in different places, so it is not even a stable property of this repo.
+ *
+ * ## Which writes are guarded, and which deliberately are not
+ *
+ * Two: {@link import('./moderationOutboxRepository').enqueueModerationOutboxEvent}
+ * and {@link import('./moderationEventRepository').markModerationEventQueued}.
+ * Each is one half of a pair that must commit together, and each is the half whose
+ * absence is silent. Nothing else here is guarded — a report stored for a type Allo
+ * never delivers has no second write to commit with, and a guard on it would be a
+ * restriction the port invented rather than one it preserved.
+ */
+
+import type { AlloDatabase } from "../index";
+
+/**
+ * The handle `db.transaction(...)` hands its callback.
+ *
+ * Derived from the database type rather than named as `PgTransaction<…>` so it
+ * cannot disagree with what drizzle actually passes, and so a drizzle upgrade that
+ * reshapes those generics is a compile error here rather than a silent widening.
+ */
+export type AlloTransaction = Parameters<Parameters<AlloDatabase["transaction"]>[0]>[0];
+
+/** What every repository in this domain accepts: the pool, or a live transaction. */
+export type AlloDatabaseOrTransaction = AlloDatabase | AlloTransaction;
+
+/**
+ * Raised when a write that must commit with its domain row is handed the root
+ * connection.
+ *
+ * Never expected at runtime — it exists so the invariant is ENFORCED rather than
+ * reviewed.
+ */
+export class MissingTransactionError extends Error {
+  constructor(operation: string) {
+    super(
+      `Refusing to run '${operation}' outside a transaction: it must commit together ` +
+        "with the write it belongs to, or a report is answered 201 and never delivered. " +
+        "Pass the handle from `db.transaction(...)`, not `getDb()`.",
+    );
+    this.name = "MissingTransactionError";
+  }
+}
+
+/**
+ * Narrow a handle to a transaction, or throw.
+ *
+ * @param operation Names the CALL, not just the function — the callers pass the
+ *   event id too, so a refusal says which enqueue was misrouted instead of sending
+ *   whoever hits it hunting through every caller.
+ * @throws {MissingTransactionError} When handed the root connection.
+ */
+export function requireTransaction(
+  db: AlloDatabaseOrTransaction,
+  operation: string,
+): AlloTransaction {
+  if (!("rollback" in db) || typeof db.rollback !== "function") {
+    throw new MissingTransactionError(operation);
+  }
+  return db;
+}


### PR DESCRIPTION
The moderation domain of the Mongo → Postgres port — `reports`,
`moderation_events` and `moderation_outbox` — as four modules under
`db/moderation/` and one real-Postgres suite. **Nothing imports them.** No route,
service or Mongoose model is touched, so this lands with no behaviour to break;
the call-site port is a separate change.

This is the domain with all 18 of the port's transaction sites, and it is why the
port needs a transaction guard at all.

## The guard, and why a type could never have been it

Under Mongo the invariant was `session.inTransaction()`, and
`ModerationOutboxService` already wrote down why the TYPE could not carry it: a
required `ClientSession` parameter is satisfied by a bare `startSession()` nobody
opened a transaction on, which type-checks perfectly and commits the row alone.

Drizzle has the same hole and a wider one. The root handle and a transaction
handle are both accepted wherever `AlloDatabaseOrTransaction` is asked for, so
`enqueueModerationOutboxEvent(input, getDb())` compiles, runs, commits the row on
its own, and passes any test that only asserts the row exists — and it is also
what FORGETTING an argument gets you anywhere a repository defaults `db` to
`getDb()`.

`requireTransaction` discriminates on whether `.rollback` is a **function** —
the method a transaction has BECAUSE it is one, which a savepoint has too, so the
guard is safe inside a caller that already opened a transaction.
`instanceof PgTransaction` was the alternative and is worse: it holds only while
exactly one copy of drizzle is installed, which is a property of the installer's
hoisting rather than of this code.

**Two writes are guarded, not one.** The outbox enqueue is the obvious half. The
inbound event's audit write (`markModerationEventQueued`) is the sharper one: the
webhook middleware has ALREADY claimed the event id, so guarding only the outbox
leaves a caller free to complete the audit row outside the transaction and queue
the work inside it — and a crash between them leaves an event permanently
deduplicated with no work queued. That is a decision lost behind a row that says
it arrived, which is the exact failure §10.8's transaction exists to prevent.

Nothing else is guarded, deliberately. A report stored for a type Allo never
delivers has no second write to commit with, and a guard on it would be a
restriction the port invented rather than one it preserved.

## Every claim is mutation-tested

Each mutation was applied, the suite run, and the file restored by writing
pristine content back in place (never `git checkout`, which would revert the work
under test along with the mutation) and verified byte-identical by checksum
afterwards.

| Mutation | Result |
|---|---|
| Drop `requireTransaction` from the enqueue | reds *"refuses the ROOT connection, naming the call that was misrouted"* |
| Drop `requireTransaction` from the audit write | reds its own case |
| `onConflictDoNothing` → `onConflictDoUpdate` with **identical values** | reds on `xmin` (1172 → 1173) **before** the column comparison — which is the whole reason `xmin` is asserted |
| `is not distinct from` → `=` in the decision CAS | reds; the first decision about every report is dropped |
| Drop `gt(leaseUntil, now)` from the owner check | reds; a lapsed dispatcher writes an outcome for reclaimed work |
| Drop `skip locked` | see below |

**`skip locked` is the one worth reading the test for.** Deleting it leaves the
N-concurrent-dispatchers case **green** — under READ COMMITTED a plain
`for update` merely serialises the claimers, and each re-reads onto a different
row — and deadlocks the case that holds the contended row's lock open inside a
transaction, until the test times out. The case that *looks* like the concurrency
test is not the one that discriminates, so both are kept and the file says so, to
stop the discriminating one being deleted later as redundant.

## Departures from the Mongo shape, each deliberate

- **`insertReport` has no default `db`**, unlike every read beside it. Its row and
  its delivery event are a pair; a default would make passing nothing — the root
  connection — the easiest thing to write. The enqueue refuses the root outright;
  a report has no second write of its own to be refused for, so what this can do
  instead is make the handle a decision the caller states rather than one it omits.
- **A report row comes back with `null`; `ModerationOutboxEvent` is normalized to
  `undefined`.** The outbox has a defined interface whose readers test
  `=== undefined` — `applyDecisionOutboxEvent`'s first statement is exactly that,
  and a `null` would pass it and let an event proceed with no case. A report is
  fifteen optional columns with no such interface, and fifteen lines of
  `x === null ? {} : {…}` would only restore a distinction Postgres does not make.
- **The claim answers "already seen" as a VALUE.** `on conflict (id) do nothing …
  returning` replaces Mongo's `code === 11000`, so a lost connection or a failover
  can no longer be mis-classified as "already processed" by a `catch` somebody
  widened. There is no catch left to widen.
- **Three Mongoose `maxlength` bounds land in the repository** — `details` (500),
  `localStatusReason` (300), `lastDeliveryError` (2 000) — because
  `db/schema/moderation.ts` carries no CHECK for any of them. They truncate where
  Mongoose rejected, which is what every existing caller already does to the same
  values; see the note below.

## Gates

- `bun run typecheck:backend` — clean.
- Full backend suite, real Postgres 17: **33 files, 647 tests, all passing** (612
  before this change, 35 added).
- The transaction types were checked for vacuity: a deliberate
  `const bad: AlloTransaction = getDb()` is rejected with *"missing … rollback"*,
  so the union is real and the `in`-narrowing is not silently `any`.
- No shared file touched: `src/db/schema/**`, `db/index.ts`, `db/expiry.ts`,
  `db/migrate.ts`, `db/protectedColumns.ts`, `db/testDatabase.ts`, `package.json`,
  `bun.lock`, `.github/` and `drizzle/` are all untouched, and `bun.lock` is
  byte-unchanged after `bun install`.

## Two things for whoever owns the schema

Neither is changed here, because a schema change now invalidates three sibling
domains in flight.

1. **`CONVENTIONS.md` says a post-cutover row "gets a uuid v7 from
   `generatedId()`", and no table uses `generatedId()`** — every id is a bare
   `text().primaryKey()` with no database default. So every repository in every
   domain must generate the id itself or the insert fails; `insertReport` does,
   with `uuidv7()` from `@oxyhq/db`, which is what `generatedId()` would have
   produced. Either the ledger's sentence or the columns should move.
2. **Three `maxlength` bounds were not translated into CHECKs** (the three above).
   They are the schema's to hold — "if the database can express it, let the
   constraint carry it" is this ledger's own rule.

Also worth hoisting once the domains land: `AlloDatabaseOrTransaction` /
`AlloTransaction` are declared in `transactionGuard.ts` because `db/index.ts` was
off-limits for this change. `db/index.ts` is their natural home, beside
`AlloDatabase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
