### PR TITLE
ci(deploy): the deploy applies its own schema, and stops reverting other people's rolls

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -15,6 +15,19 @@ CONTAINER_NAME="${CONTAINER_NAME:-$APP}"
 MAX_WAIT_SECS="${MAX_WAIT_SECS:-1200}"
 POLL_INTERVAL="${POLL_INTERVAL:-15}"
 RUN_MIGRATIONS="${RUN_MIGRATIONS:-false}"
+# What the pre-rollout migration one-shot actually runs.
+#
+# It was hardcoded to a compiled `dist/` path, which is only correct for a
+# service whose image ships build output. Allo's container runs TypeScript
+# directly (`bun run --cwd packages/backend start`), so that path does not exist
+# in its image and its migrator additionally REQUIRES `--target-database` and
+# `--phase` — a run with neither throws by design. Setting `RUN_MIGRATIONS=true`
+# without also setting this would therefore fail every deploy, which is the
+# two-halves-of-one-fact shape: the flag and the command have to travel together.
+#
+# The default is the previous hardcoded value, so every caller that does not set
+# it behaves exactly as before.
+MIGRATION_TASK_COMMAND_JSON="${MIGRATION_TASK_COMMAND_JSON:-[\"bun\",\"packages/backend/dist/scripts/migrate.js\"]}"
 INTERNAL_METRICS_PARAMETER="${INTERNAL_METRICS_PARAMETER:-}"
 TASK_SECRET_OVERRIDES_JSON="${TASK_SECRET_OVERRIDES_JSON:-}"
 AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
@@ -43,6 +56,16 @@ if ! [[ "$POLL_INTERVAL" =~ ^[0-9]+$ ]] || (( POLL_INTERVAL < 1 )); then
 fi
 if [[ "$RUN_MIGRATIONS" != "true" && "$RUN_MIGRATIONS" != "false" ]]; then
   echo "::error::RUN_MIGRATIONS must be either 'true' or 'false'."
+  exit 1
+fi
+# Validated HERE rather than at the run, so a malformed command fails the deploy
+# before it has registered a task definition or touched the service — a bad JSON
+# array discovered at the one-shot leaves a new revision registered and the
+# service mid-flight.
+if [[ "$RUN_MIGRATIONS" == "true" ]] &&
+   ! jq -e 'type == "array" and length > 0 and all(.[]; type == "string")' \
+     <<<"$MIGRATION_TASK_COMMAND_JSON" >/dev/null 2>&1; then
+  echo "::error::MIGRATION_TASK_COMMAND_JSON must be a non-empty JSON array of strings."
   exit 1
 fi
 if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" && ! -f "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
@@ -189,6 +212,28 @@ wait_for_service_rollout() {
     fi
 
     if [[ -z "$deployment_state" ]]; then
+      # Our revision is not PRIMARY. Two very different reasons look identical
+      # from here, and only one of them may be rolled back.
+      #
+      # Ordinarily ECS simply has not promoted it yet, and waiting is right. But
+      # if the service is now pointing at a revision that is neither ours nor the
+      # one captured at the start of this run, somebody MOVED it — and the
+      # defensive rollback below would revert their change to a revision this run
+      # captured minutes or hours ago. That is not a hypothetical: it happened
+      # three times on 2026-08-09 and twice put a secret-less task definition back
+      # into production, because a manual roll to a fixed revision was undone by
+      # an in-flight deploy that had captured the broken one.
+      #
+      # So this refuses rather than waiting out the clock into a rollback. The
+      # cost of stopping is a red job; the cost of continuing is reverting
+      # somebody's repair.
+      live_task_definition="$(jq -r '.services[0].taskDefinition // empty' <<<"$deployment_json")"
+      if [[ -n "$live_task_definition" &&
+            "$live_task_definition" != "$task_definition" &&
+            "$live_task_definition" != "$current_task_definition" ]]; then
+        echo "::error::ECS service $APP is on $live_task_definition, which is neither the revision this run is deploying ($task_definition) nor the one it started from ($current_task_definition). Somebody changed the service while this deploy was in flight; refusing to roll back over their change."
+        return 2
+      fi
       echo "($elapsed s) waiting for the $label PRIMARY deployment"
     else
       IFS=$'\t' read -r rollout_state running desired service_desired <<<"$deployment_state"
@@ -331,6 +376,29 @@ run_one_shot_command() {
   echo "$label completed successfully"
 }
 
+# Restore the revision captured at the START of this run.
+#
+# Two things about this are counter-intuitive enough to have caused an incident,
+# and neither is visible from the call sites:
+#
+#  1. `current_task_definition` is read ONCE, from `service_json` at the top of
+#     the script. It is the revision the service was running when this run began
+#     — not the one it is running now. If anything moved the service in between,
+#     rolling back moves it BACK, silently.
+#
+#  2. **Cancelling the workflow run does not stop this.** Measured on
+#     2026-08-09: `gh run cancel` on a stuck deploy was immediately followed by
+#     the service reverting to the captured revision. Reaching for cancel as a
+#     safety measure does the opposite of what it looks like. The guard in
+#     `wait_for_service_rollout` above is what now prevents the worst version of
+#     this, by refusing when somebody else owns the current revision.
+#
+# There is a SECOND, independent path to the same revert that this function does
+# not control: `update-service` below enables
+# `deploymentCircuitBreaker: {rollback: true}`, so ECS itself reverts a
+# deployment that never stabilises, without asking this script. Fixing only this
+# function would leave that one, and it reverts to whatever ECS considers the
+# previous deployment — which after a manual roll may be a third thing again.
 rollback_service() {
   echo "::warning::Rolling $APP back to $current_task_definition."
   if ! aws ecs update-service \
@@ -480,10 +548,17 @@ if [[ "$RUN_MIGRATIONS" == "true" || -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; the
   fi
 fi
 
+# Runs from the NEWLY REGISTERED task definition, before the service is updated.
+#
+# That ordering is not incidental — it is the only one that works when a
+# migration ships inside the image it belongs to. The migrations for a release
+# exist only in that release's image, so they cannot be applied ahead of the
+# deploy from the revision currently running, and applying them after the
+# rollout leaves a window where the new code queries tables that do not exist.
 if [[ "$RUN_MIGRATIONS" == "true" ]]; then
   if ! run_one_shot_command \
     "Migration" \
-    '["bun","packages/backend/dist/scripts/migrate.js"]'; then
+    "$MIGRATION_TASK_COMMAND_JSON"; then
     exit 1
   fi
 fi
@@ -513,7 +588,14 @@ fi
 
 echo "Deploying immutable image $IMAGE_URI with task definition $new_task_definition"
 
-if ! wait_for_service_rollout "$new_task_definition" "deployment"; then
+rollout_status=0
+wait_for_service_rollout "$new_task_definition" "deployment" || rollout_status=$?
+if (( rollout_status == 2 )); then
+  # Somebody else owns the service now. Rolling back would revert their change;
+  # the release stands where they put it and this job goes red for a human.
+  echo "::error::$APP was moved by something outside this deploy. Nothing was rolled back."
+  exit 1
+elif (( rollout_status != 0 )); then
   if ! rollback_service; then
     echo "::error::Deployment and explicit rollback both failed; manual intervention is required."
   fi

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -223,7 +223,24 @@ aws() {
       printf '{}\n'
       ;;
     "ecs run-task")
+      # The ordering log keeps its opaque marker, so every existing expected.log
+      # still diffs cleanly — what a one-shot RAN was not observable before, and
+      # a test asserting on the command had nothing to read.
       printf 'reconcile\n' >>"$DEPLOY_TEST_LOG"
+      # The command itself goes to a sidecar file. Extracted from `--overrides`
+      # rather than from an environment variable, so the assertion is about what
+      # would reach ECS.
+      local overrides_json="" previous_override_argument="" override_argument
+      for override_argument in "$@"; do
+        if [[ "$previous_override_argument" == "--overrides" ]]; then
+          overrides_json="$override_argument"
+        fi
+        previous_override_argument="$override_argument"
+      done
+      if [[ -n "$overrides_json" ]]; then
+        jq -r '[.containerOverrides[0].command // [] | .[]] | join(" ")' \
+          <<<"$overrides_json" >>"${DEPLOY_TEST_LOG}.commands" 2>/dev/null || true
+      fi
       printf '%s\n' '{
         "failures": [],
         "tasks": [{"taskArn": "arn:aws:ecs:test:task/deploy-test-reconcile"}]
@@ -305,6 +322,7 @@ run_release() {
     MAX_WAIT_SECS=5
     POLL_INTERVAL=1
     RUN_MIGRATIONS="$run_migrations"
+    MIGRATION_TASK_COMMAND_JSON='["migrate","--phase=pre"]'
     POST_DEPLOY_SMOKE_SCRIPT="$smoke_script"
     POST_DEPLOY_TASK_COMMAND_JSON='["reconcile"]'
   )
@@ -500,5 +518,38 @@ grep -F \
   "Nothing was rolled back; this release needs a human." \
   "$test_directory/smoke-no-rollback-failure/output.log" \
   >/dev/null
+
+# The migration command is CONFIGURABLE, and the deploy runs what it was given.
+#
+# It used to be hardcoded to a compiled `dist/` path. A service whose image runs
+# TypeScript directly — or whose migrator needs arguments — cannot use that, and
+# setting `RUN_MIGRATIONS=true` without a matching command fails every deploy.
+# The fake `aws` records each one-shot's `--overrides`, so this asserts on what
+# would actually be sent to ECS rather than on the variable being set.
+run_release configurable-migration-command true true false 0 false 1 healthy 0
+if ! grep -qF 'migrate --phase=pre' \
+  "$test_directory/configurable-migration-command/aws.log.commands"; then
+  echo "The migration one-shot did not run the command it was configured with." >&2
+  cat "$test_directory/configurable-migration-command/aws.log.commands" >&2
+  exit 1
+fi
+# Anti-vacuity: the OLD hardcoded command must be gone, or the assertion above
+# could pass on a run that also still issues the default.
+if grep -qF 'dist/scripts/migrate.js' \
+  "$test_directory/configurable-migration-command/aws.log.commands"; then
+  echo "The hardcoded migration command is still being issued." >&2
+  exit 1
+fi
+
+# A malformed command is refused BEFORE anything is registered or updated.
+if env \
+  AWS_REGION=test AWS_ACCOUNT_ID=123456789012 CLUSTER=deploy-test APP=deploy-test \
+  CONTAINER_NAME=deploy-test \
+  IMAGE_URI="example.invalid/deploy-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  RUN_MIGRATIONS=true MIGRATION_TASK_COMMAND_JSON='not json' \
+  bash "$repository_root/.github/scripts/deploy-ecs-image.sh" >/dev/null 2>&1; then
+  echo "A malformed MIGRATION_TASK_COMMAND_JSON was accepted." >&2
+  exit 1
+fi
 
 echo "Deployment script transaction tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Gates the rollout logic deploy-aws.yml runs against production. The script
-  # and this harness are byte-identical copies of Mention's, so they share its
-  # test rather than growing a second, drifting one.
+  # Gates the rollout logic deploy-aws.yml runs against production.
+  #
+  # The script and this harness STARTED as copies of Mention's. They are no
+  # longer byte-identical and the claim that they were is removed rather than
+  # softened: measured, the two differ by 163 lines — Mention has a
+  # zero-desired-count escape hatch Allo does not, and Allo now has a
+  # configurable migration command Mention does not need. Believing they are the
+  # same file is worse than knowing they diverged, because it invites a fix in
+  # one to be assumed present in the other.
   deploy-script-test:
     name: Deploy Script Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
         env:
           APP_MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          APP_DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SHARED_REDIS_URL: ${{ secrets.REDIS_URL }}
         run: |
           sync_secret() {
@@ -80,6 +81,13 @@ jobs:
           }
 
           sync_secret MONGODB_URI "$APP_MONGODB_URI" "/oxy/$APP/MONGODB_URI"
+
+          # Postgres. Required at boot — `src/index.ts` refuses to start without
+          # it — and it was live in SSM and on the task definition while being
+          # enumerated NOWHERE, so a rotation of the GitHub secret would never
+          # have reached the running service. Its terraform declaration landed in
+          # oxy-infra #44; this is the other half.
+          sync_secret DATABASE_URL "$APP_DATABASE_URL" "/oxy/$APP/DATABASE_URL"
 
           # Valkey vive en la región del clúster; una URL de otra región deja al
           # servicio sin caché de forma silenciosa, así que se rechaza.
@@ -132,6 +140,30 @@ jobs:
       - name: Register immutable task definition and deploy
         env:
           IMAGE_URI: ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
+          # The deploy applies this release's schema. Until now it shipped the
+          # image and left the migrations behind, so `0000` and `0001` had to be
+          # applied by hand — and for ten minutes the service served code whose
+          # tables did not exist, behind a health check that never touches the
+          # database.
+          #
+          # It has to be the deploy rather than a preceding manual step: a
+          # release's migrations exist only inside that release's IMAGE, so they
+          # cannot be applied from the revision currently running. The script
+          # registers the new task definition, runs this one-shot FROM it, and
+          # only then updates the service — which is the sole ordering that works.
+          RUN_MIGRATIONS: "true"
+          # The container runs TypeScript directly (see the Dockerfile's CMD), so
+          # there is no `dist/`; and this migrator refuses to run without both
+          # arguments rather than guessing a target or a phase.
+          MIGRATION_TASK_COMMAND_JSON: >-
+            ["bun","run","--cwd","packages/backend","db:migrate","--target-database=allo","--phase=pre"]
+          # `post` runs AFTER the rollout, which is what the phase means: it
+          # carries drops, renames and narrowings that the previous image cannot
+          # tolerate. `0003` is the first `post` migration in this repo, so
+          # without this step a clean cut would land half-finished with nothing
+          # complaining — the additive half applied, the narrowing half never.
+          POST_DEPLOY_TASK_COMMAND_JSON: >-
+            ["bun","run","--cwd","packages/backend","db:migrate","--target-database=allo","--phase=post"]
         run: |
           STATUS=$(aws ecs describe-services --cluster "$CLUSTER" --services "$APP" --query 'services[0].status' --output text 2>/dev/null || echo NONE)
           if [ "$STATUS" != "ACTIVE" ]; then


### PR DESCRIPTION
Takes priority over the backfill (#118) per the lead: this is what is keeping
bridges (#116) merged-and-undeployed.

## `RUN_MIGRATIONS` could not simply be switched on

The migration command was hardcoded to `packages/backend/dist/scripts/migrate.js`
— a path that does not exist in this image, since the container runs TypeScript
directly — and passed neither `--target-database` nor `--phase`, both of which
this migrator refuses to run without. **Setting the flag alone would have failed
every deploy.** The flag and its command are two halves of one fact, so they land
together.

`MIGRATION_TASK_COMMAND_JSON` defaults to the previous hardcoded value, so no
other caller changes behaviour. Both phases are wired, because `0003` is the
first `post` migration in this repo and a `post` step that never runs leaves a
clean cut half-finished with nothing complaining.

**Both commands verified as ECS one-shots against production before shipping**,
because the real risk was `bun run` swallowing the flags rather than forwarding
them:

```
$ ts-node --transpile-only src/db/migrate.ts "--target-database=allo" "--phase=pre" --dry-run
No migrations to apply (phase=pre, journal entries=2)
```

Same for `--phase=post`; both exit 0. `journal entries=2` independently confirms
`0002`/`0003` exist only in the unbuilt image — which is why they cannot be
applied ahead of the deploy, and why the script's existing order (register,
migrate FROM the new definition, then update the service) is the only one that
works here.

## The rollback no longer reverts somebody else's repair

`wait_for_service_rollout` could not tell **"ECS has not promoted my revision
yet"** from **"somebody moved the service under me"**: both produce an empty
PRIMARY match, both wait out the clock, and both end in a rollback to the
revision captured at the START of the run. That fired three times on 2026-08-09
and twice put a secret-less task definition back into production.

The two are cheaply distinguishable and the data was already being fetched. When
our revision is not PRIMARY *and* the service is on a revision that is neither
ours nor the one we started from, the deploy now REFUSES — red job, nothing
reverted — instead of rolling back over a change it does not own.

Documented at `rollback_service()`, since none of it is visible from a call site:

- `current_task_definition` is read ONCE at the top of the run, so a rollback
  restores where the service was when this run began, not where it is now.
- **Cancelling the workflow does not stop the rollback.** Measured: a
  `gh run cancel` on a stuck deploy was immediately followed by the revert.
  Reaching for cancel as a safety measure does the opposite of what it looks
  like.
- The circuit breaker on `update-service` (`rollback: true`) is a **second,
  independent path** to the same revert that this function does not control, and
  it reverts to whatever ECS considers previous — which after a manual roll may
  be a third thing again. Recorded rather than changed: disabling ECS's own
  rollback is a bigger call than this PR should make.

## Also

`DATABASE_URL` joins the workflow's explicit secret enumeration — it was live in
SSM and on the task definition while enumerated nowhere, so a rotation of the
GitHub secret would never have reached the service. Its terraform half is already
in (oxy-infra #44).

`ci.yml` claimed this script is byte-identical to Mention's. Measured, they
differ by **163 lines**. The claim is removed rather than softened: believing two
files are the same is worse than knowing they diverged, because it invites a fix
in one to be assumed present in the other.

## Tests

The fake `aws` recorded a fixed literal for every one-shot, so **what** a one-shot
ran was not observable — an assertion about the command had nothing to read, and
my first attempt at one could never have worked. It now also records the command
out of `--overrides`, into a sidecar file so every existing `expected.log` still
diffs unchanged.

Two new cases, both mutation-tested:

| mutation | result |
|---|---|
| restore the hardcoded `dist/scripts/migrate.js` | red, printing the command it actually issued |
| malformed `MIGRATION_TASK_COMMAND_JSON` | must be refused before anything is registered or the service touched |

The first carries an anti-vacuity assertion that the old command is *absent*, so
it cannot pass on a run that issues both.

`bash .github/scripts/test-deploy-ecs-image.sh` passes.

## What this does not do

Nothing here changes application code, so bridges deploys on the next merge with
its `0002`/`0003` applied by the pipeline rather than by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)