### PR TITLE
docs: the 503 database guard exists, and covers less than either claim said

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -313,7 +313,7 @@ Only three event categories ever trigger client-side side effects beyond updatin
 | `403` | Authenticated but not allowed (e.g. removing a participant you don't admin) |
 | `404` | Resource not found, or you are not a participant |
 | `429` | Rate limited by `createOxyRateLimit` (`@oxyhq/core/server`), applied per resolved user |
-| `503` | Matrix authentication is temporarily unavailable — retry after `Retry-After`. **Not** returned for database outages: there is no database-availability guard, so a store being unreachable surfaces as a `500`. |
+| `503` | Matrix authentication is temporarily unavailable — retry after `Retry-After`. Also returned by the connect middleware in `server.ts` when the initial database connection cannot be ESTABLISHED (`Database temporarily unavailable`). **Not** returned for an outage that starts after the process has connected: `connectToDatabase()` returns early once connected, so a store that dies mid-life surfaces as a `500`. |
 
 All error bodies are JSON.
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -161,7 +161,11 @@ Allo writes none of its own. `server.ts` applies three middlewares from `@oxyhq/
 - `createOxyRateLimit(oxyClient)` — resolves the session and applies per-user rate limiting in one pass, mounted before the API routers.
 - `createOxyAuthMiddleware(oxyClient)` — described above.
 
-There is **no** database-availability guard, despite `utils/database.ts` still exporting `isDatabaseConnected()` — that function has no callers, and the only 503s the backend returns come from Matrix authentication (`middleware/matrixAuth.ts`) and push. A request that arrives while a store is unreachable fails as a 500, so a client cannot distinguish "retry shortly" from a real fault. Worth fixing when the messaging switch touches `utils/database.ts`, and worth covering both stores rather than only Mongo.
+There **is** a database guard, and what it covers is narrower than its name suggests. `server.ts` mounts a connect middleware ahead of every route which answers `503 Database temporarily unavailable` when `connectToDatabase()` throws — so a deployment whose Mongo was never reachable does return 503. But `connectToDatabase()` returns early on `readyState === 1` and caches its promise, so **after a successful connect it never throws again**: a store that dies mid-life produces a `500`, and a client still cannot distinguish "retry shortly" from a real fault for the outage that actually happens in production.
+
+Two things follow. It covers cold start only, and it covers MONGO only — which matters now that social, moderation and bridges read Postgres, since a Postgres that is unreachable at boot gets no guard at all. And `utils/database.ts` still exports `isDatabaseConnected()` with **no callers**: that is the vestige of a state-based check, and it is not what the middleware uses.
+
+A previous revision of this page said there was no guard at all. That was half right — right about the steady state, wrong about cold start — and it is corrected here rather than quietly, because a corrected document carrying a new inaccuracy is what makes the next reader stop checking.
 
 ### Push notifications
 

--- a/packages/backend/src/db/MONGO-CLAIMS-LEDGER.md
+++ b/packages/backend/src/db/MONGO-CLAIMS-LEDGER.md
@@ -91,11 +91,20 @@ looks like their own mistake.
 | `docs/architecture.mdx` §tree | `models/  Mongoose schemas (messaging only…)` | delete the directory line with the directory |
 | `docs/architecture.mdx` §Matrix | "the Mongoose models now back only the messaging domain" | |
 
-**4.2 — a documented behaviour that does not exist.** Both docs used to describe
-a guard answering `503 Database temporarily unavailable` when Mongo was
-disconnected. There is no such guard: the only 503s in the backend come from
-`middleware/matrixAuth.ts` and `routes/push.ts`, and `isDatabaseConnected()` has
-no callers. The docs now say so. If a readiness guard is added, it must cover
+**4.2 — a documented behaviour that is real, and narrower than either claim.**
+Both docs originally described a guard answering `503 Database temporarily
+unavailable` when Mongo was disconnected; the correction then over-shot and said
+no such guard existed. Both were half right. `server.ts` DOES mount a connect
+middleware that answers exactly that 503 — but only when the initial connection
+cannot be ESTABLISHED, because `connectToDatabase()` returns early on
+`readyState === 1` and caches its promise, so it never throws once connected. A
+store that dies mid-life is the case that produces a 500.
+
+`isDatabaseConnected()` genuinely has no callers; it is the vestige of a
+state-based check the middleware does not use. **The reliable question was never
+"does it exist" but "what exactly does it cover"** — the same shape as an expiry
+registry documenting a caller that was absent, and a wait loop believed unable to
+distinguish two cases whose discriminating data it was already fetching. If a readiness guard is added, it must cover
 **both** stores while both exist — a Mongo-only check would 503 the
 Postgres-backed social, moderation and bridge routes during a Mongo outage, and
 stay silent during a Postgres one.


### PR DESCRIPTION
A one-line-class follow-up to #117, landed separately on purpose.

#117 corrected the docs from *"there is a guard that 503s when the database is
disconnected"* to *"there is **no** database-availability guard"*. **Both are
half right**, which is why neither reader caught it.

`server.ts:136` mounts a connect middleware ahead of every route:

```js
app.use(async (req, res, next) => {
  try { await connectToDatabase(); next(); }
  catch (error) { … res.status(503).json({ message: "Database temporarily unavailable" }); }
});
```

So a deployment whose database was never reachable really does return 503. But
`connectToDatabase()` returns early on `readyState === 1` and caches its promise,
so **after a successful connect it never throws again** — the outage that
actually happens in production, a store dying mid-life, produces a 500 exactly as
#117 said.

The accurate statement is narrower than either, and more useful than both:

- the guard covers **cold start only**, not availability;
- it covers **Mongo only** — which now matters, because social, moderation and
  bridges read Postgres, and a Postgres unreachable at boot gets no guard at all.

`isDatabaseConnected()` genuinely has no callers; #117 was right about that. It is
the vestige of a state-based check the middleware does not use.

## Why separately

A corrected document carrying a NEW inaccuracy is worse than the original,
because the correction is what makes the next reader stop checking. Landing this
inside the messaging switch would bury it in a diff about something else.

## The general form, recorded in the ledger

Third instance in one night of *"there is no X"* meaning *"X exists and does less
than its name suggests"*:

1. `db/expiry.ts` documented a caller in `server.ts` that did not exist.
2. The deploy's wait loop was believed unable to distinguish "somebody moved the
   service" from "my tasks will not start" — the discriminating data was already
   in the response it was reading.
3. This.

**The reliable question is not "does it exist" but "what exactly does it cover".**

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)