### PR TITLE
feat(db): Matrix bridge repositories on Postgres, landing unused

### DIFF
--- a/packages/backend/src/__tests__/db/bridges.realdb.test.ts
+++ b/packages/backend/src/__tests__/db/bridges.realdb.test.ts
@@ -1,0 +1,1097 @@
+/**
+ * The bridge repositories, against a REAL Postgres server.
+ *
+ * Every claim these modules make is a claim about a STATEMENT — a conflict
+ * branch that omits a column, a `FOR UPDATE` that orders two writers, a CHECK
+ * that refuses a country code, a projection that withholds a seed. A mocked
+ * `insert` accepts all of them equally, including the ones the server rejects
+ * outright, so nothing short of a server can tell a working repository from a
+ * plausible one.
+ *
+ * Nothing in `src/services` or `src/routes` imports these repositories yet; this
+ * file is their only caller, and it is deliberately the only one until the
+ * call-site switch lands.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { createDatabase, constraintNameOf, isCheckViolation, uuidv7 } from "@oxyhq/db";
+import type postgres from "postgres";
+import { setUpTestDatabase, type TestDatabaseHandle } from "../../db/testDatabase";
+import * as schema from "../../db/schema";
+import {
+  applyReportedState,
+  countAccounts,
+  deleteAccount,
+  findAccountByNetworkRemoteLogin,
+  findAccountByRemoteLogin,
+  findAccountForUser,
+  findSlotOwner,
+  listAccountsForUser,
+  markAccountNotified,
+  markStaleAccountsFailed,
+  reconcileAccount,
+  upsertLinkedAccount,
+} from "../../db/bridges/accounts";
+import {
+  closeLinkSession,
+  completeLinkSession,
+  findLinkSessionForUser,
+  findOpenLinkSessions,
+  insertLinkSession,
+  recordLinkSessionStep,
+} from "../../db/bridges/linkSessions";
+import {
+  acquireLease,
+  findLease,
+  listLeaseRotations,
+  recordLeaseExit,
+  rotateLease,
+} from "../../db/bridges/proxyLeases";
+
+let handle: TestDatabaseHandle;
+let db: ReturnType<typeof createDatabase<typeof schema>>["db"];
+let client: postgres.Sql;
+
+/** Unique per call, so cases cannot collide inside the one shared database. */
+let counter = 0;
+function unique(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${String(counter).padStart(4, "0")}`;
+}
+
+beforeAll(async () => {
+  handle = await setUpTestDatabase();
+  const created = createDatabase({ databaseUrl: handle.databaseUrl, schema });
+  db = created.db;
+  client = created.client;
+}, 180_000);
+
+afterAll(async () => {
+  await client?.end();
+  await handle?.drop();
+});
+
+describe("bridge_accounts — the upsert that replaces findOneAndUpdate(upsert)", () => {
+  it("creates an account, and converges on the unique index rather than duplicating it", async () => {
+    const oxyUserId = unique("user");
+    const remoteLoginId = unique("login");
+    const at = new Date();
+
+    const first = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId,
+      at,
+      remoteName: "Ada",
+      spaceRoomId: "!space:allo.you",
+      remoteProfileUsername: "ada",
+    });
+    expect(first.state).toBe("connecting");
+    expect(first.remoteName).toBe("Ada");
+
+    const second = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId,
+      at: new Date(at.getTime() + 1_000),
+    });
+
+    // The row is the same row: the caller's second id was discarded by the
+    // database, which is what makes two concurrent completions of one login
+    // produce one account instead of a duplicate-key error.
+    expect(second.id).toBe(first.id);
+    expect(await countAccounts(db, { oxyUserId, network: "telegram" })).toBe(1);
+  });
+
+  it("does NOT erase a detail the second call omits", async () => {
+    // The port hazard `keepUnlessSupplied` exists for. A key Mongo never
+    // receives is a key Mongo never writes; `excluded.remote_name` is NULL for
+    // an absent value, and assigning it would wipe the display name the last
+    // `whoami` established — silently, and visible only one call later.
+    const oxyUserId = unique("user");
+    const remoteLoginId = unique("login");
+    const at = new Date();
+
+    await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "slack",
+      remoteLoginId,
+      at,
+      remoteName: "Grace",
+      spaceRoomId: "!grace:allo.you",
+      remoteProfileName: "Grace H",
+      remoteProfileUsername: "grace",
+      remoteProfilePhone: "+100",
+      remoteProfileAvatarUrl: "mxc://a",
+    });
+
+    const kept = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "slack",
+      remoteLoginId,
+      at: new Date(at.getTime() + 1_000),
+    });
+
+    expect(kept.remoteName).toBe("Grace");
+    expect(kept.spaceRoomId).toBe("!grace:allo.you");
+    expect(kept.remoteProfileName).toBe("Grace H");
+    expect(kept.remoteProfileUsername).toBe("grace");
+    expect(kept.remoteProfilePhone).toBe("+100");
+    expect(kept.remoteProfileAvatarUrl).toBe("mxc://a");
+  });
+
+  it("overwrites a detail the second call DOES supply", async () => {
+    // The other half of the same statement: `coalesce` must not become "never
+    // update", or a renamed remote account would keep its old name forever.
+    const oxyUserId = unique("user");
+    const remoteLoginId = unique("login");
+    const at = new Date();
+
+    await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "slack",
+      remoteLoginId,
+      at,
+      remoteName: "Old",
+    });
+    const renamed = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "slack",
+      remoteLoginId,
+      at: new Date(at.getTime() + 1_000),
+      remoteName: "New",
+    });
+    expect(renamed.remoteName).toBe("New");
+  });
+
+  it("keeps linked_at from the FIRST link, because a re-link is not a new one", async () => {
+    const oxyUserId = unique("user");
+    const remoteLoginId = unique("login");
+    const first = new Date("2024-01-01T00:00:00.000Z");
+    const later = new Date("2025-06-01T00:00:00.000Z");
+
+    const created = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId,
+      at: first,
+    });
+    const relinked = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId,
+      at: later,
+    });
+
+    expect(created.linkedAt.toISOString()).toBe(first.toISOString());
+    expect(relinked.linkedAt.toISOString()).toBe(first.toISOString());
+    // `last_state_at` DOES move — it is when the state was last reported.
+    expect(relinked.lastStateAt.toISOString()).toBe(later.toISOString());
+  });
+});
+
+describe("bridge_accounts — reported state", () => {
+  it("records a state event this deployment has never heard of", async () => {
+    // `raw_state_event` carries no CHECK, deliberately. A refusal here would
+    // drop the status update that tells an operator something changed — which
+    // is exactly the update worth having when a bridge ships a new vocabulary.
+    const oxyUserId = unique("user");
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+
+    const updated = await applyReportedState(db, {
+      id: account.id,
+      state: "degraded",
+      at: new Date(),
+      rawStateEvent: "SOMETHING_NOBODY_HAS_SEEN_YET",
+    });
+    expect(updated?.rawStateEvent).toBe("SOMETHING_NOBODY_HAS_SEEN_YET");
+  });
+
+  it("replaces the whole raw state, so a cleared error does not linger", async () => {
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId: unique("user"),
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+
+    const failing = await applyReportedState(db, {
+      id: account.id,
+      state: "action_required",
+      at: new Date(),
+      rawStateEvent: "BAD_CREDENTIALS",
+      rawStateError: "FI.MAU.TELEGRAM.INVALID_PASSWORD",
+      rawStateTtl: 3_600,
+    });
+    expect(failing?.rawStateError).toBe("FI.MAU.TELEGRAM.INVALID_PASSWORD");
+    expect(failing?.rawStateTtl).toBe(3_600);
+
+    const recovered = await applyReportedState(db, {
+      id: account.id,
+      state: "connected",
+      at: new Date(),
+      rawStateEvent: "CONNECTED",
+    });
+    // Mongo's `$set: { rawState: {…} }` replaced the subdocument wholesale, so
+    // an absent error means there is no longer an error.
+    expect(recovered?.rawStateError).toBeNull();
+    expect(recovered?.rawStateTtl).toBeNull();
+  });
+
+  it("clears the notification marker when an account reaches connected", async () => {
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId: unique("user"),
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+    await markAccountNotified(db, {
+      id: account.id,
+      state: "action_required",
+      at: new Date(),
+    });
+
+    const recovered = await applyReportedState(db, {
+      id: account.id,
+      state: "connected",
+      at: new Date(),
+      rawStateEvent: "CONNECTED",
+    });
+
+    // Without this, a user who reconnects and is later logged out again would
+    // never be told the second time.
+    expect(recovered?.lastNotifiedState).toBeNull();
+    expect(recovered?.lastNotifiedAt).toBeNull();
+    expect(recovered?.lastConnectedAt).not.toBeNull();
+  });
+
+  it("clears it from the reconcile path too, which is a different writer", async () => {
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId: unique("user"),
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+    await markAccountNotified(db, { id: account.id, state: "failed", at: new Date() });
+
+    const reconciled = await reconcileAccount(db, {
+      id: account.id,
+      state: "connected",
+      at: new Date(),
+      remoteName: "Reconciled",
+    });
+    expect(reconciled?.lastNotifiedState).toBeNull();
+    expect(reconciled?.lastConnectedAt).not.toBeNull();
+    expect(reconciled?.remoteName).toBe("Reconciled");
+  });
+});
+
+describe("bridge_accounts — the stale sweep, which was a Mongo $expr", () => {
+  it("holds each account to its OWN reported TTL", async () => {
+    /**
+     * The sweep is deliberately UNSCOPED — it is a faithful port of an
+     * `updateMany` with no user filter — so in a database shared with every
+     * other case in this file, any neighbour's account could satisfy its
+     * predicate and inflate the count. The clock is therefore set earlier than
+     * every other timestamp this file writes (the oldest elsewhere is 2024),
+     * which makes the fixtures below the only rows that can possibly be stale
+     * and lets the count stay exact rather than becoming a toothless `>= 2`.
+     */
+    const now = new Date("2021-06-01T12:00:00.000Z");
+    const twoHoursAgo = new Date(now.getTime() - 2 * 3_600_000);
+    const tenHoursAgo = new Date(now.getTime() - 10 * 3_600_000);
+    const oxyUserId = unique("user");
+
+    const shortTtl = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: twoHoursAgo,
+    });
+    await applyReportedState(db, {
+      id: shortTtl.id,
+      state: "connected",
+      at: twoHoursAgo,
+      rawStateEvent: "CONNECTED",
+      rawStateTtl: 3_600,
+    });
+
+    const longTtl = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "slack",
+      remoteLoginId: unique("login"),
+      at: twoHoursAgo,
+    });
+    await applyReportedState(db, {
+      id: longTtl.id,
+      state: "connected",
+      at: twoHoursAgo,
+      rawStateEvent: "CONNECTED",
+      rawStateTtl: 21_600,
+    });
+
+    // No TTL ever reported: held to the caller's default rather than to no
+    // budget at all, which is how a dead process stays green forever.
+    const noTtl = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "discord",
+      remoteLoginId: unique("login"),
+      at: tenHoursAgo,
+    });
+    await reconcileAccount(db, { id: noTtl.id, state: "connecting", at: tenHoursAgo });
+
+    const stillLinking = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      remoteLoginId: unique("login"),
+      at: tenHoursAgo,
+    });
+    await reconcileAccount(db, { id: stillLinking.id, state: "linking", at: tenHoursAgo });
+
+    const alreadyFailed = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "instagram",
+      remoteLoginId: unique("login"),
+      at: tenHoursAgo,
+    });
+    await reconcileAccount(db, { id: alreadyFailed.id, state: "failed", at: tenHoursAgo });
+
+    const marked = await markStaleAccountsFailed(db, {
+      now,
+      marginSeconds: 300,
+      defaultTtlSeconds: 21_600,
+    });
+    expect(marked).toBe(2);
+
+    const after = await listAccountsForUser(db, oxyUserId);
+    const stateOf = (id: string) => after.find((row) => row.id === id)?.state;
+
+    expect(stateOf(shortTtl.id)).toBe("failed");
+    expect(stateOf(noTtl.id)).toBe("failed");
+    // Six hours of budget and two hours of silence: healthy.
+    expect(stateOf(longTtl.id)).toBe("connected");
+    // An attempt in progress has no reported state; its own expiry governs it.
+    expect(stateOf(stillLinking.id)).toBe("linking");
+    expect(stateOf(alreadyFailed.id)).toBe("failed");
+
+    const swept = after.find((row) => row.id === shortTtl.id);
+    expect(swept?.rawStateReason).toBe("stale");
+    // The bridge's own last word is left intact beside the sweep's reason.
+    expect(swept?.rawStateEvent).toBe("CONNECTED");
+  });
+});
+
+describe("bridge_accounts — lookups", () => {
+  it("scopes a lookup by oxyUserId, so an id alone is never enough", async () => {
+    const owner = unique("user");
+    const stranger = unique("user");
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId: owner,
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+
+    expect(await findAccountForUser(db, { oxyUserId: owner, id: account.id })).toBeDefined();
+    expect(
+      await findAccountForUser(db, { oxyUserId: stranger, id: account.id }),
+    ).toBeUndefined();
+  });
+
+  it("finds an account by network and remote login when a report names no user", async () => {
+    const oxyUserId = unique("user");
+    const remoteLoginId = unique("login");
+    await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId,
+      at: new Date(),
+    });
+
+    const scoped = await findAccountByRemoteLogin(db, {
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId,
+    });
+    const fallback = await findAccountByNetworkRemoteLogin(db, {
+      network: "telegram",
+      remoteLoginId,
+    });
+    expect(fallback?.id).toBe(scoped?.id);
+  });
+
+  it("resolves a slot to its owner and nothing else", async () => {
+    const oxyUserId = unique("user");
+    const slotId = unique("slot");
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+    await db
+      .update(schema.bridgeAccounts)
+      .set({ slotId })
+      .where(eq(schema.bridgeAccounts.id, account.id));
+
+    const owner = await findSlotOwner(db, slotId);
+    expect(owner).toEqual({ oxyUserId, network: "whatsapp" });
+    // Named columns, not a whole row: this runs on the bridge's connect path.
+    expect(Object.keys(owner ?? {}).sort()).toEqual(["network", "oxyUserId"]);
+    expect(await findSlotOwner(db, unique("slot"))).toBeUndefined();
+  });
+
+  it("reports whether a delete removed anything", async () => {
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId: unique("user"),
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+    expect(await deleteAccount(db, account.id)).toBe(true);
+    expect(await deleteAccount(db, account.id)).toBe(false);
+  });
+});
+
+describe("bridge_link_sessions — expiry is the query's business, not the sweep's", () => {
+  it("returns an EXPIRED attempt, so the caller can answer 410 rather than 404", async () => {
+    // The sweep lags, exactly as Mongo's TTL monitor lagged its check interval,
+    // and this read must not pretend otherwise. Filtering here would collapse
+    // "this attempt expired" into "no such attempt" — the distinction the
+    // `expired` outcome exists to preserve.
+    const oxyUserId = unique("user");
+    const linkId = unique("lnk");
+    await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId,
+      oxyUserId,
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      currentStepId: "step-1",
+      currentStepType: "user_input",
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const found = await findLinkSessionForUser(db, { oxyUserId, linkId });
+    expect(found).toBeDefined();
+    expect(found?.outcome).toBe("pending");
+    expect(found?.expiresAt.getTime()).toBeLessThan(Date.now());
+  });
+
+  it("excludes an expired attempt from the OPEN-attempt question", async () => {
+    // The read where a lagging sweep changes the ANSWER rather than the row
+    // count, so the deadline is part of the predicate.
+    const oxyUserId = unique("user");
+    await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId: unique("lnk"),
+      oxyUserId,
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const live = await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId: unique("lnk"),
+      oxyUserId,
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    const cancelled = await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId: unique("lnk"),
+      oxyUserId,
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    await closeLinkSession(db, { id: cancelled.id, outcome: "cancelled", at: new Date() });
+
+    const open = await findOpenLinkSessions(db, {
+      oxyUserId,
+      network: "telegram",
+      now: new Date(),
+    });
+    expect(open.map((row) => row.id)).toEqual([live.id]);
+  });
+
+  it("withholds the bridge's login-process handle from the open-attempt read", async () => {
+    const oxyUserId = unique("user");
+    const linkId = unique("lnk");
+    await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId,
+      oxyUserId,
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      currentStepId: "step-1",
+      currentStepType: "user_input",
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+
+    const open = await findOpenLinkSessions(db, {
+      oxyUserId,
+      network: "telegram",
+      now: new Date(),
+    });
+    expect(open).toHaveLength(1);
+    const keys = Object.keys(open[0]);
+    // Positive floor first: an empty projection would satisfy the exclusions
+    // below without withholding anything.
+    expect(keys).toContain("linkId");
+    expect(keys).toContain("outcome");
+    expect(keys).not.toContain("remoteLoginProcessId");
+    expect(keys).not.toContain("currentStepId");
+
+    // The relay read is the ONE opt-in, and it really does carry them.
+    const relay = await findLinkSessionForUser(db, { oxyUserId, linkId });
+    expect(relay?.remoteLoginProcessId).toBeTruthy();
+    expect(relay?.currentStepId).toBe("step-1");
+  });
+});
+
+describe("bridge_link_sessions — the lifecycle of one attempt", () => {
+  it("advances a step with the deadline that step earns", async () => {
+    const session = await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId: unique("lnk"),
+      oxyUserId: unique("user"),
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      currentStepId: "step-1",
+      currentStepType: "user_input",
+      expiresAt: new Date(Date.now() + 600_000),
+    });
+
+    const shorter = new Date(Date.now() + 170_000);
+    const advanced = await recordLinkSessionStep(db, {
+      id: session.id,
+      currentStepId: "step-2",
+      currentStepType: "display_and_wait",
+      expiresAt: shorter,
+      at: new Date(),
+    });
+    expect(advanced?.currentStepType).toBe("display_and_wait");
+    expect(advanced?.expiresAt.toISOString()).toBe(shorter.toISOString());
+  });
+
+  it("keeps a completed attempt after the account it produced is unlinked", async () => {
+    // `result_account_id` was a bare ObjectId nothing checked. As a real FK with
+    // ON DELETE SET NULL the session outlives the account — it is the record of
+    // an ATTEMPT — without pointing at one that is gone.
+    const oxyUserId = unique("user");
+    const account = await upsertLinkedAccount(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "telegram",
+      remoteLoginId: unique("login"),
+      at: new Date(),
+    });
+    const linkId = unique("lnk");
+    const session = await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId,
+      oxyUserId,
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      expiresAt: new Date(Date.now() + 600_000),
+    });
+
+    const completed = await completeLinkSession(db, {
+      id: session.id,
+      currentStepId: "step-final",
+      resultAccountId: account.id,
+      at: new Date(),
+    });
+    expect(completed?.outcome).toBe("completed");
+    expect(completed?.resultAccountId).toBe(account.id);
+
+    await deleteAccount(db, account.id);
+
+    const survivor = await findLinkSessionForUser(db, { oxyUserId, linkId });
+    expect(survivor?.outcome).toBe("completed");
+    expect(survivor?.resultAccountId).toBeNull();
+  });
+
+  it("records a failure code beside a failed outcome", async () => {
+    const session = await insertLinkSession(db, {
+      id: uuidv7(),
+      linkId: unique("lnk"),
+      oxyUserId: unique("user"),
+      network: "telegram",
+      flowId: "phone",
+      remoteLoginProcessId: unique("proc"),
+      expiresAt: new Date(Date.now() + 600_000),
+    });
+    const closed = await closeLinkSession(db, {
+      id: session.id,
+      outcome: "failed",
+      failureCode: "FI.MAU.TELEGRAM.PHONE_CODE_INVALID",
+      at: new Date(),
+    });
+    expect(closed?.outcome).toBe("failed");
+    expect(closed?.failureCode).toBe("FI.MAU.TELEGRAM.PHONE_CODE_INVALID");
+  });
+});
+
+describe("bridge_proxy_leases — acquisition converges on the unique index", () => {
+  it("creates a lease, and reports that it did", async () => {
+    const oxyUserId = unique("user");
+    const { lease, created } = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode: "ES",
+      regionCode: "MD",
+      sessionSeed: "seed-one",
+      at: new Date(),
+    });
+    expect(created).toBe(true);
+    expect(lease.state).toBe("active");
+    expect(lease.countryCode).toBe("ES");
+  });
+
+  it("returns an existing lease UNTOUCHED, however different today's candidate is", async () => {
+    // §8.3 rules 2, 3 and 7 in one statement: `country_code`, `region_code` and
+    // `session_seed` are absent from the conflict branch, so no acquisition can
+    // move a user's geography or hand them a new session — not because the
+    // caller checked first, but because the SET list has nowhere to put it.
+    const oxyUserId = unique("user");
+    const first = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode: "ES",
+      regionCode: "MD",
+      sessionSeed: "seed-original",
+      at: new Date(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const second = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-b",
+      countryCode: "DE",
+      regionCode: "BE",
+      sessionSeed: "seed-replacement",
+      at: new Date(),
+    });
+
+    expect(second.created).toBe(false);
+    expect(second.lease.id).toBe(first.lease.id);
+    expect(second.lease.countryCode).toBe("ES");
+    expect(second.lease.regionCode).toBe("MD");
+    expect(second.lease.sessionSeed).toBe("seed-original");
+    expect(second.lease.provider).toBe("provider-a");
+    // A conflict branch that changed nothing must not claim it changed
+    // something: `updated_at` is guarded by the same predicate as the revival.
+    expect(second.lease.updatedAt.toISOString()).toBe(first.lease.updatedAt.toISOString());
+  });
+
+  it("does NOT quietly reactivate a quarantined lease", async () => {
+    // Quarantine is a decision about a geography we no longer trust. Undoing it
+    // on the next link attempt would connect from the country already judged
+    // wrong.
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "instagram",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "seed-q",
+      at: new Date(),
+    });
+    await recordLeaseExit(db, {
+      id: created.lease.id,
+      observedIp: "203.0.113.7",
+      observedCountry: "DE",
+      at: new Date(),
+      quarantine: true,
+    });
+
+    const reacquired = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "instagram",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "seed-new",
+      at: new Date(),
+    });
+    expect(reacquired.lease.state).toBe("quarantined");
+  });
+
+  it("revives a released lease in place, keeping its country and its seed", async () => {
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "messenger",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "seed-kept",
+      at: new Date(),
+    });
+    await db
+      .update(schema.bridgeProxyLeases)
+      .set({ state: "released", releasedAt: new Date() })
+      .where(eq(schema.bridgeProxyLeases.id, created.lease.id));
+
+    const revived = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "messenger",
+      provider: "provider-b",
+      countryCode: "DE",
+      sessionSeed: "seed-ignored",
+      at: new Date(),
+    });
+
+    expect(revived.created).toBe(false);
+    expect(revived.lease.state).toBe("active");
+    expect(revived.lease.releasedAt).toBeNull();
+    // Releasing is an operational act; it does not make the user's home country
+    // a different country.
+    expect(revived.lease.countryCode).toBe("ES");
+    expect(revived.lease.sessionSeed).toBe("seed-kept");
+  });
+
+  it("gives eight concurrent acquisitions one lease, without a retry anywhere", async () => {
+    const oxyUserId = unique("user");
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_unused, index) =>
+        acquireLease(db, {
+          id: uuidv7(),
+          oxyUserId,
+          network: "whatsapp",
+          provider: "provider-a",
+          countryCode: "ES",
+          sessionSeed: `seed-${String(index)}`,
+          at: new Date(),
+        }),
+      ),
+    );
+
+    const ids = new Set(results.map((result) => result.lease.id));
+    expect(ids.size).toBe(1);
+    expect(results.filter((result) => result.created)).toHaveLength(1);
+    // Every caller ends up on the winner's seed, so no lease is silently
+    // orphaned the way the Mongo race's loser was.
+    const seeds = new Set(results.map((result) => result.lease.sessionSeed));
+    expect(seeds.size).toBe(1);
+  });
+
+  /**
+   * Both halves of `^[A-Z]{2}$`, separately.
+   *
+   * `"esp"` alone is not enough, and finding that out cost a surviving
+   * mutation: it is wrong on BOTH axes at once, so a repository that
+   * "helpfully" upper-cased the input would still be refused (`"ESP"` is three
+   * letters) and the case-sensitivity of the constraint would go untested.
+   * `"es"` is wrong on the CASE axis only, which is the one input shape that
+   * tells a normalizing repository from one that stores what it was given.
+   */
+  it.each([
+    ["wrong length", "esp"],
+    ["wrong case", "es"],
+  ])("refuses a country code with the %s", async (_axis, countryCode) => {
+    const error = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId: unique("user"),
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode,
+      sessionSeed: "seed",
+      at: new Date(),
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).not.toBeNull();
+    expect(isCheckViolation(error)).toBe(true);
+    // Named, not matched on a message: drizzle wraps the driver error, so the
+    // constraint name lives on `cause` and a regex over the text would pass for
+    // the wrong constraint.
+    expect(constraintNameOf(error)).toBe("bridge_proxy_leases_country_code_check");
+  });
+});
+
+describe("bridge_proxy_leases — the egress identity never leaves in a read", () => {
+  it("never returns last_exit_ip, not even to the path that wrote it", async () => {
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "seed-ip",
+      at: new Date(),
+    });
+    const observed = await recordLeaseExit(db, {
+      id: created.lease.id,
+      observedIp: "198.51.100.9",
+      observedCountry: "ES",
+      at: new Date(),
+      quarantine: false,
+    });
+
+    const keys = Object.keys(observed ?? {});
+    expect(keys).toContain("lastExitCountry");
+    // The seed IS the one protected column this domain legitimately needs, and
+    // it is opted into by name in exactly one place.
+    expect(keys).toContain("sessionSeed");
+    expect(keys).not.toContain("lastExitIp");
+
+    // The row really was written; only the projection withholds it.
+    const stored = await client<{ last_exit_ip: string }[]>`
+      select last_exit_ip from bridge_proxy_leases where id = ${created.lease.id}
+    `;
+    expect(stored[0].last_exit_ip).toBe("198.51.100.9");
+    expect(observed?.lastExitCountry).toBe("ES");
+
+    const found = await findLease(db, { oxyUserId, network: "whatsapp" });
+    expect(Object.keys(found ?? {})).not.toContain("lastExitIp");
+  });
+});
+
+describe("bridge_proxy_lease_rotations — append-only evidence", () => {
+  it("appends a rotation and never replaces the history", async () => {
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode: "ES",
+      regionCode: "MD",
+      sessionSeed: "seed-0",
+      at: new Date(),
+    });
+
+    for (const [index, reason] of (
+      ["provider_retired", "ban_quarantine", "operator_forced"] as const
+    ).entries()) {
+      const rotated = await rotateLease(db, {
+        oxyUserId,
+        network: "whatsapp",
+        rotationId: uuidv7(),
+        toSeed: `seed-${String(index + 1)}`,
+        reason,
+        at: new Date(Date.now() + index * 1_000),
+      });
+      expect(rotated?.lease.sessionSeed).toBe(`seed-${String(index + 1)}`);
+      // Rotation is always WITHIN country (§8.3 rule 4).
+      expect(rotated?.lease.countryCode).toBe("ES");
+      expect(rotated?.lease.regionCode).toBe("MD");
+    }
+
+    const chain = await client<{ from_seed: string; to_seed: string; reason: string }[]>`
+      select from_seed, to_seed, reason from bridge_proxy_lease_rotations
+      where lease_id = ${created.lease.id} order by rotated_at
+    `;
+    // Three rows, not one overwritten three times — which is exactly what an
+    // embedded array could not guarantee.
+    expect(chain).toHaveLength(3);
+    expect(chain.map((row) => [row.from_seed, row.to_seed])).toEqual([
+      ["seed-0", "seed-1"],
+      ["seed-1", "seed-2"],
+      ["seed-2", "seed-3"],
+    ]);
+    expect(chain.map((row) => row.reason)).toEqual([
+      "provider_retired",
+      "ban_quarantine",
+      "operator_forced",
+    ]);
+  });
+
+  it("returns a lease to active, which is what makes rotation the remedy for a quarantine", async () => {
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "instagram",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "seed-q0",
+      at: new Date(),
+    });
+    await recordLeaseExit(db, {
+      id: created.lease.id,
+      observedIp: "203.0.113.1",
+      observedCountry: "DE",
+      at: new Date(),
+      quarantine: true,
+    });
+
+    const rotated = await rotateLease(db, {
+      oxyUserId,
+      network: "instagram",
+      rotationId: uuidv7(),
+      toSeed: "seed-q1",
+      reason: "ban_quarantine",
+      at: new Date(),
+    });
+    expect(rotated?.lease.state).toBe("active");
+  });
+
+  it("chains concurrent rotations instead of recording the same predecessor twice", async () => {
+    // The race the Mongo version had: `sessionSeed` was read in one query and
+    // pushed as `fromSeed` in another, so two rotations could both name the
+    // seed that only one of them replaced. `FOR UPDATE` in the same transaction
+    // as the swap is what orders them.
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "race-0",
+      at: new Date(),
+    });
+
+    await Promise.all([
+      rotateLease(db, {
+        oxyUserId,
+        network: "whatsapp",
+        rotationId: uuidv7(),
+        toSeed: "race-a",
+        reason: "operator_forced",
+        at: new Date(),
+      }),
+      rotateLease(db, {
+        oxyUserId,
+        network: "whatsapp",
+        rotationId: uuidv7(),
+        toSeed: "race-b",
+        reason: "operator_forced",
+        at: new Date(),
+      }),
+    ]);
+
+    const rows = await client<{ from_seed: string; to_seed: string }[]>`
+      select from_seed, to_seed from bridge_proxy_lease_rotations
+      where lease_id = ${created.lease.id}
+    `;
+    expect(rows).toHaveLength(2);
+    // Whichever order they landed in, the two must form a CHAIN: one starts at
+    // the original seed, and the other starts where that one ended. Two rows
+    // both reading `race-0` is the corruption this test exists to catch.
+    const first = rows.find((row) => row.from_seed === "race-0");
+    const second = rows.find((row) => row.from_seed !== "race-0");
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(second?.from_seed).toBe(first?.to_seed);
+  });
+
+  it("shows an operator WHEN and WHY, and never the seeds themselves", async () => {
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "messenger",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "ev-0",
+      at: new Date(),
+    });
+    await rotateLease(db, {
+      oxyUserId,
+      network: "messenger",
+      rotationId: uuidv7(),
+      toSeed: "ev-1",
+      reason: "provider_retired",
+      at: new Date(),
+    });
+
+    const evidence = await listLeaseRotations(db, created.lease.id);
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].reason).toBe("provider_retired");
+    const keys = Object.keys(evidence[0]);
+    expect(keys).toContain("rotatedAt");
+    expect(keys).not.toContain("fromSeed");
+    expect(keys).not.toContain("toSeed");
+  });
+
+  it("answers undefined when there is no lease to rotate", async () => {
+    const rotated = await rotateLease(db, {
+      oxyUserId: unique("user"),
+      network: "whatsapp",
+      rotationId: uuidv7(),
+      toSeed: "nothing",
+      reason: "operator_forced",
+      at: new Date(),
+    });
+    expect(rotated).toBeUndefined();
+  });
+
+  it("cascades the history when its lease is deleted", async () => {
+    const oxyUserId = unique("user");
+    const created = await acquireLease(db, {
+      id: uuidv7(),
+      oxyUserId,
+      network: "whatsapp",
+      provider: "provider-a",
+      countryCode: "ES",
+      sessionSeed: "cascade-0",
+      at: new Date(),
+    });
+    await rotateLease(db, {
+      oxyUserId,
+      network: "whatsapp",
+      rotationId: uuidv7(),
+      toSeed: "cascade-1",
+      reason: "operator_forced",
+      at: new Date(),
+    });
+    expect(await listLeaseRotations(db, created.lease.id)).toHaveLength(1);
+
+    await db
+      .delete(schema.bridgeProxyLeases)
+      .where(eq(schema.bridgeProxyLeases.id, created.lease.id));
+    expect(await listLeaseRotations(db, created.lease.id)).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/db/bridges/accounts.ts
+++ b/packages/backend/src/db/bridges/accounts.ts
@@ -1,0 +1,447 @@
+/**
+ * `bridge_accounts` — one remote account linked through one bridge.
+ *
+ * Ported from the `BridgeAccount` call sites in `services/bridges/*` and
+ * `routes/bridges*.ts`. Nothing imports this yet: the destination lands first so
+ * the switch is a diff in which call sites move and the repository does not
+ * change underneath them.
+ *
+ * ## Two Mongo idioms this replaces, and what each becomes
+ *
+ * `findOneAndUpdate(..., { upsert: true })` becomes `INSERT … ON CONFLICT`
+ * against the unique index the model already declared, so re-linking the same
+ * remote account converges on the constraint rather than on a service being
+ * careful. `$setOnInsert` becomes the ABSENCE of a column from the conflict
+ * branch's SET list — a stronger guarantee than the operator, because a column
+ * that is not there cannot be written.
+ *
+ * `$set` with a SPREAD of optional details is the one that does not translate
+ * literally, and it is a real port hazard: a key Mongo never receives is a key
+ * Mongo never writes, while `excluded.remote_name` is NULL for an absent value
+ * and would ERASE the name already on the row. Every optional detail therefore
+ * goes through {@link keepUnlessSupplied}. `bridges.realdb.test.ts` pins it,
+ * because the failure is silent and surfaces one `whoami` later.
+ *
+ * ## `raw_state_event` is recorded, never validated
+ *
+ * The column carries a CHECK nowhere (see `schema/CONVENTIONS.md`), and this
+ * module adds none. The bridge's vocabulary is the bridge's; refusing a value
+ * this deployment has not caught up with would drop precisely the status update
+ * that tells an operator something changed.
+ */
+
+import { and, asc, eq, notInArray, sql, type SQL } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
+import { publicColumns } from "@oxyhq/db/assert";
+import { qualified, sqlColumnName, type SelectedRow } from "@oxyhq/db";
+import type { BridgeNetworkId } from "../../config/bridges";
+import type { AlloDatabase } from "../index";
+import { PROTECTED_COLUMNS } from "../protectedColumns";
+import { bridgeAccounts, type BridgeAccountState } from "../schema/bridges";
+
+/**
+ * `bridge_accounts` protects no column today, and this still reads through the
+ * registry rather than `.select()`: a bare select returns whatever the table
+ * grows next, whereas this one starts withholding a column the moment somebody
+ * registers it.
+ */
+const ACCOUNT_COLUMNS = publicColumns(bridgeAccounts, PROTECTED_COLUMNS);
+
+export type BridgeAccountRow = SelectedRow<typeof ACCOUNT_COLUMNS>;
+
+/**
+ * `coalesce(excluded.<col>, bridge_accounts.<col>)` for a conflict branch.
+ *
+ * Both halves have to be spelled by the casing authority rather than by hand:
+ * `column.name` is the TypeScript property name, so `excluded.remoteName` would
+ * be a column Postgres has never heard of, and a bare interpolation of the
+ * table side renders unqualified — which inside `DO UPDATE SET` is ambiguous
+ * with `excluded`.
+ */
+function keepUnlessSupplied(column: PgColumn): SQL {
+  return sql`coalesce(excluded.${sql.identifier(sqlColumnName(column))}, ${qualified(column)})`;
+}
+
+/**
+ * The remote profile, flattened.
+ *
+ * The schema chose prefixed columns over `jsonb` because every field is read on
+ * its own, so the flattening happens at the edge of the domain — here — rather
+ * than in a mapper that would be a second shape to keep in step with the table.
+ * A caller that owes a client the nested `remoteProfile` object composes it in
+ * the serializer that already owns that contract.
+ */
+export interface BridgeAccountDetails {
+  readonly remoteName?: string;
+  readonly spaceRoomId?: string;
+  readonly remoteProfileName?: string;
+  readonly remoteProfileUsername?: string;
+  readonly remoteProfilePhone?: string;
+  readonly remoteProfileAvatarUrl?: string;
+}
+
+export interface UpsertLinkedAccountInput extends BridgeAccountDetails {
+  readonly id: string;
+  readonly oxyUserId: string;
+  readonly network: BridgeNetworkId;
+  readonly remoteLoginId: string;
+  readonly at: Date;
+}
+
+/**
+ * Record a completed login, converging on `(oxy_user_id, network, remote_login_id)`.
+ *
+ * `linkedAt` is absent from the conflict branch on purpose: it is when this user
+ * FIRST linked this remote account, and a re-link is not a new one. `id` is
+ * likewise never overwritten, so the caller's freshly minted id is discarded by
+ * the database when the row already exists — which is what makes two concurrent
+ * completions of one login produce one account rather than a duplicate-key error
+ * somebody has to catch.
+ */
+export async function upsertLinkedAccount(
+  db: AlloDatabase,
+  input: UpsertLinkedAccountInput,
+): Promise<BridgeAccountRow> {
+  const rows = await db
+    .insert(bridgeAccounts)
+    .values({
+      id: input.id,
+      oxyUserId: input.oxyUserId,
+      network: input.network,
+      remoteLoginId: input.remoteLoginId,
+      state: "connecting",
+      linkedAt: input.at,
+      lastStateAt: input.at,
+      ...detailValues(input),
+    })
+    .onConflictDoUpdate({
+      target: [
+        bridgeAccounts.oxyUserId,
+        bridgeAccounts.network,
+        bridgeAccounts.remoteLoginId,
+      ],
+      set: {
+        state: "connecting",
+        lastStateAt: input.at,
+        updatedAt: input.at,
+        remoteName: keepUnlessSupplied(bridgeAccounts.remoteName),
+        spaceRoomId: keepUnlessSupplied(bridgeAccounts.spaceRoomId),
+        remoteProfileName: keepUnlessSupplied(bridgeAccounts.remoteProfileName),
+        remoteProfileUsername: keepUnlessSupplied(bridgeAccounts.remoteProfileUsername),
+        remoteProfilePhone: keepUnlessSupplied(bridgeAccounts.remoteProfilePhone),
+        remoteProfileAvatarUrl: keepUnlessSupplied(bridgeAccounts.remoteProfileAvatarUrl),
+      },
+    })
+    .returning(ACCOUNT_COLUMNS);
+
+  const account = rows[0];
+  if (!account) throw new Error("bridge account upsert returned no row");
+  return account;
+}
+
+export interface ReportedStateInput extends BridgeAccountDetails {
+  readonly id: string;
+  readonly state: BridgeAccountState;
+  readonly at: Date;
+  /** The bridge's own word for its state, stored verbatim and never checked. */
+  readonly rawStateEvent: string;
+  readonly rawStateError?: string;
+  readonly rawStateMessage?: string;
+  readonly rawStateReason?: string;
+  readonly rawStateTtl?: number;
+}
+
+/**
+ * Apply one reported state to the account it is about.
+ *
+ * The five `raw_state_*` columns are written TOGETHER, absent ones as NULL,
+ * because Mongo's `$set: { rawState: {…} }` replaced the whole subdocument — a
+ * report that carries no `error` means there is no longer an error, not that the
+ * previous one still stands. This is the opposite of the detail columns above,
+ * and the difference is the source model's, not a choice made here.
+ *
+ * Reaching `connected` clears the notification marker and stamps
+ * `last_connected_at`. Both writers of this row do exactly that today, in two
+ * places, and the rule belongs to the row rather than to whoever is writing it:
+ * a third writer that forgot would leave a user who reconnects and is later
+ * logged out again permanently un-notifiable, which nothing would report.
+ */
+export async function applyReportedState(
+  db: AlloDatabase,
+  input: ReportedStateInput,
+): Promise<BridgeAccountRow | undefined> {
+  const rows = await db
+    .update(bridgeAccounts)
+    .set({
+      state: input.state,
+      lastStateAt: input.at,
+      rawStateEvent: input.rawStateEvent,
+      rawStateError: input.rawStateError ?? null,
+      rawStateMessage: input.rawStateMessage ?? null,
+      rawStateReason: input.rawStateReason ?? null,
+      rawStateTtl: input.rawStateTtl ?? null,
+      rawStateAt: input.at,
+      ...detailValues(input),
+      ...connectedTransition(input.state, input.at),
+    })
+    .where(eq(bridgeAccounts.id, input.id))
+    .returning(ACCOUNT_COLUMNS);
+  return rows[0];
+}
+
+export interface ReconcileAccountInput {
+  readonly id: string;
+  readonly state: BridgeAccountState;
+  readonly at: Date;
+  readonly remoteName?: string;
+  readonly spaceRoomId?: string;
+}
+
+/**
+ * Reconcile an account from `whoami` — the reconnect route, and what §5.4
+ * prescribes for an account that has gone quiet.
+ *
+ * Distinct from {@link applyReportedState} because it carries no reported state:
+ * `whoami` answers what the bridge BELIEVES, not what it last announced, so
+ * writing `raw_state_*` here would invent a report no bridge sent. The
+ * `connected` transition is shared, for the reason stated there.
+ */
+export async function reconcileAccount(
+  db: AlloDatabase,
+  input: ReconcileAccountInput,
+): Promise<BridgeAccountRow | undefined> {
+  const rows = await db
+    .update(bridgeAccounts)
+    .set({
+      state: input.state,
+      lastStateAt: input.at,
+      ...detailValues(input),
+      ...connectedTransition(input.state, input.at),
+    })
+    .where(eq(bridgeAccounts.id, input.id))
+    .returning(ACCOUNT_COLUMNS);
+  return rows[0];
+}
+
+/** Records that the user has been told about `state`, so a re-send does not tell them again. */
+export async function markAccountNotified(
+  db: AlloDatabase,
+  input: { readonly id: string; readonly state: BridgeAccountState; readonly at: Date },
+): Promise<void> {
+  await db
+    .update(bridgeAccounts)
+    .set({ lastNotifiedState: input.state, lastNotifiedAt: input.at, updatedAt: input.at })
+    .where(eq(bridgeAccounts.id, input.id));
+}
+
+export interface StaleAccountSweepInput {
+  readonly now: Date;
+  /** How far past a state's own TTL a bridge may go silent (§5.4). */
+  readonly marginSeconds: number;
+  /** The TTL to assume for an account whose last report carried none. */
+  readonly defaultTtlSeconds: number;
+}
+
+/**
+ * Mark as `failed` every account whose last state outlived its OWN TTL.
+ *
+ * Mongo needed an `$expr` aggregation to compare a stored field against a
+ * computed deadline; in SQL it is the predicate it always was. The comparison
+ * stays per-account rather than against one global age because the TTL is
+ * per-state — one hour when the bridge reported an error, six when it did not —
+ * and a single fixed age would either declare healthy accounts dead or let
+ * broken ones sit green for hours.
+ *
+ * Both thresholds are the CALLER's: the margin is configuration and the default
+ * TTL is the bridge's own healthy default, and neither is a fact about the
+ * table. `linking` is excluded because an attempt in progress has no reported
+ * state yet and its own expiry governs it; `failed` is excluded so the sweep
+ * does not keep rewriting `last_state_at` on accounts it already marked.
+ */
+export async function markStaleAccountsFailed(
+  db: AlloDatabase,
+  input: StaleAccountSweepInput,
+): Promise<number> {
+  const rows = await db
+    .update(bridgeAccounts)
+    .set({
+      state: "failed",
+      rawStateReason: "stale",
+      lastStateAt: input.now,
+      updatedAt: input.now,
+    })
+    .where(
+      and(
+        notInArray(bridgeAccounts.state, ["failed", "linking"]),
+        // The deadline is bound as an ISO string with an explicit cast, NOT as a
+        // `Date`: inside a raw `sql` template there is no column to encode it,
+        // and postgres.js's bind path throws `ERR_INVALID_ARG_TYPE` on the
+        // object. A runtime failure `tsc` cannot see.
+        sql`${bridgeAccounts.lastStateAt} + ((coalesce(${bridgeAccounts.rawStateTtl}, ${input.defaultTtlSeconds}::int) + ${input.marginSeconds}::int) * interval '1 second') < ${input.now.toISOString()}::timestamptz`,
+      ),
+    )
+    .returning({ id: bridgeAccounts.id });
+  return rows.length;
+}
+
+export async function countAccounts(
+  db: AlloDatabase,
+  input: { readonly oxyUserId: string; readonly network: BridgeNetworkId },
+): Promise<number> {
+  const rows = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(bridgeAccounts)
+    .where(
+      and(
+        eq(bridgeAccounts.oxyUserId, input.oxyUserId),
+        eq(bridgeAccounts.network, input.network),
+      ),
+    );
+  return rows[0]?.total ?? 0;
+}
+
+/** This user's linked accounts, oldest link first — and nobody else's. */
+export async function listAccountsForUser(
+  db: AlloDatabase,
+  oxyUserId: string,
+): Promise<BridgeAccountRow[]> {
+  return await db
+    .select(ACCOUNT_COLUMNS)
+    .from(bridgeAccounts)
+    .where(eq(bridgeAccounts.oxyUserId, oxyUserId))
+    .orderBy(asc(bridgeAccounts.linkedAt));
+}
+
+/**
+ * One account, scoped by `oxyUserId`.
+ *
+ * The scoping is the point rather than a convenience: §5.1's rule is that an
+ * identifier alone is never enough, so there is deliberately no `findAccount(id)`
+ * for a route to reach for.
+ */
+export async function findAccountForUser(
+  db: AlloDatabase,
+  input: { readonly oxyUserId: string; readonly id: string },
+): Promise<BridgeAccountRow | undefined> {
+  const rows = await db
+    .select(ACCOUNT_COLUMNS)
+    .from(bridgeAccounts)
+    .where(
+      and(eq(bridgeAccounts.oxyUserId, input.oxyUserId), eq(bridgeAccounts.id, input.id)),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+/** The status webhook's preferred lookup: the report named the Matrix user. */
+export async function findAccountByRemoteLogin(
+  db: AlloDatabase,
+  input: {
+    readonly oxyUserId: string;
+    readonly network: BridgeNetworkId;
+    readonly remoteLoginId: string;
+  },
+): Promise<BridgeAccountRow | undefined> {
+  const rows = await db
+    .select(ACCOUNT_COLUMNS)
+    .from(bridgeAccounts)
+    .where(
+      and(
+        eq(bridgeAccounts.oxyUserId, input.oxyUserId),
+        eq(bridgeAccounts.network, input.network),
+        eq(bridgeAccounts.remoteLoginId, input.remoteLoginId),
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+/**
+ * The status webhook's fallback, when the bridge's report carries no `user_id`.
+ *
+ * Served by `bridge_accounts_network_remote_login_id_idx`, which exists because
+ * the unique index starts with `oxy_user_id` and therefore cannot answer this —
+ * a sequential scan on the hot path of every state change every bridge reports.
+ */
+export async function findAccountByNetworkRemoteLogin(
+  db: AlloDatabase,
+  input: { readonly network: BridgeNetworkId; readonly remoteLoginId: string },
+): Promise<BridgeAccountRow | undefined> {
+  const rows = await db
+    .select(ACCOUNT_COLUMNS)
+    .from(bridgeAccounts)
+    .where(
+      and(
+        eq(bridgeAccounts.network, input.network),
+        eq(bridgeAccounts.remoteLoginId, input.remoteLoginId),
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+export interface SlotOwner {
+  readonly oxyUserId: string;
+  readonly network: BridgeNetworkId;
+}
+
+/**
+ * Who a dedicated appservice slot belongs to.
+ *
+ * Two columns, named, because this runs on the bridge's connect path where a
+ * slow or failed answer fails the connection outright — and because the caller
+ * needs nothing else in order to find the lease. The `slot_id` index is partial,
+ * matching Mongo's `sparse`, so it holds only the rows that could ever match.
+ */
+export async function findSlotOwner(
+  db: AlloDatabase,
+  slotId: string,
+): Promise<SlotOwner | undefined> {
+  const rows = await db
+    .select({ oxyUserId: bridgeAccounts.oxyUserId, network: bridgeAccounts.network })
+    .from(bridgeAccounts)
+    .where(eq(bridgeAccounts.slotId, slotId))
+    .limit(1);
+  return rows[0];
+}
+
+/**
+ * Unlink.
+ *
+ * The proxy lease is deliberately untouched (§8.3 rule 3), which is why nothing
+ * here reaches into `bridge_proxy_leases`: coming back to a network has to mean
+ * coming back through the same geography.
+ */
+export async function deleteAccount(db: AlloDatabase, id: string): Promise<boolean> {
+  const rows = await db
+    .delete(bridgeAccounts)
+    .where(eq(bridgeAccounts.id, id))
+    .returning({ id: bridgeAccounts.id });
+  return rows.length > 0;
+}
+
+/** Only the details the caller actually supplied, so an absent one is never written. */
+function detailValues(details: BridgeAccountDetails) {
+  return {
+    ...(details.remoteName === undefined ? {} : { remoteName: details.remoteName }),
+    ...(details.spaceRoomId === undefined ? {} : { spaceRoomId: details.spaceRoomId }),
+    ...(details.remoteProfileName === undefined
+      ? {}
+      : { remoteProfileName: details.remoteProfileName }),
+    ...(details.remoteProfileUsername === undefined
+      ? {}
+      : { remoteProfileUsername: details.remoteProfileUsername }),
+    ...(details.remoteProfilePhone === undefined
+      ? {}
+      : { remoteProfilePhone: details.remoteProfilePhone }),
+    ...(details.remoteProfileAvatarUrl === undefined
+      ? {}
+      : { remoteProfileAvatarUrl: details.remoteProfileAvatarUrl }),
+  };
+}
+
+/** What reaching `connected` does to the row, wherever the state came from. */
+function connectedTransition(state: BridgeAccountState, at: Date) {
+  if (state !== "connected") return {};
+  return { lastConnectedAt: at, lastNotifiedState: null, lastNotifiedAt: null };
+}

--- a/packages/backend/src/db/bridges/linkSessions.ts
+++ b/packages/backend/src/db/bridges/linkSessions.ts
@@ -1,0 +1,276 @@
+/**
+ * `bridge_link_sessions` — one login attempt in progress.
+ *
+ * Ported from the `BridgeLinkSession` call sites in `services/bridges/
+ * BridgeLinkService.ts` and `routes/bridges.ts`. Nothing imports it yet.
+ *
+ * ## The sweep is retention; expiry is a QUERY's business
+ *
+ * Mongo reaped these rows with a TTL index, and `src/db/expiry.ts` reproduces
+ * that. Neither reaps promptly: Mongo's TTL monitor runs on an interval and the
+ * sweep runs when its caller runs it, so an attempt past `expires_at` is
+ * readable for a while afterwards under both. A read that assumed otherwise
+ * would be wrong on both databases — it just happens to be a port that makes
+ * somebody think about it. There is deliberately no deletion path here; the
+ * registry owns that, and a second one would race it.
+ *
+ * The two reads below therefore differ ON PURPOSE, and the difference is the
+ * whole reason they are two functions:
+ *
+ * - {@link findLinkSessionForUser} answers "WHICH attempt is this?" and does not
+ *   filter, so the caller can tell an expired attempt (410) from one that never
+ *   existed (404). Filtering here would collapse those into "no such attempt",
+ *   which is exactly the distinction the `expired` outcome exists to preserve.
+ * - {@link findOpenLinkSessions} answers "does this user have an attempt OPEN?"
+ *   and filters on both `outcome` and `expires_at`, because a `pending` row past
+ *   its deadline is not open — the remote login process behind it is gone.
+ *
+ * ## Nothing the user typed is ever written here
+ *
+ * Not the phone number, not the six-digit code, not the 2FA password: the model
+ * this is ported from holds the SHAPE of the conversation and no answer in it,
+ * and no function below takes one.
+ */
+
+import { and, asc, eq, gt } from "drizzle-orm";
+import { publicColumns } from "@oxyhq/db/assert";
+import type { SelectedRow } from "@oxyhq/db";
+import type { BridgeNetworkId } from "../../config/bridges";
+import type { AlloDatabase } from "../index";
+import { PROTECTED_COLUMNS } from "../protectedColumns";
+import {
+  bridgeLinkSessions,
+  type BridgeLinkOutcome,
+  type BridgeLoginStepType,
+} from "../schema/bridges";
+
+/**
+ * Everything a caller may see. `remote_login_process_id` and `current_step_id`
+ * are withheld — possession of either lets a caller drive somebody else's
+ * half-finished linking flow.
+ */
+const SESSION_PUBLIC_COLUMNS = publicColumns(bridgeLinkSessions, PROTECTED_COLUMNS);
+
+/**
+ * The public columns PLUS the two protected handles, named here so the opt-in is
+ * greppable rather than implicit.
+ *
+ * Relaying the next answer to the bridge is impossible without both, so this is
+ * a legitimate need and not a shortcut — but it is also the ONLY one, which is
+ * why the columns are added in exactly one place and why the row this produces
+ * must never be handed to a serializer.
+ */
+const SESSION_RELAY_COLUMNS = {
+  ...SESSION_PUBLIC_COLUMNS,
+  remoteLoginProcessId: bridgeLinkSessions.remoteLoginProcessId,
+  currentStepId: bridgeLinkSessions.currentStepId,
+};
+
+export type BridgeLinkSessionRow = SelectedRow<typeof SESSION_PUBLIC_COLUMNS>;
+
+/** Carries the bridge's login-process handle. Internal only — see above. */
+export type BridgeLinkSessionRelayRow = SelectedRow<typeof SESSION_RELAY_COLUMNS>;
+
+export interface InsertLinkSessionInput {
+  readonly id: string;
+  /** Opaque and unguessable. The only identifier a client ever sees. */
+  readonly linkId: string;
+  readonly oxyUserId: string;
+  readonly network: BridgeNetworkId;
+  readonly flowId: string;
+  readonly slotId?: string;
+  readonly remoteLoginProcessId: string;
+  readonly currentStepId?: string;
+  readonly currentStepType?: BridgeLoginStepType;
+  readonly expiresAt: Date;
+}
+
+/**
+ * Open an attempt.
+ *
+ * A plain insert with no conflict handling: `link_id` is unique, and a collision
+ * on it would mean the caller's randomness failed. That must surface as the
+ * unique violation it is rather than silently converge on somebody else's
+ * attempt.
+ */
+export async function insertLinkSession(
+  db: AlloDatabase,
+  input: InsertLinkSessionInput,
+): Promise<BridgeLinkSessionRelayRow> {
+  const rows = await db
+    .insert(bridgeLinkSessions)
+    .values({
+      id: input.id,
+      linkId: input.linkId,
+      oxyUserId: input.oxyUserId,
+      network: input.network,
+      flowId: input.flowId,
+      ...(input.slotId === undefined ? {} : { slotId: input.slotId }),
+      remoteLoginProcessId: input.remoteLoginProcessId,
+      ...(input.currentStepId === undefined ? {} : { currentStepId: input.currentStepId }),
+      ...(input.currentStepType === undefined
+        ? {}
+        : { currentStepType: input.currentStepType }),
+      expiresAt: input.expiresAt,
+      outcome: "pending",
+    })
+    .returning(SESSION_RELAY_COLUMNS);
+
+  const session = rows[0];
+  if (!session) throw new Error("bridge link session insert returned no row");
+  return session;
+}
+
+/**
+ * One attempt, scoped by `oxyUserId` — the link id alone is never enough (§5.1).
+ *
+ * Deliberately UNFILTERED by `expires_at`: the caller has to be able to answer
+ * "this attempt expired" rather than "no such attempt", and it is the caller
+ * that owns that distinction because it also owns the status code. Every caller
+ * must check `expiresAt` against its own clock; the row carries it for exactly
+ * that purpose.
+ *
+ * Returns the relay row, because the one thing a caller does with an attempt is
+ * relay the next answer to the bridge.
+ */
+export async function findLinkSessionForUser(
+  db: AlloDatabase,
+  input: { readonly oxyUserId: string; readonly linkId: string },
+): Promise<BridgeLinkSessionRelayRow | undefined> {
+  if (input.linkId.length === 0) return undefined;
+  const rows = await db
+    .select(SESSION_RELAY_COLUMNS)
+    .from(bridgeLinkSessions)
+    .where(
+      and(
+        eq(bridgeLinkSessions.oxyUserId, input.oxyUserId),
+        eq(bridgeLinkSessions.linkId, input.linkId),
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+/**
+ * The attempts this user still has open on a network, oldest first.
+ *
+ * The question `bridge_link_sessions_oxy_user_id_network_outcome_idx` exists to
+ * serve, and the read where a lagging sweep would change the ANSWER rather than
+ * merely the row count — so `expires_at` is part of the predicate and not left
+ * to the reaper. Public columns only: knowing an attempt is open needs no
+ * ability to drive it.
+ */
+export async function findOpenLinkSessions(
+  db: AlloDatabase,
+  input: {
+    readonly oxyUserId: string;
+    readonly network: BridgeNetworkId;
+    readonly now: Date;
+  },
+): Promise<BridgeLinkSessionRow[]> {
+  return await db
+    .select(SESSION_PUBLIC_COLUMNS)
+    .from(bridgeLinkSessions)
+    .where(
+      and(
+        eq(bridgeLinkSessions.oxyUserId, input.oxyUserId),
+        eq(bridgeLinkSessions.network, input.network),
+        eq(bridgeLinkSessions.outcome, "pending"),
+        gt(bridgeLinkSessions.expiresAt, input.now),
+      ),
+    )
+    .orderBy(asc(bridgeLinkSessions.createdAt));
+}
+
+/**
+ * Move an attempt on to its next step, with the deadline that step earns.
+ *
+ * `expiresAt` is required rather than optional because every step recomputes it:
+ * a `display_and_wait` step lives about as long as the code inside it, and
+ * carrying the previous step's deadline forward is how a session comes to claim
+ * it outlives a QR that already refreshed.
+ */
+export async function recordLinkSessionStep(
+  db: AlloDatabase,
+  input: {
+    readonly id: string;
+    readonly currentStepId: string;
+    readonly currentStepType: BridgeLoginStepType;
+    readonly expiresAt: Date;
+    readonly at: Date;
+  },
+): Promise<BridgeLinkSessionRow | undefined> {
+  const rows = await db
+    .update(bridgeLinkSessions)
+    .set({
+      currentStepId: input.currentStepId,
+      currentStepType: input.currentStepType,
+      expiresAt: input.expiresAt,
+      updatedAt: input.at,
+    })
+    .where(eq(bridgeLinkSessions.id, input.id))
+    .returning(SESSION_PUBLIC_COLUMNS);
+  return rows[0];
+}
+
+/**
+ * Close an attempt as completed, naming the account it produced.
+ *
+ * `resultAccountId` is a real foreign key here where Mongo had a bare
+ * `ObjectId` nothing checked, so the account must already exist — which it does:
+ * the login is recorded before the session is closed. `ON DELETE SET NULL` is
+ * what lets the session outlive an unlink, as a record of an ATTEMPT, without
+ * pointing at an account that is gone.
+ */
+export async function completeLinkSession(
+  db: AlloDatabase,
+  input: {
+    readonly id: string;
+    readonly currentStepId: string;
+    readonly resultAccountId: string;
+    readonly at: Date;
+  },
+): Promise<BridgeLinkSessionRow | undefined> {
+  const rows = await db
+    .update(bridgeLinkSessions)
+    .set({
+      currentStepId: input.currentStepId,
+      currentStepType: "complete",
+      outcome: "completed",
+      resultAccountId: input.resultAccountId,
+      updatedAt: input.at,
+    })
+    .where(eq(bridgeLinkSessions.id, input.id))
+    .returning(SESSION_PUBLIC_COLUMNS);
+  return rows[0];
+}
+
+/**
+ * Close an attempt that did not complete.
+ *
+ * One function for `cancelled`, `expired` and `failed` because they differ only
+ * in which of them happened; `completed` is separate because it alone carries an
+ * account. `failureCode` is the bridge's own error code and never user input —
+ * it is optional rather than absent so that `failed`, which the outcome tuple
+ * already admits, is reachable at all.
+ */
+export async function closeLinkSession(
+  db: AlloDatabase,
+  input: {
+    readonly id: string;
+    readonly outcome: Exclude<BridgeLinkOutcome, "pending" | "completed">;
+    readonly failureCode?: string;
+    readonly at: Date;
+  },
+): Promise<BridgeLinkSessionRow | undefined> {
+  const rows = await db
+    .update(bridgeLinkSessions)
+    .set({
+      outcome: input.outcome,
+      ...(input.failureCode === undefined ? {} : { failureCode: input.failureCode }),
+      updatedAt: input.at,
+    })
+    .where(eq(bridgeLinkSessions.id, input.id))
+    .returning(SESSION_PUBLIC_COLUMNS);
+  return rows[0];
+}

--- a/packages/backend/src/db/bridges/proxyLeases.ts
+++ b/packages/backend/src/db/bridges/proxyLeases.ts
@@ -1,0 +1,317 @@
+/**
+ * `bridge_proxy_leases` and `bridge_proxy_lease_rotations` — a user's exit
+ * geography on one network, and the history of every time it moved.
+ *
+ * Ported from the `BridgeProxyLease` call sites in
+ * `services/bridges/proxy/ProxyLeaseService.ts`. Nothing imports it yet.
+ *
+ * ## Acquisition converges on the constraint
+ *
+ * `UNIQUE(oxy_user_id, network)` is what makes §8.3 rule 7 — a lease is never
+ * shared between users — true, and Mongo could only USE it by racing into it:
+ * read, create, catch the duplicate, read again. {@link acquireLease} is one
+ * `INSERT … ON CONFLICT DO UPDATE … RETURNING`, so the loser of a race is
+ * handed the winner's row by the database rather than by a retry that has to be
+ * remembered. There is no read-then-write anywhere in this module's write path.
+ *
+ * The conflict branch's SET list is the interesting part, and what it does NOT
+ * contain is the point: `country_code`, `region_code` and `session_seed` are
+ * absent, so §8.3 rule 2 (the country is frozen at creation and never
+ * recalculated) and rule 3 (unlinking does not release the lease, so re-linking
+ * returns to the same geography) are properties of the statement rather than of
+ * a caller checking first. A `released` lease is REVIVED in place, keeping both
+ * — releasing is an operational act and does not make the user's home country a
+ * different country.
+ *
+ * ## The rotation history is append-only, and that is why it is a table
+ *
+ * `rotations[]` was an embedded array, which is what an array is worst at:
+ * nothing stops a write replacing the whole thing and erasing the evidence it
+ * exists to keep. {@link rotateLease} only ever INSERTs a row, and no function
+ * here updates or deletes one. It also closes a race the Mongo version had —
+ * reading `sessionSeed` in one query and pushing it as `fromSeed` in another
+ * let two concurrent rotations record the same predecessor — by taking the row
+ * lock and reading the seed under it, in one transaction with the swap.
+ *
+ * ## Two protected columns, and only one of them is reachable
+ *
+ * `session_seed` and `last_exit_ip` are the egress identity. The seed is
+ * genuinely needed — a proxy URL cannot be composed without it — so it is named
+ * explicitly, in one place. `last_exit_ip` is only ever WRITTEN, so no read here
+ * returns it, and the rotation reads withhold both seeds.
+ */
+
+import { and, asc, eq, sql } from "drizzle-orm";
+import { publicColumns } from "@oxyhq/db/assert";
+import type { SelectedRow } from "@oxyhq/db";
+import type { BridgeNetworkId } from "../../config/bridges";
+import type { AlloDatabase } from "../index";
+import { PROTECTED_COLUMNS } from "../protectedColumns";
+import {
+  bridgeProxyLeaseRotations,
+  bridgeProxyLeases,
+  type BridgeProxyRotationReason,
+} from "../schema/bridges";
+
+/**
+ * The lease as the proxy allocator needs it: every public column plus
+ * `session_seed`, which the provider's sticky session is keyed on and without
+ * which no URL can be composed.
+ *
+ * `last_exit_ip` stays withheld. It is written by {@link recordLeaseExit} and
+ * read by nothing, which is the right shape for a value that ties a user to a
+ * network location — so this row cannot leak one however it is serialized.
+ */
+const LEASE_COLUMNS = {
+  ...publicColumns(bridgeProxyLeases, PROTECTED_COLUMNS),
+  sessionSeed: bridgeProxyLeases.sessionSeed,
+};
+
+/** Rotation evidence WITHOUT the seeds: when the exit identity changed, and why. */
+const ROTATION_COLUMNS = publicColumns(bridgeProxyLeaseRotations, PROTECTED_COLUMNS);
+
+export type BridgeProxyLeaseRow = SelectedRow<typeof LEASE_COLUMNS>;
+export type BridgeProxyLeaseRotationRow = SelectedRow<typeof ROTATION_COLUMNS>;
+
+export interface AcquireLeaseInput {
+  /** Used only if the lease does not exist yet; discarded by the database if it does. */
+  readonly id: string;
+  readonly oxyUserId: string;
+  readonly network: BridgeNetworkId;
+  /** The provider's identifier — never the vendor's brand name (§8.2). */
+  readonly provider: string;
+  /** ISO 3166-1 alpha-2, and CHECK-enforced as such. */
+  readonly countryCode: string;
+  readonly regionCode?: string;
+  /** Random, unguessable, 128 bits. Only reaches the row on a genuine create. */
+  readonly sessionSeed: string;
+  readonly at: Date;
+}
+
+export interface AcquiredLease {
+  readonly lease: BridgeProxyLeaseRow;
+  /**
+   * Whether this call is the one that created the row.
+   *
+   * `false` covers both "somebody else got there first" and "it has existed for
+   * months", which is correct: the caller wanted a lease and there is exactly
+   * one. It exists so the create can be LOGGED once rather than on every link
+   * attempt, not so a caller can branch on it.
+   */
+  readonly created: boolean;
+}
+
+/**
+ * The lease for this (user, network), creating it if there is none.
+ *
+ * One statement, always. The three outcomes it produces:
+ *
+ * - no row  → the caller's country and seed are stored, `state` is `active`;
+ * - `released` row → revived to `active` with `released_at` cleared, keeping the
+ *   country and the seed it already had;
+ * - any other row → returned exactly as it stands, including a `quarantined`
+ *   one. Quarantine is a decision about a lease we no longer trust, and an
+ *   acquisition must not quietly undo it.
+ *
+ * The conflict branch runs even when it changes nothing, which costs one dead
+ * tuple per acquisition on the common path. That is the price of a single
+ * statement that always RETURNS the row; `DO UPDATE … WHERE` would return
+ * nothing on that same common path and force a follow-up SELECT — the
+ * read-then-write this exists to avoid. `updated_at` is guarded by the same
+ * predicate as the revival, so a no-op acquisition leaves it where it was.
+ */
+export async function acquireLease(
+  db: AlloDatabase,
+  input: AcquireLeaseInput,
+): Promise<AcquiredLease> {
+  const wasReleased = sql`${bridgeProxyLeases.state} = 'released'`;
+  /**
+   * Bound as an ISO string with an explicit cast, NOT as a `Date`.
+   *
+   * A `Date` handed to `.set({ updatedAt })` is encoded by the column's own
+   * driver mapper; the same `Date` interpolated into a raw `sql` template has no
+   * column to be mapped by, and postgres.js's bind path then throws
+   * `ERR_INVALID_ARG_TYPE: … Received an instance of Date`. Measured against a
+   * real server — it is a runtime failure `tsc` cannot see, and it is invisible
+   * in any test whose writes go through plain column values.
+   */
+  const at = sql`${input.at.toISOString()}::timestamptz`;
+  const rows = await db
+    .insert(bridgeProxyLeases)
+    .values({
+      id: input.id,
+      oxyUserId: input.oxyUserId,
+      network: input.network,
+      provider: input.provider,
+      countryCode: input.countryCode,
+      ...(input.regionCode === undefined ? {} : { regionCode: input.regionCode }),
+      sessionSeed: input.sessionSeed,
+      state: "active",
+    })
+    .onConflictDoUpdate({
+      target: [bridgeProxyLeases.oxyUserId, bridgeProxyLeases.network],
+      set: {
+        state: sql`case when ${wasReleased} then 'active' else ${bridgeProxyLeases.state} end`,
+        releasedAt: sql`case when ${wasReleased} then null else ${bridgeProxyLeases.releasedAt} end`,
+        updatedAt: sql`case when ${wasReleased} then ${at} else ${bridgeProxyLeases.updatedAt} end`,
+      },
+    })
+    .returning(LEASE_COLUMNS);
+
+  const lease = rows[0];
+  if (!lease) throw new Error("bridge proxy lease acquisition returned no row");
+  return { lease, created: lease.id === input.id };
+}
+
+/** The lease for this (user, network), or nothing. Never creates one. */
+export async function findLease(
+  db: AlloDatabase,
+  input: { readonly oxyUserId: string; readonly network: BridgeNetworkId },
+): Promise<BridgeProxyLeaseRow | undefined> {
+  const rows = await db
+    .select(LEASE_COLUMNS)
+    .from(bridgeProxyLeases)
+    .where(
+      and(
+        eq(bridgeProxyLeases.oxyUserId, input.oxyUserId),
+        eq(bridgeProxyLeases.network, input.network),
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+export interface RecordLeaseExitInput {
+  readonly id: string;
+  readonly observedIp: string;
+  /** Uppercased by the caller, so it can be compared against `country_code` by eye. */
+  readonly observedCountry: string;
+  readonly at: Date;
+  /**
+   * `true` records the observation AND moves the lease to `quarantined` — the
+   * mismatch path (§8.3 rule 5). Quarantining rather than rotating is
+   * deliberate: an exit from an unexpected country is evidence that the
+   * provider's configuration is not what we think it is, and silently taking a
+   * new session from the same provider would paper over exactly that fault.
+   */
+  readonly quarantine: boolean;
+}
+
+/**
+ * Record where the proxy actually came out.
+ *
+ * The observation is stored on BOTH paths, including the mismatch, because the
+ * country that was not expected is the one worth having on the row during an
+ * incident.
+ */
+export async function recordLeaseExit(
+  db: AlloDatabase,
+  input: RecordLeaseExitInput,
+): Promise<BridgeProxyLeaseRow | undefined> {
+  const rows = await db
+    .update(bridgeProxyLeases)
+    .set({
+      lastExitIp: input.observedIp,
+      lastExitCountry: input.observedCountry,
+      lastVerifiedAt: input.at,
+      updatedAt: input.at,
+      ...(input.quarantine ? { state: "quarantined" as const } : {}),
+    })
+    .where(eq(bridgeProxyLeases.id, input.id))
+    .returning(LEASE_COLUMNS);
+  return rows[0];
+}
+
+export interface RotateLeaseInput {
+  readonly oxyUserId: string;
+  readonly network: BridgeNetworkId;
+  /** Id for the rotation row. Every rotation is a new row; none is ever reused. */
+  readonly rotationId: string;
+  readonly toSeed: string;
+  readonly reason: BridgeProxyRotationReason;
+  readonly at: Date;
+}
+
+export interface RotatedLease {
+  readonly lease: BridgeProxyLeaseRow;
+  readonly rotation: BridgeProxyLeaseRotationRow;
+}
+
+/**
+ * Move a lease to a new session within the SAME country (§8.3 rule 4).
+ *
+ * `country_code` and `region_code` are untouched by construction — they are not
+ * in the SET list, so a rotation cannot move a user's geography however it is
+ * called. The lease also returns to `active`, which is what makes rotation the
+ * remedy for a quarantine.
+ *
+ * The transaction is not decoration. `from_seed` must be the seed the row
+ * ACTUALLY held at the instant of the swap, so it is read under `FOR UPDATE` in
+ * the same transaction that writes the replacement; two concurrent rotations
+ * then serialize into a chain, each naming its true predecessor, instead of both
+ * recording the same one and leaving a gap in the evidence.
+ *
+ * `undefined` means there was no lease to rotate.
+ */
+export async function rotateLease(
+  db: AlloDatabase,
+  input: RotateLeaseInput,
+): Promise<RotatedLease | undefined> {
+  return await db.transaction(async (tx) => {
+    const locked = await tx
+      .select({ id: bridgeProxyLeases.id, sessionSeed: bridgeProxyLeases.sessionSeed })
+      .from(bridgeProxyLeases)
+      .where(
+        and(
+          eq(bridgeProxyLeases.oxyUserId, input.oxyUserId),
+          eq(bridgeProxyLeases.network, input.network),
+        ),
+      )
+      .limit(1)
+      .for("update");
+
+    const current = locked[0];
+    if (!current) return undefined;
+
+    const rotationRows = await tx
+      .insert(bridgeProxyLeaseRotations)
+      .values({
+        id: input.rotationId,
+        leaseId: current.id,
+        rotatedAt: input.at,
+        fromSeed: current.sessionSeed,
+        toSeed: input.toSeed,
+        reason: input.reason,
+      })
+      .returning(ROTATION_COLUMNS);
+
+    const leaseRows = await tx
+      .update(bridgeProxyLeases)
+      .set({ sessionSeed: input.toSeed, state: "active", updatedAt: input.at })
+      .where(eq(bridgeProxyLeases.id, current.id))
+      .returning(LEASE_COLUMNS);
+
+    const rotation = rotationRows[0];
+    const lease = leaseRows[0];
+    if (!rotation || !lease) throw new Error("bridge proxy lease rotation returned no row");
+    return { lease, rotation };
+  });
+}
+
+/**
+ * Every rotation this lease has ever had, oldest first — the record that gets
+ * read when somebody asks why this user's accounts keep being challenged.
+ *
+ * Without the seeds: what an operator needs is WHEN the exit identity changed
+ * and WHY, and the seeds are the identity itself.
+ */
+export async function listLeaseRotations(
+  db: AlloDatabase,
+  leaseId: string,
+): Promise<BridgeProxyLeaseRotationRow[]> {
+  return await db
+    .select(ROTATION_COLUMNS)
+    .from(bridgeProxyLeaseRotations)
+    .where(eq(bridgeProxyLeaseRotations.leaseId, leaseId))
+    .orderBy(asc(bridgeProxyLeaseRotations.rotatedAt));
+}


### PR DESCRIPTION
The Matrix bridge domain of the Mongo → Postgres port: repositories for
`bridge_accounts`, `bridge_link_sessions`, `bridge_proxy_leases` and
`bridge_proxy_lease_rotations`, derived from the call sites in
`services/bridges/**` and `routes/bridges*.ts`.

**Nothing imports them.** `grep` for `db/bridges` outside the new files and the
new test returns zero. The switch is a separate PR, so its diff can read as
"call sites move" rather than "call sites move and the repositories changed
underneath them". Only two paths are added; no route, service, model, schema
file or shared `db/*` module is touched.

## What the port makes structural

Three Mongo idioms stop being a service being careful and become a property of
a statement:

**Lease acquisition converges on `UNIQUE(oxy_user_id, network)`.** Mongo could
only *use* that index by racing into it — read, create, catch the duplicate,
read again. `acquireLease` is one `INSERT … ON CONFLICT DO UPDATE … RETURNING`,
so the loser of a race is handed the winner's row by the database. What the
conflict branch does **not** set is the point: `country_code`, `region_code`
and `session_seed` are absent from it, so §8.3 rule 2 (country frozen at
creation), rule 3 (unlinking does not release a lease) and rule 7 (never shared)
hold however the function is called. A `released` lease is revived in place;
a `quarantined` one is returned untouched, because an acquisition must not
quietly undo a decision that a geography is no longer trusted.

**The upsert coalesces optional details.** This is the port hazard I'd flag to a
reviewer: `$set` with a spread of optional keys means a key Mongo never receives
is a key Mongo never writes, whereas `excluded.remote_name` is NULL for an
absent value and would *erase* the display name the last `whoami` established —
silently, visible one call later. Every optional detail goes through
`coalesce(excluded.x, bridge_accounts.x)`. `$setOnInsert: {linkedAt}` becomes the
absence of the column from the SET list, which is stronger than the operator: a
column that is not there cannot be written.

**Rotation is append-only and race-free.** `rotations[]` was an embedded array —
the one shape nothing stops a write replacing wholesale. `rotateLease` only ever
INSERTs, and it reads the previous seed under `FOR UPDATE` in the same
transaction as the swap, closing a race the Mongo version had (seed read in one
query, pushed as `fromSeed` in another, so two concurrent rotations could both
name the predecessor only one of them replaced).

## Expiry: filtered in one direction, deliberately not in the other

`bridge_link_sessions` is in the expiry registry, and no second deletion path is
added here. But neither Mongo's TTL monitor nor the sweep reaps promptly, so the
reads own the deadline — in *both* directions, which is why they are two
functions:

- `findLinkSessionForUser` answers "which attempt is this?" and does **not**
  filter, so a caller can distinguish an expired attempt (410) from one that
  never existed (404) — the distinction the `expired` outcome exists for.
- `findOpenLinkSessions` answers "is an attempt open?" and filters `outcome`
  **and** `expires_at`, because a `pending` row past its deadline is not open.

## Protected columns

Every read goes through `publicColumns(table, PROTECTED_COLUMNS)`; there is no
bare `.select()` in the repositories. `session_seed` is the one protected column
the domain genuinely needs (no proxy URL can be composed without it), so it is
opted into by name in exactly one place. `last_exit_ip` is written and read by
nothing, so no projection can return it; the rotation reads withhold both seeds
and return only *when* the exit identity changed and *why*.

`BRIDGE_NETWORK_IDS` is not redeclared — only the `BridgeNetworkId` type is
imported from `config/bridges`. `raw_state_event` is stored verbatim with no
validation, and a test pins that an unrecognised bridge state is recorded rather
than dropped.

## Verification

`bun run typecheck:backend` clean (all four files confirmed in the tsc program
via `--listFiles`, not assumed). Full backend suite **645 passed / 33 files**,
including 33 new real-Postgres cases.

Six mutations, each reverted by writing pristine content back in place rather
than with `git checkout` (which would have deleted these uncommitted files
outright):

| mutation | result |
|---|---|
| drop the `coalesce` from the conflict branch | 1 red — `expected null to be 'Grace'` |
| let acquisition overwrite country + seed | 3 red, incl. 8 concurrent callers landing on 8 different seeds |
| drop `FOR UPDATE` from rotation | 1 red, **3 runs of 3** — both rotations record the same predecessor |
| drop the deadline from the open-attempt read | 1 red |
| add a deadline to the identity lookup | 1 red — the 410-becomes-404 case |
| repository upper-cases the country code | **survived** — see below |

The last one is worth reporting rather than hiding. The country-code fixture was
`"esp"`, which is wrong on *both* axes at once, so a normalizing repository would
still be refused (`"ESP"` is three letters) and the constraint's case-sensitivity
went untested. Added `"es"` — wrong on the case axis only, the one input shape
that tells a normalizing repository from one that stores what it was given. The
mutation now dies, and only on that case.

One runtime bug the real server caught that `tsc` could not: a `Date`
interpolated into a raw `sql` template has no column to be encoded by, and
postgres.js's bind path throws `ERR_INVALID_ARG_TYPE`. It took out 13 tests in
two functions; both now bind an ISO string with an explicit `::timestamptz`, and
say why.

Nothing here contradicts `schema/CONVENTIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
