### PR TITLE
feat(backend): messaging repositories on Postgres, landing unused

### DIFF
--- a/packages/backend/src/__tests__/db/messaging.realdb.test.ts
+++ b/packages/backend/src/__tests__/db/messaging.realdb.test.ts
@@ -1,0 +1,1125 @@
+/**
+ * The messaging repositories, against a REAL Postgres server.
+ *
+ * A mocked `insert` accepts any statement, including one the server rejects
+ * outright — and every property worth asserting about this domain is one only a
+ * server has: a deferred constraint trigger judged at COMMIT, `ON CONFLICT`
+ * against a unique index, `xmax`, `nulls last`, an increment evaluated in SQL,
+ * and two levels of `ON DELETE CASCADE`. There is nothing here a mock could tell
+ * the truth about.
+ *
+ * The cases are grouped by the CLAIM they pin rather than by function, because
+ * several of the claims (the Mongo `Map` asymmetry, the lost-update fix) are
+ * about how two functions differ from each other.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createDatabase, constraintNameOf, isCheckViolation } from "@oxyhq/db";
+import type postgres from "postgres";
+import { and, eq } from "drizzle-orm";
+import { setUpTestDatabase, type TestDatabaseHandle } from "../../db/testDatabase";
+import * as schema from "../../db/schema";
+import {
+  addParticipants,
+  createConversation,
+  findConversationForParticipant,
+  findDirectConversationBetween,
+  isConversationParticipant,
+  listConversationsForUser,
+  markConversationRead,
+  removeParticipant,
+  setConversationArchived,
+  updateConversationDetails,
+} from "../../db/messaging/conversationRepository";
+import {
+  createMessage,
+  editMessageText,
+  findMessageById,
+  listConversationMessages,
+  markMessageDelivered,
+  markMessageRead,
+  softDeleteMessage,
+  toggleReaction,
+} from "../../db/messaging/messageRepository";
+import {
+  deleteDevice,
+  findDevice,
+  findDevicePreKeys,
+  listDeviceBundlesForUser,
+  listDevicesForUser,
+  registerDevice,
+  updateDeviceKeys,
+} from "../../db/messaging/deviceRepository";
+
+let handle: TestDatabaseHandle;
+let db: ReturnType<typeof createDatabase<typeof schema>>["db"];
+let client: postgres.Sql;
+
+/** Unique per call, so cases cannot collide inside the one shared database. */
+let counter = 0;
+function uid(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${String(counter).padStart(4, "0")}`;
+}
+
+/**
+ * Block until at least `expected` backends are waiting on a row lock in this
+ * database, or fail loudly.
+ *
+ * This is the anti-vacuity guard for the interleaving test below: if the send
+ * never actually blocks, the race it claims to exercise did not happen and a
+ * green result would be meaningless. Throwing names that outright rather than
+ * letting the assertion pass for the wrong reason.
+ */
+async function waitForBlockedBackend(expected: number): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const rows = await client<{ count: string }[]>`
+      select count(*)::text as count from pg_stat_activity
+      where wait_event_type = 'Lock' and datname = current_database()
+    `;
+    if (Number(rows[0].count) >= expected) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(
+    `no backend ever blocked on a row lock; the interleaving under test never occurred`,
+  );
+}
+
+/** A two-person `direct` conversation and the two user ids in it. */
+async function directConversation(): Promise<{
+  conversationId: string;
+  alice: string;
+  bob: string;
+}> {
+  const alice = uid("alice");
+  const bob = uid("bob");
+  const conversation = await createConversation(db, {
+    type: "direct",
+    createdBy: alice,
+    participants: [
+      { userId: alice, role: "admin" },
+      { userId: bob, role: "member" },
+    ],
+  });
+  return { conversationId: conversation.id, alice, bob };
+}
+
+beforeAll(async () => {
+  handle = await setUpTestDatabase();
+  const created = createDatabase({ databaseUrl: handle.databaseUrl, schema });
+  db = created.db;
+  client = created.client;
+}, 180_000);
+
+afterAll(async () => {
+  await client?.end();
+  await handle?.drop();
+});
+
+describe("creating a conversation, which the deferred trigger makes indivisible", () => {
+  it("writes the conversation and its participants in one transaction", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const found = await findConversationForParticipant(db, conversationId, alice);
+
+    expect(found).not.toBeNull();
+    expect(found?.participants.map((p) => p.userId).sort()).toEqual([alice, bob].sort());
+    // The role the caller asked for, not a default applied by the table.
+    expect(found?.participants.find((p) => p.userId === alice)?.role).toBe("admin");
+    expect(found?.participants.find((p) => p.userId === bob)?.role).toBe("member");
+  });
+
+  it("is refused at COMMIT when a direct conversation would not have exactly 2", async () => {
+    const solo = uid("solo");
+    const error = await createConversation(db, {
+      type: "direct",
+      createdBy: solo,
+      participants: [{ userId: solo, role: "admin" }],
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).not.toBeNull();
+    // By NAME, off `cause`. A regex over the driver's message text would pass
+    // for a different constraint raised by the same statement.
+    expect(constraintNameOf(error)).toBe("conversations_participant_count_check");
+  });
+
+  it("leaves nothing behind when the trigger refuses", async () => {
+    const before = await client<{ count: string }[]>`select count(*) from conversations`;
+    const solo = uid("solo");
+    await createConversation(db, {
+      type: "direct",
+      createdBy: solo,
+      participants: [{ userId: solo, role: "admin" }],
+    }).catch(() => undefined);
+    const after = await client<{ count: string }[]>`select count(*) from conversations`;
+
+    // The conversation row is written before its participants; if the rollback
+    // were not whole, this is where the orphan would show up.
+    expect(after[0].count).toBe(before[0].count);
+  });
+});
+
+describe("the conversation list", () => {
+  it("puts conversations that never received a message LAST, as Mongo did", async () => {
+    // The porting trap this whole test exists for. Mongo sorts a missing value
+    // lowest, so `{lastMessageAt: -1}` sent never-used conversations to the end;
+    // Postgres defaults `desc` to NULLS FIRST, which would open every user's
+    // list on the empty conversations they once created.
+    const owner = uid("owner");
+    const other = uid("other");
+
+    const quiet = await createConversation(db, {
+      type: "direct",
+      createdBy: owner,
+      participants: [
+        { userId: owner, role: "admin" },
+        { userId: other, role: "member" },
+      ],
+    });
+    const active = await createConversation(db, {
+      type: "direct",
+      createdBy: owner,
+      participants: [
+        { userId: owner, role: "admin" },
+        { userId: uid("third"), role: "member" },
+      ],
+    });
+    await createMessage(db, {
+      conversationId: active.id,
+      senderId: owner,
+      senderDeviceId: 1,
+      ciphertext: "hello",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const listed = await listConversationsForUser(db, { userId: owner, limit: 50, offset: 0 });
+    const ids = listed.map((conversation) => conversation.id);
+
+    expect(ids.indexOf(active.id)).toBeLessThan(ids.indexOf(quiet.id));
+    expect(ids).toContain(quiet.id);
+  });
+
+  it("hides a conversation the caller archived, and only for them", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+
+    expect(await setConversationArchived(db, conversationId, alice, true)).toBe(true);
+
+    const forAlice = await listConversationsForUser(db, { userId: alice, limit: 50, offset: 0 });
+    const forBob = await listConversationsForUser(db, { userId: bob, limit: 50, offset: 0 });
+
+    expect(forAlice.map((c) => c.id)).not.toContain(conversationId);
+    // `archivedBy` was a list on the conversation in Mongo; as a column on the
+    // membership row, one person's archive cannot reach the other's list.
+    expect(forBob.map((c) => c.id)).toContain(conversationId);
+
+    await setConversationArchived(db, conversationId, alice, false);
+    const restored = await listConversationsForUser(db, { userId: alice, limit: 50, offset: 0 });
+    expect(restored.map((c) => c.id)).toContain(conversationId);
+  });
+
+  it("carries each participant's own unread count and last-read time", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const forBob = await listConversationsForUser(db, { userId: bob, limit: 50, offset: 0 });
+    const conversation = forBob.find((c) => c.id === conversationId);
+    expect(conversation?.participants.find((p) => p.userId === bob)?.unreadCount).toBe(1);
+    expect(conversation?.participants.find((p) => p.userId === alice)?.unreadCount).toBe(0);
+
+    expect(await markConversationRead(db, conversationId, bob)).toBe(true);
+    const afterRead = await findConversationForParticipant(db, conversationId, bob);
+    const bobRow = afterRead?.participants.find((p) => p.userId === bob);
+    expect(bobRow?.unreadCount).toBe(0);
+    expect(bobRow?.lastReadAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("membership is the authorization primitive", () => {
+  it("answers the same way for a stranger as for a conversation that does not exist", async () => {
+    const { conversationId } = await directConversation();
+    const stranger = uid("stranger");
+
+    expect(await findConversationForParticipant(db, conversationId, stranger)).toBeNull();
+    expect(await findConversationForParticipant(db, uid("nope"), stranger)).toBeNull();
+    expect(await isConversationParticipant(db, conversationId, stranger)).toBe(false);
+  });
+
+  it("agrees with the full lookup for a real participant", async () => {
+    const { conversationId, bob } = await directConversation();
+    expect(await isConversationParticipant(db, conversationId, bob)).toBe(true);
+    expect(await findConversationForParticipant(db, conversationId, bob)).not.toBeNull();
+  });
+});
+
+describe("finding the existing direct conversation between two people", () => {
+  it("matches the pair, and does not match a group that merely contains them", async () => {
+    const alice = uid("alice");
+    const bob = uid("bob");
+    const carol = uid("carol");
+
+    const group = await createConversation(db, {
+      type: "group",
+      createdBy: alice,
+      participants: [
+        { userId: alice, role: "admin" },
+        { userId: bob, role: "member" },
+        { userId: carol, role: "member" },
+      ],
+    });
+    const direct = await createConversation(db, {
+      type: "direct",
+      createdBy: alice,
+      participants: [
+        { userId: alice, role: "admin" },
+        { userId: bob, role: "member" },
+      ],
+    });
+
+    const found = await findDirectConversationBetween(db, [alice, bob]);
+    expect(found?.id).toBe(direct.id);
+    expect(found?.id).not.toBe(group.id);
+
+    expect(await findDirectConversationBetween(db, [alice, uid("nobody")])).toBeNull();
+  });
+});
+
+describe("changing a group's membership", () => {
+  it("converges when the same person is added twice", async () => {
+    const alice = uid("alice");
+    const bob = uid("bob");
+    const carol = uid("carol");
+    const group = await createConversation(db, {
+      type: "group",
+      createdBy: alice,
+      participants: [
+        { userId: alice, role: "admin" },
+        { userId: bob, role: "member" },
+      ],
+    });
+
+    await addParticipants(db, group.id, [{ userId: carol, role: "member" }]);
+    // Mongo filtered the request against an in-memory member list, so two
+    // concurrent adds both saw an absence. The unique index answers it instead.
+    const after = await addParticipants(db, group.id, [{ userId: carol, role: "member" }]);
+
+    expect(after?.participants.filter((p) => p.userId === carol)).toHaveLength(1);
+    expect(after?.participants).toHaveLength(3);
+  });
+
+  it("reports the count rule as an outcome rather than an exception", async () => {
+    const { conversationId, bob } = await directConversation();
+
+    const outcome = await removeParticipant(db, conversationId, bob);
+
+    // The rule is the deferred trigger's, translated by CONSTRAINT NAME into
+    // something the route can answer 400 with.
+    expect(outcome).toEqual({ outcome: "would_leave_too_few" });
+    const survivors = await client<{ count: string }[]>`
+      select count(*) from conversation_participants where conversation_id = ${conversationId}
+    `;
+    expect(survivors[0].count).toBe("2");
+  });
+
+  it("removes a participant when enough remain", async () => {
+    const alice = uid("alice");
+    const bob = uid("bob");
+    const carol = uid("carol");
+    const group = await createConversation(db, {
+      type: "group",
+      createdBy: alice,
+      participants: [
+        { userId: alice, role: "admin" },
+        { userId: bob, role: "member" },
+        { userId: carol, role: "member" },
+      ],
+    });
+
+    expect(await removeParticipant(db, group.id, carol)).toEqual({ outcome: "removed" });
+    expect(await removeParticipant(db, group.id, carol)).toEqual({ outcome: "not_a_participant" });
+  });
+});
+
+describe("updating a conversation's details", () => {
+  it("applies only the fields named, and distinguishes clearing from leaving alone", async () => {
+    const alice = uid("alice");
+    const group = await createConversation(db, {
+      type: "group",
+      createdBy: alice,
+      participants: [
+        { userId: alice, role: "admin" },
+        { userId: uid("bob"), role: "member" },
+      ],
+      name: "Original",
+      description: "Described",
+    });
+
+    const renamed = await updateConversationDetails(db, group.id, { name: "Renamed" });
+    expect(renamed?.name).toBe("Renamed");
+    // Untouched because the patch did not name it — a spread of a request body
+    // would have written `undefined` over it.
+    expect(renamed?.description).toBe("Described");
+
+    const cleared = await updateConversationDetails(db, group.id, { description: null });
+    expect(cleared?.description).toBeNull();
+    expect(cleared?.name).toBe("Renamed");
+  });
+
+  it("does not write at all when the patch is empty", async () => {
+    const { conversationId } = await directConversation();
+    const before = await client<{ xmin: string }[]>`
+      select xmin::text from conversations where id = ${conversationId}
+    `;
+
+    const result = await updateConversationDetails(db, conversationId, {});
+
+    const after = await client<{ xmin: string }[]>`
+      select xmin::text from conversations where id = ${conversationId}
+    `;
+    expect(result).not.toBeNull();
+    // `xmin` is the row's transaction id: an UPDATE writing identical values
+    // still moves it, which is what comparing columns would miss.
+    expect(after[0].xmin).toBe(before[0].xmin);
+  });
+});
+
+describe("sending a message, which Mongo did as two independent saves", () => {
+  it("writes the message, the sender's delivery and the conversation preview together", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 3,
+      ciphertext: "base64",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    // A sender has by definition received their own message.
+    expect(message.deliveredTo).toEqual([alice]);
+    expect(message.senderDeviceId).toBe(3);
+
+    const conversation = await findConversationForParticipant(db, conversationId, bob);
+    expect(conversation?.lastMessage?.text).toBe("[Encrypted]");
+    expect(conversation?.lastMessage?.senderId).toBe(alice);
+    // The preview's timestamp IS the message's, not a second clock reading.
+    expect(conversation?.lastMessage?.timestamp.getTime()).toBe(message.createdAt.getTime());
+    expect(conversation?.lastMessageAt?.getTime()).toBe(message.createdAt.getTime());
+  });
+
+  it("increments everyone else's unread count and never the sender's", async () => {
+    const alice = uid("alice");
+    const bob = uid("bob");
+    const carol = uid("carol");
+    const group = await createConversation(db, {
+      type: "group",
+      createdBy: alice,
+      participants: [
+        { userId: alice, role: "admin" },
+        { userId: bob, role: "member" },
+        { userId: carol, role: "member" },
+      ],
+    });
+
+    await createMessage(db, {
+      conversationId: group.id,
+      senderId: alice,
+      senderDeviceId: 1,
+      text: "legacy plaintext",
+      messageType: "text",
+      lastMessagePreview: "legacy plaintext",
+    });
+
+    const after = await findConversationForParticipant(db, group.id, alice);
+    expect(after?.participants.find((p) => p.userId === alice)?.unreadCount).toBe(0);
+    expect(after?.participants.find((p) => p.userId === bob)?.unreadCount).toBe(1);
+    expect(after?.participants.find((p) => p.userId === carol)?.unreadCount).toBe(1);
+  });
+
+  it("counts both of two concurrent sends", async () => {
+    // Note what this does and does NOT pin — it is kept as a total-correctness
+    // check, not a race, and CONVENTIONS.md §"Concurrency tests here are prone
+    // to passing vacuously" is why that distinction is written down instead of
+    // left for someone to rediscover. Two reasons it cannot discriminate: both
+    // sends update the conversation row before touching participants, so the
+    // second blocks there and a read-modify-write reaches 2 as well (verified by
+    // mutation — this case stays green against one); and postgres.js opens
+    // connections on demand, so a burst like this can queue onto one connection
+    // and simply run in order. The discriminating case is the next test, and it
+    // fails loudly rather than silently if its interleaving never happens.
+    const { conversationId, alice, bob } = await directConversation();
+
+    await Promise.all([
+      createMessage(db, {
+        conversationId,
+        senderId: alice,
+        senderDeviceId: 1,
+        ciphertext: "one",
+        messageType: "text",
+        lastMessagePreview: "[Encrypted]",
+      }),
+      createMessage(db, {
+        conversationId,
+        senderId: alice,
+        senderDeviceId: 1,
+        ciphertext: "two",
+        messageType: "text",
+        lastMessagePreview: "[Encrypted]",
+      }),
+    ]);
+
+    const conversation = await findConversationForParticipant(db, conversationId, bob);
+    expect(conversation?.participants.find((p) => p.userId === bob)?.unreadCount).toBe(2);
+  });
+
+  it("does not clobber a mark-read that commits while the send is in flight", async () => {
+    // The case the SQL-side increment actually exists for. `markConversationRead`
+    // touches the PARTICIPANT row and not the conversation row, so it does not
+    // serialize behind the send the way another send does. A read-modify-write
+    // reads the backlog, blocks on the row lock, and then writes `stale + 1`
+    // over the zero the reader just committed — the badge comes back on a
+    // conversation the user has just read.
+    const { conversationId, alice, bob } = await directConversation();
+    for (let index = 0; index < 5; index += 1) {
+      await createMessage(db, {
+        conversationId,
+        senderId: alice,
+        senderDeviceId: 1,
+        ciphertext: `backlog-${String(index)}`,
+        messageType: "text",
+        lastMessagePreview: "[Encrypted]",
+      });
+    }
+
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let lockTaken: (() => void) | undefined;
+    const locked = new Promise<void>((resolve) => {
+      lockTaken = resolve;
+    });
+
+    // Holds bob's participant row locked, so the send below blocks precisely
+    // between reading his count and writing it.
+    const reader = db.transaction(async (tx) => {
+      await tx
+        .update(schema.conversationParticipants)
+        .set({ unreadCount: 0, lastReadAt: new Date() })
+        .where(
+          and(
+            eq(schema.conversationParticipants.conversationId, conversationId),
+            eq(schema.conversationParticipants.userId, bob),
+          ),
+        );
+      lockTaken?.();
+      await held;
+    });
+
+    await locked;
+    const send = createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "arrives-during-read",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    // Anti-vacuity: if nothing ever blocks, the interleaving this test depends
+    // on never happened and a pass would mean nothing.
+    await waitForBlockedBackend(1);
+    release?.();
+    await reader;
+    await send;
+
+    const conversation = await findConversationForParticipant(db, conversationId, bob);
+    expect(conversation?.participants.find((p) => p.userId === bob)?.unreadCount).toBe(1);
+  });
+
+  it("is refused by the content CHECK when it carries neither ciphertext nor plaintext", async () => {
+    const { conversationId, alice } = await directConversation();
+
+    const error = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      messageType: "text",
+      lastMessagePreview: null,
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).not.toBeNull();
+    expect(isCheckViolation(error)).toBe(true);
+    expect(constraintNameOf(error)).toBe("messages_content_present_check");
+  });
+
+  it("leaves the conversation preview untouched when the message is refused", async () => {
+    const { conversationId, alice } = await directConversation();
+    await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "first",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+    const before = await findConversationForParticipant(db, conversationId, alice);
+
+    await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      messageType: "text",
+      lastMessagePreview: "SHOULD NOT APPEAR",
+    }).catch(() => undefined);
+
+    const after = await findConversationForParticipant(db, conversationId, alice);
+    expect(after?.lastMessage?.text).toBe("[Encrypted]");
+    expect(after?.lastMessageAt?.getTime()).toBe(before?.lastMessageAt?.getTime());
+  });
+
+  it("round-trips the two jsonb media arrays whole", async () => {
+    const { conversationId, alice } = await directConversation();
+    const encrypted = [
+      { id: "m1", type: "image" as const, ciphertext: "cipher", fileSize: 42, mimeType: "image/png" },
+    ];
+
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      encryptedMedia: encrypted,
+      messageType: "media",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const reloaded = await findMessageById(db, message.id);
+    // Opaque envelopes the server cannot read: they must come back byte-identical,
+    // which is the whole reason they stayed `jsonb` on the row.
+    expect(reloaded?.encryptedMedia).toEqual(encrypted);
+    expect(reloaded?.media).toEqual([]);
+    expect(reloaded?.messageType).toBe("media");
+  });
+});
+
+describe("reading a conversation's messages", () => {
+  it("returns them oldest-first and excludes soft-deleted ones", async () => {
+    const { conversationId, alice } = await directConversation();
+    const first = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "one",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+    const second = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "two",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+    const third = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "three",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const page = await listConversationMessages(db, { conversationId, limit: 50 });
+    expect(page.map((m) => m.id)).toEqual([first.id, second.id, third.id]);
+
+    await softDeleteMessage(db, second.id, alice);
+    const afterDelete = await listConversationMessages(db, { conversationId, limit: 50 });
+    expect(afterDelete.map((m) => m.id)).toEqual([first.id, third.id]);
+  });
+
+  it("takes the NEWEST page under a limit, then hands it back chronologically", async () => {
+    const { conversationId, alice } = await directConversation();
+    const sent: string[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      const message = await createMessage(db, {
+        conversationId,
+        senderId: alice,
+        senderDeviceId: 1,
+        ciphertext: `m${String(index)}`,
+        messageType: "text",
+        lastMessagePreview: "[Encrypted]",
+      });
+      sent.push(message.id);
+    }
+
+    const page = await listConversationMessages(db, { conversationId, limit: 2 });
+    // The last two sent, in the order they were sent — not the first two.
+    expect(page.map((m) => m.id)).toEqual(sent.slice(-2));
+  });
+
+  it("pages backwards from a cursor", async () => {
+    const { conversationId, alice } = await directConversation();
+    const first = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "one",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+    const second = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "two",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const older = await listConversationMessages(db, {
+      conversationId,
+      limit: 50,
+      before: second.createdAt,
+    });
+    expect(older.map((m) => m.id)).toEqual([first.id]);
+  });
+});
+
+describe("the two Mongo Maps did not behave the same, and both behaviours survive", () => {
+  it("a read receipt is one row per person and its timestamp MOVES on a repeat", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const firstRead = await markMessageRead(db, message.id, bob);
+    const firstAt = firstRead?.readBy[bob];
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const secondRead = await markMessageRead(db, message.id, bob);
+    const secondAt = secondRead?.readBy[bob];
+
+    const rows = await client<{ count: string }[]>`
+      select count(*) from message_reads where message_id = ${message.id}
+    `;
+    // Idempotent in the sense that matters: the unique index, not a read-then-write.
+    expect(rows[0].count).toBe("1");
+    expect(firstAt).toBeInstanceOf(Date);
+    expect(secondAt).toBeInstanceOf(Date);
+    // `readBy.set(userId, new Date())` overwrote. Preserved deliberately.
+    expect(secondAt?.getTime()).toBeGreaterThan(firstAt?.getTime() ?? 0);
+  });
+
+  it("a delivery receipt is one row per person and KEEPS the first timestamp", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const first = await markMessageDelivered(db, message.id, bob);
+    const firstRow = await client<{ delivered_at: string }[]>`
+      select delivered_at::text from message_deliveries
+      where message_id = ${message.id} and user_id = ${bob}
+    `;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await markMessageDelivered(db, message.id, bob);
+    const secondRow = await client<{ delivered_at: string }[]>`
+      select delivered_at::text from message_deliveries
+      where message_id = ${message.id} and user_id = ${bob}
+    `;
+
+    expect(first?.deliveredTo).toEqual([alice, bob]);
+    // `deliveredTo` was pushed only `if (!includes(userId))` — first write wins,
+    // which is the OPPOSITE of the read receipt above and is inherited, not chosen.
+    expect(secondRow[0].delivered_at).toBe(firstRow[0].delivered_at);
+  });
+});
+
+describe("reactions", () => {
+  it("toggles the caller's own and leaves everyone else's alone", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    const added = await toggleReaction(db, message.id, bob, "👍");
+    expect(added.hasReacted).toBe(true);
+    expect(added.reactions["👍"]).toEqual([bob]);
+
+    const alsoAlice = await toggleReaction(db, message.id, alice, "👍");
+    expect(alsoAlice.reactions["👍"]).toEqual([bob, alice]);
+
+    const removed = await toggleReaction(db, message.id, bob, "👍");
+    expect(removed.hasReacted).toBe(false);
+    // Mongo rewrote the whole `Map<emoji, userId[]>`, so a concurrent reaction
+    // was simply overwritten; one row per (message, user, emoji) cannot be.
+    expect(removed.reactions["👍"]).toEqual([alice]);
+  });
+
+  it("drops an emoji's key once its last reactor leaves, which Mongo did not", async () => {
+    // The one divergence in this domain that is forced by the schema rather
+    // than chosen. Mongo removed a reaction with `set(emoji, filtered)`, never
+    // `delete(emoji)`, so an emoji that had ever been used stayed in the
+    // document as `[]` forever. The table's grain is (message, user, emoji), so
+    // "zero reactors" has no row to be, and a client must read a missing key and
+    // an empty array as the same thing.
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    await toggleReaction(db, message.id, bob, "👍");
+    const afterRemoval = await toggleReaction(db, message.id, bob, "👍");
+
+    expect(afterRemoval.hasReacted).toBe(false);
+    expect(afterRemoval.reactions).toEqual({});
+    expect("👍" in afterRemoval.reactions).toBe(false);
+
+    const reloaded = await findMessageById(db, message.id);
+    expect(reloaded?.reactions).toEqual({});
+  });
+
+  it("keeps different emoji apart and hydrates them onto the message", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    await toggleReaction(db, message.id, bob, "👍");
+    await toggleReaction(db, message.id, bob, "🎉");
+
+    const reloaded = await findMessageById(db, message.id);
+    expect(reloaded?.reactions).toEqual({ "👍": [bob], "🎉": [bob] });
+  });
+});
+
+describe("editing and deleting, where ownership is in the statement's own WHERE", () => {
+  it("refuses an edit from anyone but the sender, and after a delete", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      text: "original",
+      messageType: "text",
+      lastMessagePreview: "original",
+    });
+
+    expect(
+      await editMessageText(db, { messageId: message.id, senderId: bob, text: "hijacked" }),
+    ).toBeNull();
+
+    const edited = await editMessageText(db, {
+      messageId: message.id,
+      senderId: alice,
+      text: "corrected",
+    });
+    expect(edited?.text).toBe("corrected");
+    expect(edited?.editedAt).toBeInstanceOf(Date);
+
+    await softDeleteMessage(db, message.id, alice);
+    // Mongo read, mutated and saved, so a delete landing in between resurrected
+    // the text. The condition is in the UPDATE here, so there is no window.
+    expect(
+      await editMessageText(db, { messageId: message.id, senderId: alice, text: "zombie" }),
+    ).toBeNull();
+  });
+
+  it("deletes once and reports the conversation to announce it to", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+
+    expect(await softDeleteMessage(db, message.id, bob)).toBeNull();
+    expect(await softDeleteMessage(db, message.id, alice)).toEqual({
+      id: message.id,
+      conversationId,
+    });
+    // A second delete is a 404, not a silent success that moves the tombstone.
+    expect(await softDeleteMessage(db, message.id, alice)).toBeNull();
+  });
+});
+
+describe("cascades Mongo could not express", () => {
+  it("takes messages and their per-recipient rows with the conversation", async () => {
+    const { conversationId, alice, bob } = await directConversation();
+    const message = await createMessage(db, {
+      conversationId,
+      senderId: alice,
+      senderDeviceId: 1,
+      ciphertext: "hi",
+      messageType: "text",
+      lastMessagePreview: "[Encrypted]",
+    });
+    await markMessageRead(db, message.id, bob);
+    await toggleReaction(db, message.id, bob, "👍");
+
+    await db.delete(schema.conversations).where(eq(schema.conversations.id, conversationId));
+
+    expect(await findMessageById(db, message.id)).toBeNull();
+    const reads = await client<{ count: string }[]>`
+      select count(*) from message_reads where message_id = ${message.id}
+    `;
+    const reactions = await client<{ count: string }[]>`
+      select count(*) from message_reactions where message_id = ${message.id}
+    `;
+    expect(reads[0].count).toBe("0");
+    expect(reactions[0].count).toBe("0");
+  });
+});
+
+describe("registering a device", () => {
+  const signedPreKey = { keyId: 7, publicKey: "signed-public", signature: "sig" };
+
+  it("reports a first registration and a re-registration differently", async () => {
+    const userId = uid("user");
+
+    const first = await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [{ keyId: 1, publicKey: "pk1" }],
+      registrationId: 1234,
+    });
+    const second = await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity-rotated",
+      signedPreKey: { keyId: 8, publicKey: "signed-2", signature: "sig-2" },
+      preKeys: [{ keyId: 2, publicKey: "pk2" }],
+      registrationId: 5678,
+    });
+
+    // `xmax = 0` distinguishes the two branches of the upsert. The route's
+    // read-then-branch let two concurrent registrations both insert, and the
+    // loser got a 409 for a perfectly valid request.
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.device.identityKeyPublic).toBe("identity-rotated");
+    expect(second.device.signedPreKey).toEqual({
+      keyId: 8,
+      publicKey: "signed-2",
+      signature: "sig-2",
+    });
+    expect(second.device.registrationId).toBe(5678);
+    // One device, not two.
+    expect(await listDevicesForUser(db, userId)).toHaveLength(1);
+  });
+
+  it("REPLACES the pre-key bundle rather than merging with it", async () => {
+    const userId = uid("user");
+    await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [
+        { keyId: 1, publicKey: "pk1" },
+        { keyId: 2, publicKey: "pk2" },
+      ],
+      registrationId: 1,
+    });
+
+    await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [{ keyId: 9, publicKey: "pk9" }],
+      registrationId: 1,
+    });
+
+    // A client rotating its bundle is not merging with what the server held —
+    // and `unique(device_id, key_id)` would refuse a merge that reused an id.
+    expect(await findDevicePreKeys(db, userId, 1)).toEqual([{ keyId: 9, publicKey: "pk9" }]);
+  });
+
+  it("keeps two users' device number 1 apart", async () => {
+    const first = uid("user");
+    const second = uid("user");
+    await registerDevice(db, {
+      userId: first,
+      deviceId: 1,
+      identityKeyPublic: "a",
+      signedPreKey,
+      preKeys: [],
+      registrationId: 1,
+    });
+    await registerDevice(db, {
+      userId: second,
+      deviceId: 1,
+      identityKeyPublic: "b",
+      signedPreKey,
+      preKeys: [],
+      registrationId: 2,
+    });
+
+    // Signal's device number is unique only WITHIN a user.
+    expect((await findDevice(db, first, 1))?.identityKeyPublic).toBe("a");
+    expect((await findDevice(db, second, 1))?.identityKeyPublic).toBe("b");
+  });
+});
+
+describe("what each device projection does and does not carry", () => {
+  const signedPreKey = { keyId: 3, publicKey: "signed-public", signature: "sig" };
+
+  it("keeps one-time pre-keys out of the list, which is what -preKeys did", async () => {
+    const userId = uid("user");
+    await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [{ keyId: 1, publicKey: "pk1" }],
+      registrationId: 1,
+    });
+
+    const listed = await listDevicesForUser(db, userId);
+    expect(listed).toHaveLength(1);
+    // A child table now, so the list cannot leak them: it never reads them.
+    expect(Object.keys(listed[0])).not.toContain("preKeys");
+    expect(listed[0].signedPreKey).toEqual(signedPreKey);
+  });
+
+  it("gives a stranger the bundle without the owner's identity or timestamps", async () => {
+    const userId = uid("user");
+    await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [{ keyId: 1, publicKey: "pk1" }],
+      registrationId: 99,
+    });
+
+    const bundles = await listDeviceBundlesForUser(db, userId);
+    expect(bundles).toHaveLength(1);
+    expect(Object.keys(bundles[0]).sort()).toEqual(
+      ["deviceId", "id", "identityKeyPublic", "registrationId", "signedPreKey"].sort(),
+    );
+    expect(bundles[0].signedPreKey).toEqual(signedPreKey);
+  });
+
+  it("orders devices by Signal's own number", async () => {
+    const userId = uid("user");
+    for (const deviceId of [3, 1, 2]) {
+      await registerDevice(db, {
+        userId,
+        deviceId,
+        identityKeyPublic: `identity-${String(deviceId)}`,
+        signedPreKey,
+        preKeys: [],
+        registrationId: deviceId,
+      });
+    }
+    expect((await listDevicesForUser(db, userId)).map((d) => d.deviceId)).toEqual([1, 2, 3]);
+  });
+
+  it("tells an unknown device apart from one with no pre-keys left", async () => {
+    const userId = uid("user");
+    await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [],
+      registrationId: 1,
+    });
+
+    // An exhausted bundle and a wrong device id are different answers; only the
+    // second is a 404.
+    expect(await findDevicePreKeys(db, userId, 1)).toEqual([]);
+    expect(await findDevicePreKeys(db, userId, 2)).toBeNull();
+  });
+});
+
+describe("updating and removing a device", () => {
+  const signedPreKey = { keyId: 5, publicKey: "signed-public", signature: "sig" };
+
+  it("applies only the fields named and leaves stored pre-keys alone when absent", async () => {
+    const userId = uid("user");
+    await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [{ keyId: 1, publicKey: "pk1" }],
+      registrationId: 1,
+    });
+
+    const updated = await updateDeviceKeys(db, userId, 1, { registrationId: 42 });
+    expect(updated?.registrationId).toBe(42);
+    expect(updated?.identityKeyPublic).toBe("identity");
+    // `undefined` leaves the bundle alone; an empty array would clear it.
+    expect(updated?.preKeys).toEqual([{ keyId: 1, publicKey: "pk1" }]);
+
+    const cleared = await updateDeviceKeys(db, userId, 1, { preKeys: [] });
+    expect(cleared?.preKeys).toEqual([]);
+
+    expect(await updateDeviceKeys(db, userId, 99, { registrationId: 1 })).toBeNull();
+  });
+
+  it("takes the pre-keys with the device", async () => {
+    const userId = uid("user");
+    const registered = await registerDevice(db, {
+      userId,
+      deviceId: 1,
+      identityKeyPublic: "identity",
+      signedPreKey,
+      preKeys: [{ keyId: 1, publicKey: "pk1" }],
+      registrationId: 1,
+    });
+
+    expect(await deleteDevice(db, userId, 1)).toBe(true);
+    const orphans = await client<{ count: string }[]>`
+      select count(*) from device_pre_keys where device_id = ${registered.device.id}
+    `;
+    expect(orphans[0].count).toBe("0");
+    expect(await deleteDevice(db, userId, 1)).toBe(false);
+  });
+});

--- a/packages/backend/src/db/messaging/conversationRepository.ts
+++ b/packages/backend/src/db/messaging/conversationRepository.ts
@@ -1,0 +1,558 @@
+/**
+ * Conversations and their participants, as Postgres.
+ *
+ * Ported from what `routes/conversations.ts` asks `models/Conversation.ts` for —
+ * ten call sites, no more. There is deliberately no generic CRUD surface here:
+ * a function nobody calls is a function nothing pins, and this file lands unused
+ * on purpose (the call-site switch is a separate change).
+ *
+ * ## The transaction is not a style choice
+ *
+ * `conversations_participant_count_check` is a `DEFERRABLE INITIALLY DEFERRED`
+ * constraint trigger judged at COMMIT (see `schema/CONVENTIONS.md` §"The two
+ * Mongoose hooks"). A conversation necessarily exists for a moment before its
+ * participants do, so {@link createConversation} takes the participants WITH the
+ * conversation and writes both inside one `db.transaction(...)`. An API that let
+ * a caller insert a conversation alone would be an API whose every use fails at
+ * commit.
+ *
+ * ## What this file deliberately does NOT rebuild
+ *
+ * Mongo's conversation carried `unreadCounts` (a `Map<userId, number>`) and
+ * `archivedBy` (an array of user ids). Both are now columns on the participant
+ * row, which is what makes "a user who archived a conversation they are not in"
+ * unrepresentable. This repository therefore returns PARTICIPANTS carrying their
+ * own `unreadCount` and `archivedAt`, and does not re-derive the two aggregate
+ * shapes — re-assembling them here would un-port the decision the ledger made.
+ * Whether the HTTP layer still emits them is a serialization question for the
+ * switch, answered where the DTO is built.
+ *
+ * `lastMessage` IS re-assembled, and the difference is not arbitrary: it was
+ * flattened into three columns purely for storage and has no other home, whereas
+ * the two above were moved onto a row that is itself part of the result.
+ */
+
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { constraintNameOf, uuidv7, type SelectedRow } from "@oxyhq/db";
+import { publicColumns } from "@oxyhq/db/assert";
+import type { ConversationParticipantRole, ConversationType } from "@allo/shared-types";
+import type { AlloDatabase } from "../index";
+import { PROTECTED_COLUMNS } from "../protectedColumns";
+import { conversationParticipants, conversations } from "../schema/conversations";
+
+/**
+ * Neither table registers a protected column, so this is every column — and it
+ * stays correct, rather than merely lucky, if one is ever registered.
+ */
+const CONVERSATION_COLUMNS = publicColumns(conversations, PROTECTED_COLUMNS);
+const PARTICIPANT_COLUMNS = publicColumns(conversationParticipants, PROTECTED_COLUMNS);
+
+/** One person's membership, carrying the two Mongo `Map`s that collapsed onto it. */
+export interface ConversationParticipantRecord {
+  readonly userId: string;
+  readonly role: ConversationParticipantRole;
+  readonly joinedAt: Date;
+  readonly lastReadAt: Date | null;
+  readonly unreadCount: number;
+  readonly archivedAt: Date | null;
+}
+
+/** The denormalised preview, re-assembled from its three columns. */
+export interface ConversationLastMessageRecord {
+  readonly text: string | null;
+  readonly senderId: string;
+  readonly timestamp: Date;
+}
+
+export interface ConversationRecord {
+  readonly id: string;
+  readonly type: ConversationType;
+  readonly name: string | null;
+  readonly description: string | null;
+  readonly avatar: string | null;
+  readonly theme: string | null;
+  readonly createdBy: string;
+  readonly lastMessageAt: Date | null;
+  readonly lastMessage: ConversationLastMessageRecord | null;
+  readonly participants: readonly ConversationParticipantRecord[];
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+type ConversationRow = SelectedRow<typeof CONVERSATION_COLUMNS>;
+type ParticipantRow = SelectedRow<typeof PARTICIPANT_COLUMNS>;
+
+function toParticipantRecord(row: ParticipantRow): ConversationParticipantRecord {
+  return {
+    userId: row.userId,
+    role: row.role,
+    joinedAt: row.joinedAt,
+    lastReadAt: row.lastReadAt,
+    unreadCount: row.unreadCount,
+    archivedAt: row.archivedAt,
+  };
+}
+
+function toConversationRecord(
+  row: ConversationRow,
+  participants: readonly ConversationParticipantRecord[],
+): ConversationRecord {
+  return {
+    id: row.id,
+    type: row.type,
+    name: row.name,
+    description: row.description,
+    avatar: row.avatar,
+    theme: row.theme,
+    createdBy: row.createdBy,
+    lastMessageAt: row.lastMessageAt,
+    // Present only when the preview really identifies a message. `text` alone is
+    // optional — an encrypted message stores a placeholder, and a media-only one
+    // stored nothing at all.
+    lastMessage:
+      row.lastMessageSenderId !== null && row.lastMessageTimestamp !== null
+        ? {
+            text: row.lastMessageText,
+            senderId: row.lastMessageSenderId,
+            timestamp: row.lastMessageTimestamp,
+          }
+        : null,
+    participants,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Participants for a whole page of conversations in ONE query.
+ *
+ * The alternative — a query per conversation — is the N+1 the conversation list
+ * would feel first, since it is the one screen that loads fifty at a time.
+ */
+async function loadParticipants(
+  db: AlloDatabase,
+  conversationIds: readonly string[],
+): Promise<Map<string, ConversationParticipantRecord[]>> {
+  const byConversation = new Map<string, ConversationParticipantRecord[]>();
+  if (conversationIds.length === 0) return byConversation;
+
+  const rows = await db
+    .select(PARTICIPANT_COLUMNS)
+    .from(conversationParticipants)
+    .where(inArray(conversationParticipants.conversationId, [...conversationIds]))
+    .orderBy(asc(conversationParticipants.joinedAt), asc(conversationParticipants.id));
+
+  for (const row of rows) {
+    const existing = byConversation.get(row.conversationId);
+    const record = toParticipantRecord(row);
+    if (existing) existing.push(record);
+    else byConversation.set(row.conversationId, [record]);
+  }
+  return byConversation;
+}
+
+async function hydrate(
+  db: AlloDatabase,
+  rows: readonly ConversationRow[],
+): Promise<ConversationRecord[]> {
+  const participants = await loadParticipants(
+    db,
+    rows.map((row) => row.id),
+  );
+  return rows.map((row) => toConversationRecord(row, participants.get(row.id) ?? []));
+}
+
+export interface ListConversationsInput {
+  readonly userId: string;
+  readonly limit: number;
+  readonly offset: number;
+}
+
+/**
+ * Every conversation the user participates in and has NOT archived.
+ *
+ * `order by last_message_at desc nulls last` is load-bearing rather than
+ * decorative. Mongo sorts a missing value LOWEST, so `{lastMessageAt: -1}` put
+ * conversations that never received a message at the END; Postgres defaults
+ * `desc` to NULLS FIRST, which would open the list on every empty conversation a
+ * user has ever created. The port has to say `nulls last` to mean what the
+ * source meant.
+ *
+ * Offset paging is kept as Mongo had it (`.skip`). Keyset paging would be
+ * better and is a deliberate non-change: it is a contract change for the client,
+ * not a porting detail.
+ */
+export async function listConversationsForUser(
+  db: AlloDatabase,
+  input: ListConversationsInput,
+): Promise<ConversationRecord[]> {
+  const rows = await db
+    .select(CONVERSATION_COLUMNS)
+    .from(conversations)
+    .innerJoin(
+      conversationParticipants,
+      eq(conversationParticipants.conversationId, conversations.id),
+    )
+    .where(
+      and(
+        eq(conversationParticipants.userId, input.userId),
+        isNull(conversationParticipants.archivedAt),
+      ),
+    )
+    .orderBy(
+      sql`${conversations.lastMessageAt} desc nulls last`,
+      desc(conversations.createdAt),
+      desc(conversations.id),
+    )
+    .limit(input.limit)
+    .offset(input.offset);
+
+  return hydrate(db, rows);
+}
+
+/**
+ * One conversation, but only for someone who is in it.
+ *
+ * This is the authorization primitive `routes/messages.ts` leans on too: Mongo
+ * spelled it `findOne({_id, "participants.userId": userId})`, so "not found" and
+ * "not yours" are deliberately the same answer and neither confirms the
+ * conversation exists.
+ */
+export async function findConversationForParticipant(
+  db: AlloDatabase,
+  conversationId: string,
+  userId: string,
+): Promise<ConversationRecord | null> {
+  const rows = await db
+    .select(CONVERSATION_COLUMNS)
+    .from(conversations)
+    .innerJoin(
+      conversationParticipants,
+      eq(conversationParticipants.conversationId, conversations.id),
+    )
+    .where(
+      and(
+        eq(conversations.id, conversationId),
+        eq(conversationParticipants.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  const hydrated = await hydrate(db, rows);
+  return hydrated[0] ?? null;
+}
+
+/**
+ * The same question as {@link findConversationForParticipant} when the caller
+ * only needs the yes/no. Six message routes check membership; five of them then
+ * never touch the conversation again, and loading it plus its participants for a
+ * boolean is work with no reader. Only the send path needs the full record,
+ * because it emits to every participant's room.
+ */
+export async function isConversationParticipant(
+  db: AlloDatabase,
+  conversationId: string,
+  userId: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: conversationParticipants.id })
+    .from(conversationParticipants)
+    .where(
+      and(
+        eq(conversationParticipants.conversationId, conversationId),
+        eq(conversationParticipants.userId, userId),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * The existing `direct` conversation between exactly these people, if there is
+ * one — the dedupe `POST /api/conversations` runs before creating another.
+ *
+ * Mongo asked for `$all` the ids plus `participants.2: {$exists: false}`, i.e.
+ * "contains both AND has no third". Both halves are kept: `count(*) = 2` is the
+ * second one, and dropping it would match a group-sized `direct` row rather than
+ * trusting the count trigger to have made that impossible.
+ */
+export async function findDirectConversationBetween(
+  db: AlloDatabase,
+  userIds: readonly [string, string],
+): Promise<ConversationRecord | null> {
+  const matches = await db
+    .select({ id: conversationParticipants.conversationId })
+    .from(conversationParticipants)
+    .innerJoin(conversations, eq(conversations.id, conversationParticipants.conversationId))
+    .where(eq(conversations.type, "direct"))
+    .groupBy(conversationParticipants.conversationId)
+    .having(
+      and(
+        sql`count(*) = 2`,
+        sql`count(*) filter (where ${conversationParticipants.userId} in (${userIds[0]}, ${userIds[1]})) = 2`,
+      ),
+    )
+    .limit(1);
+
+  const match = matches[0];
+  if (!match) return null;
+
+  const rows = await db
+    .select(CONVERSATION_COLUMNS)
+    .from(conversations)
+    .where(eq(conversations.id, match.id))
+    .limit(1);
+
+  const hydrated = await hydrate(db, rows);
+  return hydrated[0] ?? null;
+}
+
+export interface NewParticipant {
+  readonly userId: string;
+  readonly role: ConversationParticipantRole;
+}
+
+export interface CreateConversationInput {
+  readonly type: ConversationType;
+  readonly createdBy: string;
+  readonly participants: readonly NewParticipant[];
+  readonly name?: string | null;
+  readonly description?: string | null;
+  readonly avatar?: string | null;
+}
+
+/**
+ * Create a conversation and its participants together.
+ *
+ * The field list is explicit and closed — a caller cannot widen it by handing
+ * over a request body, which is the mass-assignment shape (`new Model(req.body)`)
+ * this port is the opportunity to leave behind.
+ *
+ * Whether a `direct` conversation may carry a name, and whether the creator is
+ * the admin, are the caller's policy and are NOT re-decided here; Mongo did not
+ * decide them either, and inventing the restriction now would be a new one.
+ */
+export async function createConversation(
+  db: AlloDatabase,
+  input: CreateConversationInput,
+): Promise<ConversationRecord> {
+  const conversationId = uuidv7();
+
+  return db.transaction(async (tx) => {
+    await tx.insert(conversations).values({
+      id: conversationId,
+      type: input.type,
+      name: input.name ?? null,
+      description: input.description ?? null,
+      avatar: input.avatar ?? null,
+      createdBy: input.createdBy,
+    });
+
+    if (input.participants.length > 0) {
+      await tx.insert(conversationParticipants).values(
+        input.participants.map((participant) => ({
+          id: uuidv7(),
+          conversationId,
+          userId: participant.userId,
+          role: participant.role,
+        })),
+      );
+    }
+
+    const rows = await tx
+      .select(CONVERSATION_COLUMNS)
+      .from(conversations)
+      .where(eq(conversations.id, conversationId))
+      .limit(1);
+    const participantRows = await tx
+      .select(PARTICIPANT_COLUMNS)
+      .from(conversationParticipants)
+      .where(eq(conversationParticipants.conversationId, conversationId))
+      .orderBy(asc(conversationParticipants.joinedAt), asc(conversationParticipants.id));
+
+    const row = rows[0];
+    if (!row) {
+      throw new Error(`Conversation ${conversationId} vanished inside its own transaction`);
+    }
+    return toConversationRecord(row, participantRows.map(toParticipantRecord));
+  });
+}
+
+/**
+ * The four mutable presentation fields, each applied only when the caller names
+ * it — `undefined` means "leave alone" and `null` means "clear", which is the
+ * distinction a spread of the request body throws away.
+ */
+export interface ConversationDetailsPatch {
+  readonly name?: string | null;
+  readonly description?: string | null;
+  readonly avatar?: string | null;
+  readonly theme?: string | null;
+}
+
+export async function updateConversationDetails(
+  db: AlloDatabase,
+  conversationId: string,
+  patch: ConversationDetailsPatch,
+): Promise<ConversationRecord | null> {
+  const values: {
+    name?: string | null;
+    description?: string | null;
+    avatar?: string | null;
+    theme?: string | null;
+  } = {};
+  if (patch.name !== undefined) values.name = patch.name;
+  if (patch.description !== undefined) values.description = patch.description;
+  if (patch.avatar !== undefined) values.avatar = patch.avatar;
+  if (patch.theme !== undefined) values.theme = patch.theme;
+
+  if (Object.keys(values).length === 0) {
+    // Mongoose's `save()` on an untouched document issued no write and left
+    // `updatedAt` alone. An empty PUT must not become a write here either.
+    const rows = await db
+      .select(CONVERSATION_COLUMNS)
+      .from(conversations)
+      .where(eq(conversations.id, conversationId))
+      .limit(1);
+    const hydrated = await hydrate(db, rows);
+    return hydrated[0] ?? null;
+  }
+
+  const rows = await db
+    .update(conversations)
+    .set(values)
+    .where(eq(conversations.id, conversationId))
+    .returning(CONVERSATION_COLUMNS);
+
+  const hydrated = await hydrate(db, rows);
+  return hydrated[0] ?? null;
+}
+
+/**
+ * Add people to a conversation, converging rather than refusing.
+ *
+ * Mongo read the current members, filtered the request against them in memory
+ * and pushed the remainder — two concurrent adds of the same person both saw an
+ * absence and both pushed. `ON CONFLICT DO NOTHING` against
+ * `conversation_participants_conversation_id_user_id_key` closes that: the
+ * duplicate is refused by the index, not by a comparison that raced.
+ */
+export async function addParticipants(
+  db: AlloDatabase,
+  conversationId: string,
+  participants: readonly NewParticipant[],
+): Promise<ConversationRecord | null> {
+  if (participants.length > 0) {
+    await db
+      .insert(conversationParticipants)
+      .values(
+        participants.map((participant) => ({
+          id: uuidv7(),
+          conversationId,
+          userId: participant.userId,
+          role: participant.role,
+        })),
+      )
+      .onConflictDoNothing({
+        target: [conversationParticipants.conversationId, conversationParticipants.userId],
+      });
+  }
+
+  const rows = await db
+    .select(CONVERSATION_COLUMNS)
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .limit(1);
+  const hydrated = await hydrate(db, rows);
+  return hydrated[0] ?? null;
+}
+
+/**
+ * Why removal reports an outcome instead of throwing.
+ *
+ * "A group keeps at least two members" is now the deferred constraint trigger,
+ * and the trigger is the ONLY thing that can answer it without the race the
+ * route's in-memory length check had. But it is still a rule the caller has to
+ * report as a 400 rather than a 500, so the one constraint that means exactly
+ * that is translated here — by NAME, via `constraintNameOf`, never by matching
+ * the driver's message text, which would pass for a different constraint on the
+ * same statement.
+ */
+export type RemoveParticipantOutcome =
+  | { readonly outcome: "removed" }
+  | { readonly outcome: "not_a_participant" }
+  | { readonly outcome: "would_leave_too_few" };
+
+export async function removeParticipant(
+  db: AlloDatabase,
+  conversationId: string,
+  userId: string,
+): Promise<RemoveParticipantOutcome> {
+  try {
+    const removed = await db
+      .delete(conversationParticipants)
+      .where(
+        and(
+          eq(conversationParticipants.conversationId, conversationId),
+          eq(conversationParticipants.userId, userId),
+        ),
+      )
+      .returning({ id: conversationParticipants.id });
+
+    return removed.length > 0 ? { outcome: "removed" } : { outcome: "not_a_participant" };
+  } catch (error: unknown) {
+    if (constraintNameOf(error) === "conversations_participant_count_check") {
+      return { outcome: "would_leave_too_few" };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Archive or unarchive, for one person only.
+ *
+ * `archivedAt` rather than a boolean because the timestamp answers "since when"
+ * for free and still reads as a flag. Returns whether the caller is actually a
+ * participant, which is the 404 the route needs.
+ */
+export async function setConversationArchived(
+  db: AlloDatabase,
+  conversationId: string,
+  userId: string,
+  archived: boolean,
+): Promise<boolean> {
+  const rows = await db
+    .update(conversationParticipants)
+    .set({ archivedAt: archived ? new Date() : null })
+    .where(
+      and(
+        eq(conversationParticipants.conversationId, conversationId),
+        eq(conversationParticipants.userId, userId),
+      ),
+    )
+    .returning({ id: conversationParticipants.id });
+  return rows.length > 0;
+}
+
+/**
+ * Mark a conversation read: both halves of what Mongo did in two places — the
+ * participant's `lastReadAt` and the `unreadCounts` entry, which now live on the
+ * same row and therefore cannot disagree.
+ */
+export async function markConversationRead(
+  db: AlloDatabase,
+  conversationId: string,
+  userId: string,
+): Promise<boolean> {
+  const rows = await db
+    .update(conversationParticipants)
+    .set({ lastReadAt: new Date(), unreadCount: 0 })
+    .where(
+      and(
+        eq(conversationParticipants.conversationId, conversationId),
+        eq(conversationParticipants.userId, userId),
+      ),
+    )
+    .returning({ id: conversationParticipants.id });
+  return rows.length > 0;
+}

--- a/packages/backend/src/db/messaging/deviceRepository.ts
+++ b/packages/backend/src/db/messaging/deviceRepository.ts
@@ -1,0 +1,412 @@
+/**
+ * The Signal Protocol device registry, as Postgres.
+ *
+ * Ported from what `routes/devices.ts` asks `models/Device.ts` for — eight call
+ * sites, no more.
+ *
+ * ## `deviceId` means two different things and they must not be confused
+ *
+ * `devices.id` is this table's own text primary key. `devices.deviceId` is
+ * SIGNAL's device number, 1-based and unique only WITHIN a user — it is what
+ * every route path parameter carries, and what `device_pre_keys.deviceId` does
+ * NOT reference (that column points at `devices.id`). Every function here takes
+ * the pair `(userId, signalDeviceId)`, because Signal's number alone does not
+ * identify a device.
+ *
+ * ## Protected columns are opted into BY NAME, here
+ *
+ * `devices` registers its three key-material columns and `device_pre_keys`
+ * registers `publicKey`. Handing out public key material IS what a key-exchange
+ * endpoint does, so the selections below name those columns explicitly — the
+ * registry's sanctioned opt-in — and the one projection that must NOT carry them
+ * ({@link listDeviceBundlesForUser}'s caller-facing bundle) is a separate,
+ * narrower selection rather than the same one filtered later.
+ *
+ * ## What replaced `.select("-preKeys")`
+ *
+ * Mongo stored one-time pre-keys as an array on the device and the list route
+ * excluded them by name. They are a child table now, so nothing joins them by
+ * accident: {@link listDevicesForUser} cannot leak them because it never reads
+ * them, and only {@link findDevicePreKeys} and {@link findDevice} do.
+ */
+
+import { and, asc, eq, sql } from "drizzle-orm";
+import { uuidv7, type SelectedRow } from "@oxyhq/db";
+import type { PreKey, SignedPreKey } from "@allo/shared-types";
+import type { AlloDatabase } from "../index";
+import { devicePreKeys, devices } from "../schema/devices";
+
+/**
+ * A device with its key material — the shape both the owner's own views and the
+ * key-exchange views are built from.
+ */
+const DEVICE_COLUMNS = {
+  id: devices.id,
+  userId: devices.userId,
+  deviceId: devices.deviceId,
+  identityKeyPublic: devices.identityKeyPublic,
+  signedPreKeyId: devices.signedPreKeyId,
+  signedPreKeyPublic: devices.signedPreKeyPublic,
+  signedPreKeySignature: devices.signedPreKeySignature,
+  registrationId: devices.registrationId,
+  lastSeen: devices.lastSeen,
+  createdAt: devices.createdAt,
+  updatedAt: devices.updatedAt,
+} as const;
+
+const PRE_KEY_COLUMNS = {
+  keyId: devicePreKeys.keyId,
+  publicKey: devicePreKeys.publicKey,
+} as const;
+
+type DeviceRow = SelectedRow<typeof DEVICE_COLUMNS>;
+
+export interface DeviceRecord {
+  readonly id: string;
+  readonly userId: string;
+  /** Signal's own device number, 1-based. */
+  readonly deviceId: number;
+  readonly identityKeyPublic: string;
+  /** Re-assembled from the three columns the embedded document flattened into. */
+  readonly signedPreKey: SignedPreKey;
+  readonly registrationId: number;
+  readonly lastSeen: Date;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/** A device plus its one-time pre-keys, for the two paths that may see them. */
+export interface DeviceWithPreKeys extends DeviceRecord {
+  readonly preKeys: readonly PreKey[];
+}
+
+/**
+ * What a STRANGER gets for key exchange: no `userId`, no timestamps, no
+ * one-time pre-keys. Mongo spelled it `.select("deviceId identityKeyPublic
+ * signedPreKey registrationId")`, and it is a narrower selection here rather
+ * than a filtered {@link DEVICE_COLUMNS} so the projection cannot silently
+ * widen when a column is added to the table.
+ */
+const DEVICE_BUNDLE_COLUMNS = {
+  id: devices.id,
+  deviceId: devices.deviceId,
+  identityKeyPublic: devices.identityKeyPublic,
+  signedPreKeyId: devices.signedPreKeyId,
+  signedPreKeyPublic: devices.signedPreKeyPublic,
+  signedPreKeySignature: devices.signedPreKeySignature,
+  registrationId: devices.registrationId,
+} as const;
+
+export interface DeviceBundle {
+  readonly id: string;
+  readonly deviceId: number;
+  readonly identityKeyPublic: string;
+  readonly signedPreKey: SignedPreKey;
+  readonly registrationId: number;
+}
+
+function toDeviceRecord(row: DeviceRow): DeviceRecord {
+  return {
+    id: row.id,
+    userId: row.userId,
+    deviceId: row.deviceId,
+    identityKeyPublic: row.identityKeyPublic,
+    signedPreKey: {
+      keyId: row.signedPreKeyId,
+      publicKey: row.signedPreKeyPublic,
+      signature: row.signedPreKeySignature,
+    },
+    registrationId: row.registrationId,
+    lastSeen: row.lastSeen,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toDeviceBundle(row: SelectedRow<typeof DEVICE_BUNDLE_COLUMNS>): DeviceBundle {
+  return {
+    id: row.id,
+    deviceId: row.deviceId,
+    identityKeyPublic: row.identityKeyPublic,
+    signedPreKey: {
+      keyId: row.signedPreKeyId,
+      publicKey: row.signedPreKeyPublic,
+      signature: row.signedPreKeySignature,
+    },
+    registrationId: row.registrationId,
+  };
+}
+
+/**
+ * The caller's own devices, WITHOUT one-time pre-keys.
+ *
+ * Ordered by Signal's device number, as the route did — the numbers are what a
+ * user sees ("this phone is device 2"), so ordering by insertion time would
+ * shuffle a list whose labels are stable.
+ */
+export async function listDevicesForUser(
+  db: AlloDatabase,
+  userId: string,
+): Promise<DeviceRecord[]> {
+  const rows = await db
+    .select(DEVICE_COLUMNS)
+    .from(devices)
+    .where(eq(devices.userId, userId))
+    .orderBy(asc(devices.deviceId));
+  return rows.map(toDeviceRecord);
+}
+
+/** One of the caller's own devices, pre-keys included — `GET /api/devices/:deviceId`. */
+export async function findDevice(
+  db: AlloDatabase,
+  userId: string,
+  signalDeviceId: number,
+): Promise<DeviceWithPreKeys | null> {
+  const rows = await db
+    .select(DEVICE_COLUMNS)
+    .from(devices)
+    .where(and(eq(devices.userId, userId), eq(devices.deviceId, signalDeviceId)))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return null;
+
+  const preKeys = await db
+    .select(PRE_KEY_COLUMNS)
+    .from(devicePreKeys)
+    .where(eq(devicePreKeys.deviceId, row.id))
+    .orderBy(asc(devicePreKeys.keyId));
+
+  return { ...toDeviceRecord(row), preKeys };
+}
+
+/**
+ * Somebody else's devices, as public bundles for key exchange — no one-time
+ * pre-keys, which are handed out one at a time by {@link findDevicePreKeys}.
+ */
+export async function listDeviceBundlesForUser(
+  db: AlloDatabase,
+  userId: string,
+): Promise<DeviceBundle[]> {
+  const rows = await db
+    .select(DEVICE_BUNDLE_COLUMNS)
+    .from(devices)
+    .where(eq(devices.userId, userId))
+    .orderBy(asc(devices.deviceId));
+  return rows.map(toDeviceBundle);
+}
+
+/**
+ * A device's one-time pre-keys.
+ *
+ * `null` distinguishes "no such device" from a device that HAS no pre-keys left
+ * — an exhausted bundle and a wrong device id are different answers, and the
+ * route turns only the first into a 404.
+ */
+export async function findDevicePreKeys(
+  db: AlloDatabase,
+  userId: string,
+  signalDeviceId: number,
+): Promise<PreKey[] | null> {
+  const rows = await db
+    .select({ id: devices.id })
+    .from(devices)
+    .where(and(eq(devices.userId, userId), eq(devices.deviceId, signalDeviceId)))
+    .limit(1);
+
+  const device = rows[0];
+  if (!device) return null;
+
+  return db
+    .select(PRE_KEY_COLUMNS)
+    .from(devicePreKeys)
+    .where(eq(devicePreKeys.deviceId, device.id))
+    .orderBy(asc(devicePreKeys.keyId));
+}
+
+export interface RegisterDeviceInput {
+  readonly userId: string;
+  /** Signal's own device number. */
+  readonly deviceId: number;
+  readonly identityKeyPublic: string;
+  readonly signedPreKey: SignedPreKey;
+  readonly preKeys: readonly PreKey[];
+  readonly registrationId: number;
+}
+
+export interface RegisterDeviceResult {
+  readonly device: DeviceWithPreKeys;
+  /** `true` for a first registration (201), `false` for a re-registration (200). */
+  readonly created: boolean;
+}
+
+/**
+ * Register a device, or re-register an existing one — one statement, no race.
+ *
+ * The route read the device, branched on whether it found one, and then either
+ * inserted or updated. Two registrations of the same device racing there both
+ * saw nothing and both inserted, and the loser got a duplicate-key 409 for a
+ * request that was perfectly valid. `ON CONFLICT (user_id, device_id) DO UPDATE`
+ * has no such window.
+ *
+ * `created` comes from `xmax = 0`, the system column that distinguishes the two
+ * branches of an upsert: it is zero on a row this statement inserted and
+ * non-zero on one it updated. Re-deriving it by comparing `created_at` to
+ * `updated_at` would be a guess, and re-reading first would restore the race
+ * this statement exists to close.
+ *
+ * Pre-keys are REPLACED wholesale, which is what the route's `preKeys = preKeys`
+ * assignment did. That is a genuine part of the contract — a client rotating its
+ * bundle is not merging with what the server held — so the delete and the insert
+ * commit with the device in one transaction, and a failure cannot leave a device
+ * advertising a bundle it no longer has.
+ */
+export async function registerDevice(
+  db: AlloDatabase,
+  input: RegisterDeviceInput,
+): Promise<RegisterDeviceResult> {
+  return db.transaction(async (tx) => {
+    const upserted = await tx
+      .insert(devices)
+      .values({
+        id: uuidv7(),
+        userId: input.userId,
+        deviceId: input.deviceId,
+        identityKeyPublic: input.identityKeyPublic,
+        signedPreKeyId: input.signedPreKey.keyId,
+        signedPreKeyPublic: input.signedPreKey.publicKey,
+        signedPreKeySignature: input.signedPreKey.signature,
+        registrationId: input.registrationId,
+        lastSeen: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [devices.userId, devices.deviceId],
+        set: {
+          identityKeyPublic: input.identityKeyPublic,
+          signedPreKeyId: input.signedPreKey.keyId,
+          signedPreKeyPublic: input.signedPreKey.publicKey,
+          signedPreKeySignature: input.signedPreKey.signature,
+          registrationId: input.registrationId,
+          lastSeen: new Date(),
+        },
+      })
+      .returning({ ...DEVICE_COLUMNS, inserted: sql<boolean>`xmax = 0` });
+
+    const row = upserted[0];
+    if (!row) throw new Error(`Device ${input.userId}/${String(input.deviceId)} produced no row`);
+
+    await tx.delete(devicePreKeys).where(eq(devicePreKeys.deviceId, row.id));
+    if (input.preKeys.length > 0) {
+      await tx.insert(devicePreKeys).values(
+        input.preKeys.map((preKey) => ({
+          id: uuidv7(),
+          deviceId: row.id,
+          keyId: preKey.keyId,
+          publicKey: preKey.publicKey,
+        })),
+      );
+    }
+
+    return {
+      device: { ...toDeviceRecord(row), preKeys: [...input.preKeys] },
+      created: row.inserted,
+    };
+  });
+}
+
+/**
+ * The four fields `PUT /api/devices/:deviceId` may change, each applied only
+ * when the caller sends it.
+ *
+ * `preKeys` is the whole bundle or nothing — `undefined` leaves the stored keys
+ * alone, an array REPLACES them, and an empty array really does mean "I have
+ * none left". That three-way distinction is why this is not a nullable field.
+ */
+export interface DeviceKeysPatch {
+  readonly identityKeyPublic?: string;
+  readonly signedPreKey?: SignedPreKey;
+  readonly registrationId?: number;
+  readonly preKeys?: readonly PreKey[];
+}
+
+/**
+ * Update a device's keys. `lastSeen` moves on every update, as it did before —
+ * the request is itself evidence the device is alive.
+ */
+export async function updateDeviceKeys(
+  db: AlloDatabase,
+  userId: string,
+  signalDeviceId: number,
+  patch: DeviceKeysPatch,
+): Promise<DeviceWithPreKeys | null> {
+  return db.transaction(async (tx) => {
+    const values: {
+      identityKeyPublic?: string;
+      signedPreKeyId?: number;
+      signedPreKeyPublic?: string;
+      signedPreKeySignature?: string;
+      registrationId?: number;
+      lastSeen: Date;
+    } = { lastSeen: new Date() };
+
+    if (patch.identityKeyPublic !== undefined) {
+      values.identityKeyPublic = patch.identityKeyPublic;
+    }
+    if (patch.signedPreKey !== undefined) {
+      values.signedPreKeyId = patch.signedPreKey.keyId;
+      values.signedPreKeyPublic = patch.signedPreKey.publicKey;
+      values.signedPreKeySignature = patch.signedPreKey.signature;
+    }
+    if (patch.registrationId !== undefined) {
+      values.registrationId = patch.registrationId;
+    }
+
+    const rows = await tx
+      .update(devices)
+      .set(values)
+      .where(and(eq(devices.userId, userId), eq(devices.deviceId, signalDeviceId)))
+      .returning(DEVICE_COLUMNS);
+
+    const row = rows[0];
+    if (!row) return null;
+
+    if (patch.preKeys !== undefined) {
+      await tx.delete(devicePreKeys).where(eq(devicePreKeys.deviceId, row.id));
+      if (patch.preKeys.length > 0) {
+        await tx.insert(devicePreKeys).values(
+          patch.preKeys.map((preKey) => ({
+            id: uuidv7(),
+            deviceId: row.id,
+            keyId: preKey.keyId,
+            publicKey: preKey.publicKey,
+          })),
+        );
+      }
+    }
+
+    const preKeys = await tx
+      .select(PRE_KEY_COLUMNS)
+      .from(devicePreKeys)
+      .where(eq(devicePreKeys.deviceId, row.id))
+      .orderBy(asc(devicePreKeys.keyId));
+
+    return { ...toDeviceRecord(row), preKeys };
+  });
+}
+
+/**
+ * Remove a device. Its one-time pre-keys go with it through
+ * `ON DELETE CASCADE`, which is the relationship Mongo's embedded array had by
+ * accident and this schema has on purpose.
+ */
+export async function deleteDevice(
+  db: AlloDatabase,
+  userId: string,
+  signalDeviceId: number,
+): Promise<boolean> {
+  const rows = await db
+    .delete(devices)
+    .where(and(eq(devices.userId, userId), eq(devices.deviceId, signalDeviceId)))
+    .returning({ id: devices.id });
+  return rows.length > 0;
+}

--- a/packages/backend/src/db/messaging/messageRepository.ts
+++ b/packages/backend/src/db/messaging/messageRepository.ts
@@ -1,0 +1,610 @@
+/**
+ * Messages and the per-recipient state hanging off them, as Postgres.
+ *
+ * Ported from what `routes/messages.ts` asks `models/Message.ts` for — fourteen
+ * call sites, no more.
+ *
+ * ## Protected columns are opted into BY NAME, here
+ *
+ * `messages` registers `ciphertext`, `encryptedMedia`, `text` and `media` in
+ * `db/protectedColumns.ts`, and the registry's rule is that a path legitimately
+ * needing one names it explicitly rather than reaching it through a bare
+ * `db.select().from(messages)`. This file is that path — it IS the messaging
+ * service, and the ciphertext is the message — so {@link MESSAGE_COLUMNS} spells
+ * every column out. That is the whole opt-in, and it stays greppable: a reader
+ * asking "who can read ciphertext" finds this constant and nothing else.
+ *
+ * ## The two Mongo `Map`s did NOT have the same semantics, and both are kept
+ *
+ * `readBy.set(userId, new Date())` OVERWROTE the timestamp on every repeat,
+ * while `deliveredTo` was pushed only `if (!includes(userId))` — first write
+ * wins. The port preserves the asymmetry rather than tidying it (see
+ * {@link markMessageRead} and {@link markMessageDelivered}), because "the read
+ * receipt should show when they FIRST read it" is a product change, not a
+ * porting decision, and it is not this change's to make.
+ */
+
+import { and, asc, desc, eq, inArray, isNull, lt, ne, sql } from "drizzle-orm";
+import { uuidv7, type SelectedRow } from "@oxyhq/db";
+import { publicColumns } from "@oxyhq/db/assert";
+import type {
+  EncryptedMediaItem,
+  MediaItem,
+  MessageKind,
+} from "@allo/shared-types";
+import type { AlloDatabase } from "../index";
+import { PROTECTED_COLUMNS } from "../protectedColumns";
+import { conversationParticipants, conversations } from "../schema/conversations";
+import {
+  messageDeliveries,
+  messageReactions,
+  messageReads,
+  messages,
+} from "../schema/messages";
+
+/**
+ * Every column of `messages`, protected ones included and NAMED.
+ *
+ * Written out rather than produced by a helper: the registry's contract is that
+ * opting in "must read differently from an ordinary select", and a helper that
+ * re-included protected columns would make every call site look ordinary again.
+ */
+const MESSAGE_COLUMNS = {
+  id: messages.id,
+  conversationId: messages.conversationId,
+  senderId: messages.senderId,
+  senderDeviceId: messages.senderDeviceId,
+  ciphertext: messages.ciphertext,
+  encryptedMedia: messages.encryptedMedia,
+  encryptionVersion: messages.encryptionVersion,
+  messageType: messages.messageType,
+  text: messages.text,
+  media: messages.media,
+  replyTo: messages.replyTo,
+  fontSize: messages.fontSize,
+  editedAt: messages.editedAt,
+  deletedAt: messages.deletedAt,
+  createdAt: messages.createdAt,
+  updatedAt: messages.updatedAt,
+} as const;
+
+/** None of the three per-recipient tables registers a protected column. */
+const READ_COLUMNS = publicColumns(messageReads, PROTECTED_COLUMNS);
+const DELIVERY_COLUMNS = publicColumns(messageDeliveries, PROTECTED_COLUMNS);
+const REACTION_COLUMNS = publicColumns(messageReactions, PROTECTED_COLUMNS);
+
+type MessageRow = SelectedRow<typeof MESSAGE_COLUMNS>;
+
+/**
+ * A message with the three per-recipient collections folded back in.
+ *
+ * `readBy` and `reactions` are keyed collections rather than rows because that
+ * is what they were before the port — Mongo `Map`s whose keys the unique indexes
+ * now carry — and a reaction bar reads them exactly that way. This is the
+ * opposite of the conversation repository's choice for `unreadCounts` /
+ * `archivedBy`, and the reason differs too: those collapsed ONTO an existing row
+ * that is itself part of the result, whereas these three have no other home.
+ */
+export interface MessageRecord {
+  readonly id: string;
+  readonly conversationId: string;
+  readonly senderId: string;
+  readonly senderDeviceId: number;
+  readonly ciphertext: string | null;
+  readonly encryptedMedia: readonly EncryptedMediaItem[];
+  readonly encryptionVersion: number;
+  readonly messageType: MessageKind;
+  readonly text: string | null;
+  readonly media: readonly MediaItem[];
+  readonly replyTo: string | null;
+  readonly fontSize: number | null;
+  readonly editedAt: Date | null;
+  readonly deletedAt: Date | null;
+  /** userId -> when they read it. */
+  readonly readBy: Readonly<Record<string, Date>>;
+  /** userIds who received it, oldest first. */
+  readonly deliveredTo: readonly string[];
+  /** emoji -> the userIds who reacted with it, oldest first. */
+  readonly reactions: Readonly<Record<string, readonly string[]>>;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * Cross `jsonb`'s `unknown` into the media types.
+ *
+ * The array-ness is guaranteed by `messages_media_is_array_check`, so the guard
+ * is a statement of that invariant rather than a branch anyone expects to take;
+ * it throws instead of coercing, because silently substituting `[]` for a shape
+ * this code did not anticipate would delete a user's media rather than report a
+ * broken row.
+ *
+ * The ELEMENT type is asserted, deliberately. The write path validates every
+ * item before it is stored (`parseMediaItem` / `parseEncryptedMediaItem` in
+ * `routes/messages.ts`), and re-validating on READ would make a legacy row that
+ * predates those parsers unreadable — a new restriction introduced by the port,
+ * of exactly the kind `messages_content_present_check` was written to avoid.
+ */
+function mediaArray<T>(value: unknown, column: string, messageId: string): T[] {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `messages.${column} is not a JSON array on message ${messageId}; ` +
+        "messages_media_is_array_check should have made this unreachable",
+    );
+  }
+  return value as T[];
+}
+
+interface PerRecipientState {
+  readonly readBy: Record<string, Date>;
+  readonly deliveredTo: string[];
+  readonly reactions: Record<string, string[]>;
+}
+
+function emptyState(): PerRecipientState {
+  return { readBy: {}, deliveredTo: [], reactions: {} };
+}
+
+function toMessageRecord(row: MessageRow, state: PerRecipientState): MessageRecord {
+  return {
+    id: row.id,
+    conversationId: row.conversationId,
+    senderId: row.senderId,
+    senderDeviceId: row.senderDeviceId,
+    ciphertext: row.ciphertext,
+    encryptedMedia: mediaArray<EncryptedMediaItem>(row.encryptedMedia, "encrypted_media", row.id),
+    encryptionVersion: row.encryptionVersion,
+    messageType: row.messageType,
+    text: row.text,
+    media: mediaArray<MediaItem>(row.media, "media", row.id),
+    replyTo: row.replyTo,
+    fontSize: row.fontSize,
+    editedAt: row.editedAt,
+    deletedAt: row.deletedAt,
+    readBy: state.readBy,
+    deliveredTo: state.deliveredTo,
+    reactions: state.reactions,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * The three child tables for a whole page of messages, in three queries rather
+ * than three per message. A fifty-message page is the common case, and the N+1
+ * version of this is 150 round trips for one screen.
+ */
+async function loadPerRecipientState(
+  db: AlloDatabase,
+  messageIds: readonly string[],
+): Promise<Map<string, PerRecipientState>> {
+  const byMessage = new Map<string, PerRecipientState>();
+  if (messageIds.length === 0) return byMessage;
+
+  const ids = [...messageIds];
+  for (const id of ids) byMessage.set(id, emptyState());
+
+  const [reads, deliveries, reactions] = await Promise.all([
+    db
+      .select(READ_COLUMNS)
+      .from(messageReads)
+      .where(inArray(messageReads.messageId, ids)),
+    db
+      .select(DELIVERY_COLUMNS)
+      .from(messageDeliveries)
+      .where(inArray(messageDeliveries.messageId, ids))
+      // Mongo's `deliveredTo` was an array appended to in order.
+      .orderBy(asc(messageDeliveries.deliveredAt), asc(messageDeliveries.id)),
+    db
+      .select(REACTION_COLUMNS)
+      .from(messageReactions)
+      .where(inArray(messageReactions.messageId, ids))
+      .orderBy(asc(messageReactions.createdAt), asc(messageReactions.id)),
+  ]);
+
+  for (const read of reads) {
+    const state = byMessage.get(read.messageId);
+    if (state) state.readBy[read.userId] = read.readAt;
+  }
+  for (const delivery of deliveries) {
+    const state = byMessage.get(delivery.messageId);
+    if (state) state.deliveredTo.push(delivery.userId);
+  }
+  for (const reaction of reactions) {
+    const state = byMessage.get(reaction.messageId);
+    if (!state) continue;
+    const existing = state.reactions[reaction.emoji];
+    if (existing) existing.push(reaction.userId);
+    else state.reactions[reaction.emoji] = [reaction.userId];
+  }
+
+  return byMessage;
+}
+
+async function hydrate(
+  db: AlloDatabase,
+  rows: readonly MessageRow[],
+): Promise<MessageRecord[]> {
+  const state = await loadPerRecipientState(
+    db,
+    rows.map((row) => row.id),
+  );
+  return rows.map((row) => toMessageRecord(row, state.get(row.id) ?? emptyState()));
+}
+
+export interface ListMessagesInput {
+  readonly conversationId: string;
+  readonly limit: number;
+  /** Exclusive upper bound on `createdAt`, for "load older". */
+  readonly before?: Date;
+}
+
+/**
+ * A page of a conversation's messages, oldest-first.
+ *
+ * The SQL orders NEWEST first because the page wanted is the most recent `limit`
+ * before the cursor, and the result is then reversed for the caller — which is
+ * what the route did by hand with `messages.reverse()`.
+ *
+ * `id` is a tiebreaker the Mongo query did not have. Two messages sharing a
+ * `createdAt` had no defined order there, so a paging client could see one twice
+ * and never see the other; both id shapes this schema stores are time-ordered
+ * (uuid v7, and an ObjectId hex whose leading bytes are a timestamp), so
+ * ordering by it after `createdAt` is stable and agrees with the primary sort.
+ */
+export async function listConversationMessages(
+  db: AlloDatabase,
+  input: ListMessagesInput,
+): Promise<MessageRecord[]> {
+  const rows = await db
+    .select(MESSAGE_COLUMNS)
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, input.conversationId),
+        // Mongo asked for `deletedAt: {$exists: false}`; a soft-deleted message
+        // is excluded, not returned tombstoned.
+        isNull(messages.deletedAt),
+        input.before ? lt(messages.createdAt, input.before) : undefined,
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(input.limit);
+
+  const hydrated = await hydrate(db, rows);
+  return hydrated.reverse();
+}
+
+/**
+ * One message by id, soft-deleted ones included.
+ *
+ * `Message.findById` did not filter on `deletedAt`, and three routes rely on
+ * that: they fetch the message to learn its `conversationId` before deciding
+ * whether the caller may see it at all.
+ */
+export async function findMessageById(
+  db: AlloDatabase,
+  messageId: string,
+): Promise<MessageRecord | null> {
+  const rows = await db
+    .select(MESSAGE_COLUMNS)
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .limit(1);
+  const hydrated = await hydrate(db, rows);
+  return hydrated[0] ?? null;
+}
+
+export interface CreateMessageInput {
+  readonly conversationId: string;
+  readonly senderId: string;
+  readonly senderDeviceId: number;
+  readonly ciphertext?: string | null;
+  readonly encryptedMedia?: readonly EncryptedMediaItem[];
+  readonly encryptionVersion?: number;
+  readonly messageType: MessageKind;
+  readonly text?: string | null;
+  readonly media?: readonly MediaItem[];
+  readonly replyTo?: string | null;
+  readonly fontSize?: number | null;
+  /**
+   * The conversation-list preview.
+   *
+   * The CALLER composes it, because what a preview may contain is a privacy
+   * decision rather than a storage one: an encrypted message stores a
+   * placeholder and never its plaintext. A repository that derived this would be
+   * deciding that policy for every future caller.
+   */
+  readonly lastMessagePreview: string | null;
+}
+
+/**
+ * Send a message: the row, the sender's own delivery receipt, the conversation
+ * preview and everyone else's unread count — in ONE transaction.
+ *
+ * Mongo did these as two independent saves, so a failure between them left a
+ * stored message the conversation list never showed. They commit together here.
+ *
+ * The unread increment is `unread_count = unread_count + 1` IN SQL rather than a
+ * read-modify-write, and it is worth being precise about what that buys, because
+ * the obvious answer is wrong. It is NOT needed to make two concurrent SENDS
+ * safe: both transactions update the conversation row first, so the second
+ * blocks there until the first commits, and a read-modify-write would reach the
+ * same total. Mutation-tested — replacing this with a select-then-update leaves
+ * the concurrent-send case green.
+ *
+ * What it actually protects is a writer that touches the PARTICIPANT row without
+ * touching the conversation row, which is exactly `markConversationRead`. A
+ * read-modify-write reads the backlog, blocks on the row lock, and then writes
+ * `stale + 1` over the zero a reader just committed — the badge reappears on a
+ * conversation the user has read. Evaluated in SQL, the addition re-reads the
+ * committed value and the receipt survives.
+ */
+export async function createMessage(
+  db: AlloDatabase,
+  input: CreateMessageInput,
+): Promise<MessageRecord> {
+  const messageId = uuidv7();
+
+  return db.transaction(async (tx) => {
+    const inserted = await tx
+      .insert(messages)
+      .values({
+        id: messageId,
+        conversationId: input.conversationId,
+        senderId: input.senderId,
+        senderDeviceId: input.senderDeviceId,
+        ciphertext: input.ciphertext ?? null,
+        encryptedMedia: input.encryptedMedia ? [...input.encryptedMedia] : [],
+        encryptionVersion: input.encryptionVersion ?? 1,
+        messageType: input.messageType,
+        text: input.text ?? null,
+        media: input.media ? [...input.media] : [],
+        replyTo: input.replyTo ?? null,
+        fontSize: input.fontSize ?? null,
+      })
+      .returning(MESSAGE_COLUMNS);
+
+    const row = inserted[0];
+    if (!row) throw new Error(`Message ${messageId} produced no row on insert`);
+
+    // Mongo created the message with `deliveredTo: [senderId]` — a sender has by
+    // definition received their own message.
+    await tx.insert(messageDeliveries).values({
+      id: uuidv7(),
+      messageId,
+      userId: input.senderId,
+    });
+
+    // The message's own `created_at` rather than a second `new Date()`: the
+    // preview's timestamp IS the message's, and two clocks read moments apart
+    // can only disagree.
+    await tx
+      .update(conversations)
+      .set({
+        lastMessageAt: row.createdAt,
+        lastMessageText: input.lastMessagePreview,
+        lastMessageSenderId: input.senderId,
+        lastMessageTimestamp: row.createdAt,
+      })
+      .where(eq(conversations.id, input.conversationId));
+
+    await tx
+      .update(conversationParticipants)
+      .set({ unreadCount: sql`${conversationParticipants.unreadCount} + 1` })
+      .where(
+        and(
+          eq(conversationParticipants.conversationId, input.conversationId),
+          ne(conversationParticipants.userId, input.senderId),
+        ),
+      );
+
+    return toMessageRecord(row, {
+      readBy: {},
+      deliveredTo: [input.senderId],
+      reactions: {},
+    });
+  });
+}
+
+export interface EditMessageInput {
+  readonly messageId: string;
+  /** The sender, as the OWNERSHIP predicate — never taken from the row. */
+  readonly senderId: string;
+  readonly text: string;
+}
+
+/**
+ * Edit a message's text.
+ *
+ * The ownership and not-deleted conditions are in the UPDATE's own `WHERE`, so
+ * there is no window between checking and writing: Mongo read the document,
+ * mutated it and saved, which let a delete land in between and resurrect the
+ * message's text. `null` means no row matched — the route's single 404 for "no
+ * such message", "not yours" and "already deleted", which deliberately tells an
+ * unauthorized caller nothing about which one it was.
+ */
+export async function editMessageText(
+  db: AlloDatabase,
+  input: EditMessageInput,
+): Promise<MessageRecord | null> {
+  const rows = await db
+    .update(messages)
+    .set({ text: input.text, editedAt: new Date() })
+    .where(
+      and(
+        eq(messages.id, input.messageId),
+        eq(messages.senderId, input.senderId),
+        isNull(messages.deletedAt),
+      ),
+    )
+    .returning(MESSAGE_COLUMNS);
+
+  const hydrated = await hydrate(db, rows);
+  return hydrated[0] ?? null;
+}
+
+export interface DeletedMessage {
+  readonly id: string;
+  /** The room the caller has to emit the deletion to. */
+  readonly conversationId: string;
+}
+
+/**
+ * Soft-delete a message. Same single-statement ownership check as
+ * {@link editMessageText}, and `isNull(deletedAt)` is what makes a second delete
+ * a 404 rather than a silent success that moves the tombstone's timestamp.
+ */
+export async function softDeleteMessage(
+  db: AlloDatabase,
+  messageId: string,
+  senderId: string,
+): Promise<DeletedMessage | null> {
+  const rows = await db
+    .update(messages)
+    .set({ deletedAt: new Date() })
+    .where(
+      and(
+        eq(messages.id, messageId),
+        eq(messages.senderId, senderId),
+        isNull(messages.deletedAt),
+      ),
+    )
+    .returning({ id: messages.id, conversationId: messages.conversationId });
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Record a read receipt.
+ *
+ * `ON CONFLICT ... DO UPDATE` on `message_reads_message_id_user_id_key`. The
+ * conflict target is the idempotency: the Map's key gave it for free, and
+ * without the index this would be the read-then-write that lets two concurrent
+ * receipts insert two rows for one person.
+ *
+ * The timestamp is OVERWRITTEN on a repeat, which is what
+ * `readBy.set(userId, new Date())` did. Keeping the FIRST read instant is very
+ * likely what a receipt should mean, and switching to `DO NOTHING` is the whole
+ * change — but it is a product decision about what the ✓✓ claims, so the port
+ * reproduces the source and leaves it visible here rather than altering it in
+ * passing.
+ */
+export async function markMessageRead(
+  db: AlloDatabase,
+  messageId: string,
+  userId: string,
+): Promise<MessageRecord | null> {
+  const readAt = new Date();
+  await db
+    .insert(messageReads)
+    .values({ id: uuidv7(), messageId, userId, readAt })
+    .onConflictDoUpdate({
+      target: [messageReads.messageId, messageReads.userId],
+      set: { readAt },
+    });
+
+  return findMessageById(db, messageId);
+}
+
+/**
+ * Record a delivery receipt.
+ *
+ * `DO NOTHING`, not `DO UPDATE` — and the difference from
+ * {@link markMessageRead} is inherited, not invented: Mongo pushed onto
+ * `deliveredTo` only `if (!deliveredTo.includes(userId))`, so the FIRST delivery
+ * instant is the one it kept.
+ */
+export async function markMessageDelivered(
+  db: AlloDatabase,
+  messageId: string,
+  userId: string,
+): Promise<MessageRecord | null> {
+  await db
+    .insert(messageDeliveries)
+    .values({ id: uuidv7(), messageId, userId })
+    .onConflictDoNothing({
+      target: [messageDeliveries.messageId, messageDeliveries.userId],
+    });
+
+  return findMessageById(db, messageId);
+}
+
+export interface ReactionToggle {
+  /** The caller's state AFTER the toggle — what the route reports and emits. */
+  readonly hasReacted: boolean;
+  readonly reactions: Readonly<Record<string, readonly string[]>>;
+}
+
+/**
+ * Add the caller's reaction, or take it away if it is already there.
+ *
+ * Mongo read the whole `Map<emoji, userId[]>`, edited it in memory and saved it
+ * back, so two people reacting at once wrote over each other — one reaction
+ * simply vanished, and the Map could also hold the same user twice within one
+ * emoji. Deleting or inserting a single row against
+ * `message_reactions_message_id_user_id_emoji_key` has neither problem.
+ *
+ * The whole toggle plus the re-read run in one transaction so the returned map
+ * is the state this toggle produced, not one a concurrent reaction has already
+ * moved past.
+ *
+ * ## One divergence from Mongo, and it is forced rather than chosen
+ *
+ * Removing the LAST reactor for an emoji drops that emoji's key from the map
+ * entirely. Mongo kept it, because the route removed a reaction with
+ * `reactions.set(emoji, filtered)` and never `reactions.delete(emoji)` — so an
+ * emoji that had ever been used stayed in the document forever as `[]`, and
+ * `save()` wrote that empty array back.
+ *
+ * There is no row that could reproduce it here. The table's grain is
+ * (message, user, emoji), so "this emoji has zero reactors" has nothing to be a
+ * row OF — carrying it would take a second table or a tombstone column existing
+ * solely to preserve an artefact of how the Map happened to be edited. The
+ * behaviour is pinned by a test rather than left to be rediscovered, and a
+ * client must treat a missing key and an empty array as the same thing.
+ */
+export async function toggleReaction(
+  db: AlloDatabase,
+  messageId: string,
+  userId: string,
+  emoji: string,
+): Promise<ReactionToggle> {
+  return db.transaction(async (tx) => {
+    const removed = await tx
+      .delete(messageReactions)
+      .where(
+        and(
+          eq(messageReactions.messageId, messageId),
+          eq(messageReactions.userId, userId),
+          eq(messageReactions.emoji, emoji),
+        ),
+      )
+      .returning({ id: messageReactions.id });
+
+    const hasReacted = removed.length === 0;
+    if (hasReacted) {
+      await tx
+        .insert(messageReactions)
+        .values({ id: uuidv7(), messageId, userId, emoji })
+        .onConflictDoNothing({
+          target: [messageReactions.messageId, messageReactions.userId, messageReactions.emoji],
+        });
+    }
+
+    const rows = await tx
+      .select(REACTION_COLUMNS)
+      .from(messageReactions)
+      .where(eq(messageReactions.messageId, messageId))
+      .orderBy(asc(messageReactions.createdAt), asc(messageReactions.id));
+
+    const reactions: Record<string, string[]> = {};
+    for (const row of rows) {
+      const existing = reactions[row.emoji];
+      if (existing) existing.push(row.userId);
+      else reactions[row.emoji] = [row.userId];
+    }
+
+    return { hasReacted, reactions };
+  });
+}


### PR DESCRIPTION
The messaging domain of the Mongo → Postgres port: `conversations`,
`conversation_participants`, `messages`, `message_reads`, `message_deliveries`,
`message_reactions`, `devices`, `device_pre_keys`.

Nothing imports these yet, deliberately. Every function was derived by reading
what `routes/conversations.ts` (10 model call sites), `routes/messages.ts` (14)
and `routes/devices.ts` (8) actually ask for — there is no generic CRUD surface,
because a function nobody calls is a function nothing pins. No route, service or
model is touched, so the switch PR's diff can read as "call sites move" rather
than "call sites move and the repositories changed under them".

## The schema dictated the API shape, not the other way round

`createConversation` takes the participants **with** the conversation because
`conversations_participant_count_check` is `DEFERRABLE INITIALLY DEFERRED` and
judged at COMMIT. A repository that could insert a conversation alone would be
one whose every use fails at commit, so the transaction is part of the contract
rather than an implementation detail.

`removeParticipant` returns `removed | not_a_participant | would_leave_too_few`
instead of throwing, translating that same trigger by **constraint name** through
`constraintNameOf`. This is where the "never a message regex" rule earns itself:
the two triggers are called `conversations_participant_count_check` and
`conversation_participants_count_check`, so a regex over the driver's text would
happily pass for the wrong one. A mutation pointing the check at the sibling name
fails the suite, and the failure output names the real constraint.

## The three Mongo `Map`s are not all treated the same, on purpose

`readBy`, `reactions` and `deliveredTo` come back as keyed collections, because
their child tables have no other home and a reaction bar reads them that way.
`unreadCounts` and `archivedBy` are **not** re-derived: they collapsed onto the
participant row, which is what makes "a user who archived a conversation they are
not in" unrepresentable, and re-assembling them here would un-port that decision.
Whether the HTTP layer still emits those two aggregates is a serialization
question, answered where the DTO is built.

## Behaviour preserved, including where it is untidy

- Read receipts **overwrite** their timestamp; delivery receipts **keep the
  first**. That asymmetry is real in the Mongoose route (`readBy.set(...)` versus
  `if (!deliveredTo.includes(...))`). Keeping only the first read instant is
  probably what a ✓✓ should mean, but that is a product decision and not this
  change's to make.
- `lastMessageAt` sorts `NULLS LAST`, because Mongo sorts a missing value lowest
  and Postgres defaults `desc` to NULLS FIRST. Left alone, every user's list
  would open on the empty conversations they once created.
- Offset paging is kept as `.skip` had it; keyset paging is a client contract
  change, not a porting detail.
- One divergence is **forced** rather than chosen, and is documented and pinned:
  removing the last reactor drops that emoji's key, where Mongo kept it as `[]`
  forever. The table's grain is (message, user, emoji), so "zero reactors" has no
  row to be.

## Behaviour improved where the database can now carry it

Sending a message is one transaction over four writes instead of two independent
saves. Ownership predicates live in the `UPDATE`'s own `WHERE`, closing the
read-mutate-save window that let a delete land mid-edit and resurrect a message.
Add/register/react converge on unique indexes instead of read-then-write, so the
device-registration race that returned a 409 for a valid request is gone.

## What the mutation testing actually found

Four mutations. Three were killed immediately. **One survived, and it was the
useful one**: the concurrent-send test could not tell the SQL-side
`unread_count + 1` from a read-modify-write, because both sends update the
conversation row first and serialize there anyway. The claim was wrong, not the
code. The doc comment now states what the SQL-side increment really buys — safety
against `markConversationRead`, which touches the participant row *without*
touching the conversation row — and a new interleaving test holds that row locked
so the send blocks between reading and writing. It fails at `6` versus `1` against
a read-modify-write, and carries an anti-vacuity guard that throws if the
contention it depends on never occurs.

This is the third independent instance of that class in this port; `CONVENTIONS.md`
on `main` now records the same lesson from two other domains.

## Verification

41 cases against a real Postgres server — a deferred constraint trigger, `ON
CONFLICT` against real unique indexes, `xmax`, `nulls last`, two levels of
`ON DELETE CASCADE` and lock contention are all properties only a server has.
Full backend suite green at **755 tests / 36 files** after rebasing onto
`0868baf`, `bun run typecheck:backend` and `build:backend` clean, `bun.lock`
byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
